### PR TITLE
RFC - Rough implementation of Calendar Date

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -60,6 +60,13 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
     use TestingAidTrait;
 
     /**
+     * Format to use for __toString method when type juggling occurs.
+     *
+     * @var string
+     */
+    protected static $toStringFormat = ChronosInterface::DEFAULT_TO_STRING_FORMAT;
+
+    /**
      * Create a new Chronos instance.
      *
      * Please see the testing aids section (specifically static::setTestNow())

--- a/src/Date.php
+++ b/src/Date.php
@@ -35,6 +35,13 @@ class Date extends DateTimeImmutable implements ChronosInterface
     use TestingAidTrait;
 
     /**
+     * Format to use for __toString method when type juggling occurs.
+     *
+     * @var string
+     */
+    protected static $toStringFormat = 'Y-m-d';
+
+    /**
      * Create a new Immutable Date instance.
      *
      * Please see the testing aids section (specifically static::setTestNow())

--- a/src/Date.php
+++ b/src/Date.php
@@ -13,6 +13,7 @@ namespace Cake\Chronos;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use LogicException;
 
 /**
  * An immutable date object that does converts all time components
@@ -131,5 +132,58 @@ class Date extends DateTimeImmutable implements ChronosInterface
     public function setTimezone($value)
     {
         return $this;
+    }
+
+    /**
+     * Overloaded to throw exceptions for time components.
+     *
+     * You cannot set the time on calendar dates.
+     *
+     * @param string $relative The relative change to make.
+     * @return static A modified Date
+     * @throws \LogicException When time components are changed.
+     */
+    public function modify($relative)
+    {
+        if (preg_match('/hour|minute|second/', $relative)) {
+            throw new LogicException('You cannot modify the time component of a calendar date.');
+        }
+        return parent::modify($relative);
+    }
+
+    /**
+     * Set the instance's hour
+     *
+     * @param int $value The hour value.
+     * @return void
+     * @throws \LogicException You cannot modify the time on a calendar date.
+     */
+    public function hour($value)
+    {
+        throw new LogicException('You cannot modify the time component of a calendar date.');
+    }
+
+    /**
+     * Set the instance's minute
+     *
+     * @param int $value The minute value.
+     * @return void
+     * @throws \LogicException You cannot modify the time on a calendar date.
+     */
+    public function minute($value)
+    {
+        throw new LogicException('You cannot modify the time component of a calendar date.');
+    }
+
+    /**
+     * Set the instance's second
+     *
+     * @param int $value The seconds value.
+     * @return void
+     * @throws \LogicException You cannot modify the time on a calendar date.
+     */
+    public function second($value)
+    {
+        throw new LogicException('You cannot modify the time component of a calendar date.');
     }
 }

