### PR TITLE
update .gitattributes for file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,15 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+*.php text
+*.txt text
+*.xml text
+
+# Remove files for archives generated using `git archive`
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore


### PR DESCRIPTION
Similar to CakePHP core.
Makes the newline conversion correct for all OS.