### PR TITLE
Allow isBirthday() to work with current day by default.

### DIFF
--- a/src/ComparisonTrait.php
+++ b/src/ComparisonTrait.php
@@ -358,11 +358,14 @@ trait ComparisonTrait
     /**
      * Check if its the birthday. Compares the date/month values of the two dates.
      *
-     * @param ChronosInterface $dt The instance to compare with.
+     * @param ChronosInterface|null $dt The instance to compare with or null to use current day.
      * @return static
      */
-    public function isBirthday(ChronosInterface $dt)
+    public function isBirthday(ChronosInterface $dt = null)
     {
+        if ($dt === null) {
+            $dt = static::now($this->tz);
+        }
         return $this->format('md') === $dt->format('md');
     }
 

--- a/tests/DateTime/ComparisonTest.php
+++ b/tests/DateTime/ComparisonTest.php
@@ -383,6 +383,14 @@ class ComparisonTest extends TestCase
      */
     public function testIsBirthday($class)
     {
+        $dt = $class::now();
+        $aBirthday = $dt->subYear();
+        $this->assertTrue($aBirthday->isBirthday());
+        $notABirthday = $dt->subDay();
+        $this->assertFalse($notABirthday->isBirthday());
+        $alsoNotABirthday = $dt->addDays(2);
+        $this->assertFalse($alsoNotABirthday->isBirthday());
+
         $dt1 = $class::createFromDate(1987, 4, 23);
         $dt2 = $class::createFromDate(2014, 9, 26);
         $dt3 = $class::createFromDate(2014, 4, 23);


### PR DESCRIPTION
Curently you would need to pass an object as argument, whereas intuitively you shouldn't have to if you are referring to the present (which is the default IMO).

So it simplifies to:
```php
$birthdayString = $this->request->data['birthday']['year'] . '-' . $this->request->data['birthday']['month'] . '-' . $this->request->data['birthday']['day'];

$birthday = new Chronos($birthdayString);
$isBirthday = $birthday->isBirthday(); // Today
```