--- a/src/Date.php
+++ b/src/Date.php
@@ -108,7 +108,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
      * Timezones have no effect on calendar dates.
      *
      * @param DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return $this
      */
     public function timezone($value)
     {
@@ -121,7 +121,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
      * Timezones have no effect on calendar dates.
      *
      * @param DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return $this
      */
     public function tz($value)
     {
@@ -134,7 +134,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
      * Timezones have no effect on calendar dates.
      *
      * @param DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return $this
      */
     public function setTimezone($value)
     {

--- a/src/Date.php
+++ b/src/Date.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Chronos;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * An immutable date object that does converts all time components
+ * into 00:00:00.
+ *
+ * This class is useful when you want to represent a calendar date and ignore times.
+ * This means that timezone changes take no effect as a calendar date exists in all timezones
+ * in each respective date.
+ */
+class Date extends DateTimeImmutable implements ChronosInterface
+{
+    use ComparisonTrait;
+    use DifferenceTrait;
+    use FactoryTrait;
+    use FormattingTrait;
+    use MagicPropertyTrait;
+    use ModifierTrait;
+    use RelativeKeywordTrait;
+    use TestingAidTrait;
+
+    /**
+     * No-op method.
+     *
+     * Timezones have no effect on calendar dates.
+     *
+     * @param DateTimeZone|string $value The DateTimeZone object or timezone name to use.
+     * @return static
+     */
+    public function timezone($value)
+    {
+        return $this;
+    }
+
+    /**
+     * No-op method.
+     *
+     * Timezones have no effect on calendar dates.
+     *
+     * @param DateTimeZone|string $value The DateTimeZone object or timezone name to use.
+     * @return static
+     */
+    public function tz($value)
+    {
+        return $this;
+    }
+
+    /**
+     * No-op method.
+     *
+     * Timezones have no effect on calendar dates.
+     *
+     * @param DateTimeZone|string $value The DateTimeZone object or timezone name to use.
+     * @return static
+     */
+    public function setTimezone($value)
+    {
+        return $this;
+    }
+}

--- a/src/Date.php
+++ b/src/Date.php
@@ -105,6 +105,55 @@ class Date extends DateTimeImmutable implements ChronosInterface
     }
 
     /**
+     * Modify the time on the Date.
+     *
+     * This method ignores all inputs and forces all inputs to 0.
+     *
+     * @param int $hours The hours to set (ignored)
+     * @param int $minutes The hours to set (ignored)
+     * @param int $seconds The hours to set (ignored)
+     * @return static A modified Date instance.
+     */
+    public function setTime($hours, $minutes, $seconds = 0)
+    {
+        return parent::setTime(0, 0, 0);
+    }
+
+    /**
+     * Add an Interval to a Date
+     *
+     * Any changes to the time will be ignored and reset to 00:00:00
+     *
+     * @param \DateInterval $interval The interval to modify this date by.
+     * @return static A modified Date instance
+     */
+    public function add($interval)
+    {
+        $date = parent::add($interval);
+        if ($date->format('H:i:s') !== '00:00:00') {
+            return $date->setTime(0, 0, 0);
+        }
+        return $date;
+    }
+
+    /**
+     * Subtract an Interval from a Date.
+     *
+     * Any changes to the time will be ignored and reset to 00:00:00
+     *
+     * @param \DateInterval $interval The interval to modify this date by.
+     * @return static A modified Date instance
+     */
+    public function sub($interval)
+    {
+        $date = parent::sub($interval);
+        if ($date->format('H:i:s') !== '00:00:00') {
+            return $date->setTime(0, 0, 0);
+        }
+        return $date;
+    }
+
+    /**
      * No-op method.
      *
      * Timezones have no effect on calendar dates.
@@ -174,41 +223,8 @@ class Date extends DateTimeImmutable implements ChronosInterface
         }
         $new = parent::modify($relative);
         if ($new->format('H:i:s') !== '00:00:00') {
-            return $new->modify('00:00:00');
+            return $new->setTime(0, 0, 0);
         }
         return $new;
-    }
-
-    /**
-     * Set the instance's hour
-     *
-     * @param int $value The hour value.
-     * @return $this
-     */
-    public function hour($value)
-    {
-        return $this;
-    }
-
-    /**
-     * Set the instance's minute
-     *
-     * @param int $value The minute value.
-     * @return $this
-     */
-    public function minute($value)
-    {
-        return $this;
-    }
-
-    /**
-     * Set the instance's second
-     *
-     * @param int $value The seconds value.
-     * @return $this
-     */
-    public function second($value)
-    {
-        return $this;
     }
 }

--- a/src/Date.php
+++ b/src/Date.php
@@ -13,7 +13,6 @@ namespace Cake\Chronos;
 
 use DateTimeImmutable;
 use DateTimeZone;
-use LogicException;
 
 /**
  * An immutable date object that does converts all time components
@@ -145,55 +144,71 @@ class Date extends DateTimeImmutable implements ChronosInterface
     }
 
     /**
-     * Overloaded to throw exceptions for time components.
+     * Set the timestamp value and get a new object back.
      *
-     * You cannot set the time on calendar dates.
+     * This method will discard the time aspects of the timestamp
+     * and only apply the date portions
+     *
+     * @param int $value The timestamp value to set.
+     * @return static
+     */
+    public function setTimestamp($value)
+    {
+        $date = date('Y-m-d 00:00:00', $value);
+        return parent::setTimestamp(strtotime($value));
+    }
+
+    /**
+     * Overloaded to ignore time changes.
+     *
+     * Changing any aspect of the time will be ignored, and the resulting object
+     * will have its time frozen to 00:00:00.
      *
      * @param string $relative The relative change to make.
-     * @return static A modified Date
-     * @throws \LogicException When time components are changed.
+     * @return static A new date with the applied date changes.
      */
     public function modify($relative)
     {
         if (preg_match('/hour|minute|second/', $relative)) {
-            throw new LogicException('You cannot modify the time component of a calendar date.');
+            return $this;
         }
-        return parent::modify($relative);
+        $new = parent::modify($relative);
+        if ($new->format('H:i:s') !== '00:00:00') {
+            return $new->modify('00:00:00');
+        }
+        return $new;
     }
 
     /**
      * Set the instance's hour
      *
      * @param int $value The hour value.
-     * @return void
-     * @throws \LogicException You cannot modify the time on a calendar date.
+     * @return $this
      */
     public function hour($value)
     {
-        throw new LogicException('You cannot modify the time component of a calendar date.');
+        return $this;
     }
 
     /**
      * Set the instance's minute
      *
      * @param int $value The minute value.
-     * @return void
-     * @throws \LogicException You cannot modify the time on a calendar date.
+     * @return $this
      */
     public function minute($value)
     {
-        throw new LogicException('You cannot modify the time component of a calendar date.');
+        return $this;
     }
 
     /**
      * Set the instance's second
      *
      * @param int $value The seconds value.
-     * @return void
-     * @throws \LogicException You cannot modify the time on a calendar date.
+     * @return $this
      */
     public function second($value)
     {
-        throw new LogicException('You cannot modify the time component of a calendar date.');
+        return $this;
     }
 }

