### PR TITLE
Optimize relative keyword detection.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",
+    "athletic/athletic": "~0.1",
     "cakephp/cakephp-codesniffer": "dev-master"
   },
   "autoload": {

--- a/src/RelativeKeywordTrait.php
+++ b/src/RelativeKeywordTrait.php
@@ -18,23 +18,7 @@ namespace Cake\Chronos;
  */
 trait RelativeKeywordTrait
 {
-    /**
-     * Terms used to detect if a time passed is a relative date for testing purposes
-     *
-     * @var array
-     */
-    protected static $relativeKeywords = [
-        'this',
-        'next',
-        'last',
-        'tomorrow',
-        'yesterday',
-        '+',
-        '-',
-        'first',
-        'last',
-        'ago',
-    ];
+    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|\+|\-|first|last|ago/i';
 
     /**
      * Determine if there is a relative keyword in the time string, this is to
@@ -47,11 +31,7 @@ trait RelativeKeywordTrait
     {
         // skip common format with a '-' in it
         if (preg_match('/[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}/', $time) !== 1) {
-            foreach (static::$relativeKeywords as $keyword) {
-                if (stripos($time, $keyword) !== false) {
-                    return true;
-                }
-            }
+            return preg_match(static::$relativePattern, $time) > 0;
         }
 
         return false;

--- a/tests/Benchmark/RelativeTimeEvent.php
+++ b/tests/Benchmark/RelativeTimeEvent.php
@@ -1,0 +1,27 @@
+<?php
+namespace Cake\Chronos\Test\Benchmark;
+
+use Athletic\AthleticEvent;
+use Cake\Chronos\Chronos;
+
+/**
+ * Benchmark relative time parsing.
+ */
+class RelativeTimeEvent extends AthleticEvent
+{
+    /**
+     * @iterations 1000
+     */
+    public function hasRelativeKeywordPlus()
+    {
+        Chronos::hasRelativeKeywords('+3 days');
+    }
+
+    /**
+     * @iterations 1000
+     */
+    public function hasRelativeKeywordWords()
+    {
+        Chronos::hasRelativeKeywords('first day of month');
+    }
+}


### PR DESCRIPTION
Add athletic as a dev dependency and use it to ensure the new code is faster.

### Before
```
$ vendor/bin/athletic -p tests/ -b vendor/autoload.php

Cake\Chronos\Test\Benchmark\RelativeTimeEvent
    Method Name               Iterations    Average Time      Ops/second
    -----------------------  ------------  --------------    -------------
    hasRelativeKeywordPlus : [1,000     ] [0.0000045390129] [220,312.21767]
    hasRelativeKeywordWords: [1,000     ] [0.0000036211014] [276,159.07295]
```

### After

```
$ vendor/bin/athletic -p tests/ -b vendor/autoload.php

Cake\Chronos\Test\Benchmark\RelativeTimeEvent
    Method Name               Iterations    Average Time      Ops/second
    -----------------------  ------------  --------------    -------------
    hasRelativeKeywordPlus : [1,000     ] [0.0000034070015] [293,513.22603]
    hasRelativeKeywordWords: [1,000     ] [0.0000012760162] [783,689.08819]
```