--- a/src/Date.php
+++ b/src/Date.php
@@ -93,6 +93,9 @@ class Date extends DateTimeImmutable implements ChronosInterface
      */
     protected function stripTime($time)
     {
+        if (substr($time, 0, 1) === '@') {
+            return gmdate('Y-m-d 00:00:00', substr($time, 1));
+        }
         if (is_int($time) || ctype_digit($time)) {
             return gmdate('Y-m-d 00:00:00', $time);
         }

--- a/src/FormattingTrait.php
+++ b/src/FormattingTrait.php
@@ -16,16 +16,11 @@ use DateTime;
 
 /**
  * Provides string formatting methods for datetime instances.
+ *
+ * Expects implementing classes to define static::$toStringFormat
  */
 trait FormattingTrait
 {
-    /**
-     * Format to use for __toString method when type juggling occurs.
-     *
-     * @var string
-     */
-    protected static $toStringFormat = ChronosInterface::DEFAULT_TO_STRING_FORMAT;
-
     /**
      * Reset the format used to the default when type juggling a ChronosInterface instance to a string
      *

--- a/src/ModifierTrait.php
+++ b/src/ModifierTrait.php
@@ -122,7 +122,7 @@ trait ModifierTrait
      */
     public function timestamp($value)
     {
-        return parent::setTimestamp($value);
+        return $this->setTimestamp($value);
     }
 
     /**

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -35,6 +35,13 @@ class MutableDateTime extends DateTime implements ChronosInterface
     use TestingAidTrait;
 
     /**
+     * Format to use for __toString method when type juggling occurs.
+     *
+     * @var string
+     */
+    protected static $toStringFormat = ChronosInterface::DEFAULT_TO_STRING_FORMAT;
+
+    /**
      * Create a new MutableDateTime instance.
      *
      * Please see the testing aids section (specifically static::setTestNow())

--- a/tests/Date/AddTest.php
+++ b/tests/Date/AddTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Brian Nesbitt <brian@nesbot.com>
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Chronos\Test\Date;
+
+use Cake\Chronos\Date;
+use TestCase;
+
+class AddTest extends TestCase
+{
+    public function testAddDay()
+    {
+        $this->assertEquals(1, Date::create(1975, 5, 31)->addDays(1)->day);
+        $this->assertEquals(30, Date::create(1975, 5, 31)->addDays(-1)->day);
+    }
+
+    public function testAddMonth()
+    {
+        $this->assertEquals(6, Date::create(1975, 5, 31)->addMonths(1)->month);
+        $this->assertEquals(4, Date::create(1975, 5, 31)->addMonths(-1)->month);
+    }
+
+    public function testAddYear()
+    {
+        $this->assertEquals(1976, Date::create(1975, 5, 31)->addYears(1)->year);
+        $this->assertEquals(1974, Date::create(1975, 5, 31)->addYears(-1)->year);
+    }
+
+    public function testAddWeekdays()
+    {
+        $this->assertEquals(2, Date::create(1975, 5, 31)->addWeekdays(1)->day);
+        $this->assertEquals(30, Date::create(1975, 5, 31)->addWeekdays(-1)->day);
+    }
+}

--- a/tests/Date/AddTest.php
+++ b/tests/Date/AddTest.php
@@ -13,10 +13,39 @@
 namespace Cake\Chronos\Test\Date;
 
 use Cake\Chronos\Date;
+use DateInterval;
 use TestCase;
 
 class AddTest extends TestCase
 {
+    public function testAddIgnoreTime()
+    {
+        $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
+        $date = Date::create(2001, 1, 1);
+        $new = $date->add($interval);
+
+        $this->assertEquals(0, $new->hour);
+        $this->assertEquals(0, $new->minute);
+        $this->assertEquals(0, $new->second);
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->second);
+    }
+
+    public function testSubIgnoreTime()
+    {
+        $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
+        $date = Date::create(2001, 1, 1);
+        $new = $date->sub($interval);
+
+        $this->assertEquals(0, $new->hour);
+        $this->assertEquals(0, $new->minute);
+        $this->assertEquals(0, $new->second);
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->second);
+    }
+
     public function testAddDay()
     {
         $this->assertEquals(1, Date::create(1975, 5, 31)->addDays(1)->day);

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Chronos\Test\Date;
+
+use Cake\Chronos\Date;
+use DateTimeZone;
+use TestCase;
+
+/**
+ * Test constructors for Date objects.
+ */
+class ConstructTest extends TestCase
+{
+    public function classNameProvider()
+    {
+        return [[Date::class]];
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testCreatesAnInstanceDefaultToNow($class)
+    {
+        $c = new $class();
+        $now = $class::now();
+        $this->assertInstanceOf($class, $c);
+        $this->assertSame($now->tzName, $c->tzName);
+        $this->assertDateTime($c, $now->year, $now->month, $now->day, 0, 0, 0);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseCreatesAnInstanceDefaultToNow($class)
+    {
+        $c = $class::parse();
+        $now = $class::now();
+        $this->assertInstanceOf($class, $c);
+        $this->assertSame($now->tzName, $c->tzName);
+        $this->assertDateTime($c, $now->year, $now->month, $now->day, 0, 0, 0);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testWithFancyString($class)
+    {
+        $c = new $class('first day of January 2008');
+        $this->assertDateTime($c, 2008, 1, 1, 0, 0, 0);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseWithFancyString($class)
+    {
+        $c = $class::parse('first day of January 2008');
+        $this->assertDateTime($c, 2008, 1, 1, 0, 0, 0);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testUsesUTC($class)
+    {
+        $c = new $class('now');
+        $this->assertSame('UTC', $c->tzName);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseUsesUTC($class)
+    {
+        $c = $class::parse('now');
+        $this->assertSame('UTC', $c->tzName);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testSettingTimezoneIgnored($class)
+    {
+        $timezone = 'Europe/London';
+        $dtz = new \DateTimeZone($timezone);
+        $c = new $class('now', $dtz);
+        $this->assertSame('UTC', $c->tzName);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseSettingTimezoneIgnored($class)
+    {
+        $timezone = 'Europe/London';
+        $dtz = new \DateTimeZone($timezone);
+        $c = $class::parse('now', $dtz);
+
+        $this->assertSame('UTC', $c->tzName);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testSettingTimezoneWithStringIgnored($class)
+    {
+        $timezone = 'Asia/Tokyo';
+        $dtz = new \DateTimeZone($timezone);
+
+        $c = new $class('now', $timezone);
+        $this->assertSame('UTC', $c->tzName);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseSettingTimezoneWithStringIgnored($class)
+    {
+        $timezone = 'Asia/Tokyo';
+        $dtz = new \DateTimeZone($timezone);
+        $c = $class::parse('now', $timezone);
+        $this->assertSame('UTC', $c->tzName);
+    }
+
+    /**
+     * Data provider for constructor testing.
+     *
+     * @return array
+     */
+    public function inputTimeProvider()
+    {
+        return [
+            [strtotime('2015-10-19 22:24:32')],
+            ['2015-10-19 10:00:00'],
+            ['2015-10-19T10:00:00+05:00'],
+            ['Monday, 15-Aug-2005 15:52:01 UTC'],
+            ['Mon, 15 Aug 05 15:52:01 +0000'],
+            ['Monday, 15-Aug-05 15:52:01 UTC'],
+            ['Mon, 15 Aug 05 15:52:01 +0000'],
+            ['Mon, 15 Aug 2005 15:52:01 +0000'],
+            ['Mon, 15 Aug 2005 15:52:01 +0000'],
+            ['Mon, 15 Aug 2005 15:52:01 +0000'],
+            ['2005-08-15T15:52:01+00:00'],
+        ];
+    }
+
+    /**
+     * @dataProvider inputTimeProvider
+     * @return void
+     */
+    public function testConstructWithTimeParts($time)
+    {
+        $dt = new Date($time);
+        $this->assertEquals(0, $dt->hour);
+        $this->assertEquals(0, $dt->minute);
+        $this->assertEquals(0, $dt->second);
+    }
+}

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -149,9 +149,10 @@ class ConstructTest extends TestCase
     public function inputTimeProvider()
     {
         return [
-            [strtotime('2015-10-19 22:24:32')],
-            ['2015-10-19 10:00:00'],
-            ['2015-10-19T10:00:00+05:00'],
+            ['@' . strtotime('2015-08-19 22:24:32')],
+            [strtotime('2015-08-19 22:24:32')],
+            ['2015-08-19 10:00:00'],
+            ['2015-08-19T10:00:00+05:00'],
             ['Monday, 15-Aug-2005 15:52:01 UTC'],
             ['Mon, 15 Aug 05 15:52:01 +0000'],
             ['Monday, 15-Aug-05 15:52:01 UTC'],
@@ -170,6 +171,7 @@ class ConstructTest extends TestCase
     public function testConstructWithTimeParts($time)
     {
         $dt = new Date($time);
+        $this->assertEquals(8, $dt->month);
         $this->assertEquals(0, $dt->hour);
         $this->assertEquals(0, $dt->minute);
         $this->assertEquals(0, $dt->second);

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -176,4 +176,14 @@ class ConstructTest extends TestCase
         $this->assertEquals(0, $dt->minute);
         $this->assertEquals(0, $dt->second);
     }
+
+    public function testConstructWithTestNow()
+    {
+        Date::setTestNow(Date::create(2001, 1, 1));
+        $date = new Date('+2 days');
+        $this->assertDateTime($date, 2001, 1, 3);
+
+        $date = new Date('2015-12-12');
+        $this->assertDateTime($date, 2015, 12, 12);
+    }
 }

--- a/tests/Date/StringsTest.php
+++ b/tests/Date/StringsTest.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Chronos\Test\Date;
+
+use Cake\Chronos\Date;
+use TestCase;
+
+class StringsTest extends TestCase
+{
+    public function classNameProvider()
+    {
+        return [[Date::class]];
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToString($class)
+    {
+        $d = Date::now();
+        $this->assertSame(Date::now()->toDateTimeString(), '' . $d);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testSetToStringFormat($class)
+    {
+        $class::setToStringFormat('jS \o\f F, Y g:i:s a');
+        $d = $class::create(1975, 12, 25);
+        $this->assertSame('25th of December, 1975 12:00:00 am', '' . $d);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testResetToStringFormat($class)
+    {
+        $d = $class::now();
+        $class::setToStringFormat('123');
+        $class::resetToStringFormat();
+        $this->assertSame($d->toDateTimeString(), '' . $d);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToDateString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('1975-12-25', $d->toDateString());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToFormattedDateString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('Dec 25, 1975', $d->toFormattedDateString());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToTimeString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('00:00:00', $d->toTimeString());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToDateTimeString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('1975-12-25 00:00:00', $d->toDateTimeString());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToDayDateTimeString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('Thu, Dec 25, 1975 12:00 AM', $d->toDayDateTimeString());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToAtomString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('1975-12-25T00:00:00+00:00', $d->toAtomString());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToCOOKIEString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        if (\DateTime::COOKIE === 'l, d-M-y H:i:s T') {
+            $cookieString = 'Thursday, 25-Dec-75 00:00:00 UTC';
+        } else {
+            $cookieString = 'Thursday, 25-Dec-1975 00:00:00 UTC';
+        }
+
+        $this->assertSame($cookieString, $d->toCOOKIEString());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToIso8601String($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('1975-12-25T00:00:00+0000', $d->toIso8601String());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToRC822String($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('Thu, 25 Dec 75 00:00:00 +0000', $d->toRfc822String());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToRfc850String($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('Thursday, 25-Dec-75 00:00:00 UTC', $d->toRfc850String());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToRfc1036String($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('Thu, 25 Dec 75 00:00:00 +0000', $d->toRfc1036String());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToRfc1123String($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('Thu, 25 Dec 1975 00:00:00 +0000', $d->toRfc1123String());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToRfc2822String($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('Thu, 25 Dec 1975 00:00:00 +0000', $d->toRfc2822String());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToRfc3339String($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('1975-12-25T00:00:00+00:00', $d->toRfc3339String());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToRssString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('Thu, 25 Dec 1975 00:00:00 +0000', $d->toRssString());
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToW3cString($class)
+    {
+        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $this->assertSame('1975-12-25T00:00:00+00:00', $d->toW3cString());
+    }
+}

--- a/tests/Date/StringsTest.php
+++ b/tests/Date/StringsTest.php
@@ -28,7 +28,7 @@ class StringsTest extends TestCase
     public function testToString($class)
     {
         $d = Date::now();
-        $this->assertSame(Date::now()->toDateTimeString(), '' . $d);
+        $this->assertSame(Date::now()->toDateString(), '' . $d);
     }
 
     /**

--- a/tests/Date/TimeMutateTest.php
+++ b/tests/Date/TimeMutateTest.php
@@ -35,12 +35,18 @@ class TimeMutateTest extends TestCase
 
     /**
      * @dataProvider invalidModificationProvider
-     * @expectedException LogicException
      */
     public function testModifyFails($value)
     {
         $date = new Date();
-        $date->modify($value);
+        $new = $date->modify($value);
+
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->second);
+        $this->assertEquals(0, $new->hour);
+        $this->assertEquals(0, $new->minute);
+        $this->assertEquals(0, $new->second);
     }
 
     /**
@@ -52,18 +58,107 @@ class TimeMutateTest extends TestCase
     {
         return [
             ['second', 10],
+            ['addSeconds', 10],
+            ['subSeconds', 10],
             ['minute', 40],
+            ['addMinutes', 40],
+            ['subMinutes', 40],
             ['hour', 11],
+            ['addHours', 11],
+            ['subHours', 11],
         ];
     }
 
     /**
      * @dataProvider invalidModifierProvider
-     * @expectedException LogicException
      */
-    public function testSetterMethodFails($method, $value)
+    public function testSetterMethodIsIgnored($method, $value)
     {
         $date = new Date();
-        $date->{$method}($value);
+        $new = $date->{$method}($value);
+        $this->assertEquals(0, $new->hour);
+        $this->assertEquals(0, $new->minute);
+        $this->assertEquals(0, $new->second);
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->second);
+    }
+
+    /**
+     * Test that timestamp methods ignore time changes.
+     *
+     * @return void
+     */
+    public function testSetTimestampRemovesTime()
+    {
+        $date = new Date();
+        $date->setTimestamp(strtotime('+2 hours +2 minutes'));
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->second);
+
+        $date = new Date();
+        $date->timestamp(strtotime('+2 hours +2 minutes'));
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->second);
+    }
+
+    public function testStartOfDay()
+    {
+        $date = new Date();
+        $this->assertEquals('00:00:00', $date->startOfDay()->format('H:i:s'));
+    }
+
+    public function testEndOfDay()
+    {
+        $date = Date::create(2001, 1, 1);
+        $new = $date->endOfDay();
+        $this->assertEquals('00:00:00', $new->format('H:i:s'));
+        $this->assertEquals('2001-01-01', $new->format('Y-m-d'));
+    }
+
+    public function testEndOfMonth()
+    {
+        $date = Date::create(2001, 1, 1);
+        $new = $date->endOfMonth();
+        $this->assertEquals('00:00:00', $new->format('H:i:s'));
+        $this->assertEquals('2001-01-31', $new->format('Y-m-d'));
+    }
+
+    public function testEndOfYear()
+    {
+        $date = Date::create(2001, 1, 1);
+        $new = $date->endOfYear();
+        $this->assertEquals('00:00:00', $new->format('H:i:s'));
+        $this->assertEquals('2001-12-31', $new->format('Y-m-d'));
+    }
+
+    public function testEndOfDecade()
+    {
+        $date = Date::create(2001, 1, 1);
+        $new = $date->endOfDecade();
+        $this->assertEquals('00:00:00', $new->format('H:i:s'));
+        $this->assertEquals('2009-12-31', $new->format('Y-m-d'));
+    }
+
+    public function testEndOfCentury()
+    {
+        $date = Date::create(2001, 1, 1);
+        $new = $date->endOfCentury();
+        $this->assertEquals('00:00:00', $new->format('H:i:s'));
+        $this->assertEquals('2100-12-31', $new->format('Y-m-d'));
+    }
+
+    public function testNextAndPrev()
+    {
+        $date = Date::create(2001, 1, 1);
+        $new = $date->next(3);
+        $this->assertEquals('00:00:00', $new->format('H:i:s'));
+        $this->assertEquals('2001-01-03', $new->format('Y-m-d'));
+
+        $new = $date->previous(1);
+        $this->assertEquals('00:00:00', $new->format('H:i:s'));
+        $this->assertEquals('2000-12-25', $new->format('Y-m-d'));
     }
 }

--- a/tests/Date/TimeMutateTest.php
+++ b/tests/Date/TimeMutateTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Chronos\Test\Date;
+
+use Cake\Chronos\Date;
+use DateTimeZone;
+use TestCase;
+
+/**
+ * Test that setting time components fails.
+ */
+class TimeMutateTest extends TestCase
+{
+    public function invalidModificationProvider()
+    {
+        return [
+            ['-3 hours'],
+            ['-3 minutes'],
+            ['-3 seconds'],
+            ['+1 hour'],
+            ['+1 minute'],
+            ['+1 second'],
+            ['+1 hours, +9 minutes, -1 second'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidModificationProvider
+     * @expectedException LogicException
+     */
+    public function testModifyFails($value)
+    {
+        $date = new Date();
+        $date->modify($value);
+    }
+
+    /**
+     * Provide invalid modifier method calls.
+     *
+     * @return array
+     */
+    public function invalidModifierProvider()
+    {
+        return [
+            ['second', 10],
+            ['minute', 40],
+            ['hour', 11],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidModifierProvider
+     * @expectedException LogicException
+     */
+    public function testSetterMethodFails($method, $value)
+    {
+        $date = new Date();
+        $date->{$method}($value);
+    }
+}

--- a/tests/Date/TimezoneTest.php
+++ b/tests/Date/TimezoneTest.php
@@ -9,7 +9,6 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-
 namespace Cake\Chronos\Test\Date;
 
 use Cake\Chronos\Date;

--- a/tests/Date/TimezoneTest.php
+++ b/tests/Date/TimezoneTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Chronos\Test\Date;
+
+use Cake\Chronos\Date;
+use DateTimeZone;
+use TestCase;
+
+/**
+ * Test that timezone methods don't do anything to calendar dates.
+ */
+class TimezoneTest extends TestCase
+{
+    public static function methodNameProvider()
+    {
+        return [['tz'], ['timezone'], ['setTimezone']];
+    }
+
+    /**
+     * Test that all the timezone methods do nothing.
+     *
+     * @dataProvider methodNameProvider
+     */
+    public function testNoopOnTimezoneChange($method)
+    {
+        $tz = new DateTimeZone('Pacific/Honolulu');
+        $date = new Date('2015-01-01');
+        $new = $date->{$method}($tz);
+        $this->assertSame($new, $date);
+        $this->assertNotEquals($tz, $date->timezone);
+    }
+}


### PR DESCRIPTION
This is still somewhat rough, but I wanted to get some feedback on the direction and some of the assumptions I've made.

### Assumptions

* Calendar Dates cannot have times added/mutated.
* Calendar Dates are immutable. There will be no mutable version of this object type.
* Calendar Dates can reasonably be normalized to UTC. Given that each calendar date occurs in all timezones, picking one to normalize on is fairly arbitrary.

### Things left to do

* [x] Hunt down other mutator methods that change times and nerf them.
* [x] Implement toString

Related to #13