### PR TITLE
Add methods from Cake\I18n\Time

### DIFF
--- a/src/DifferenceTrait.php
+++ b/src/DifferenceTrait.php
@@ -220,4 +220,16 @@ trait DifferenceTrait
     {
         return $this->diffInSeconds($this->copy()->endOfDay());
     }
+
+    /**
+     * Convenience method for getting the remaining time from a given time.
+     *
+     * @param \DateTime|\DateTimeImmutable $datetime The date to get the remaining time from.
+     * @return \DateInterval|bool The DateInterval object representing the difference between the two dates or FALSE on failure.
+     */
+    public static function fromNow($datetime)
+    {
+        $timeNow = new static();
+        return $timeNow->diff($datetime);
+    }
 }

--- a/src/FormattingTrait.php
+++ b/src/FormattingTrait.php
@@ -221,4 +221,30 @@ trait FormattingTrait
     {
         return $this->format('U');
     }
+
+    /**
+     * Returns the quarter
+     *
+     * @param bool $range Range.
+     * @return mixed 1, 2, 3, or 4 quarter of year or array if $range true
+     */
+    public function toQuarter($range = false)
+    {
+        $quarter = ceil($this->format('m') / 3);
+        if ($range === false) {
+            return $quarter;
+        }
+
+        $year = $this->format('Y');
+        switch ($quarter) {
+            case 1:
+                return [$year . '-01-01', $year . '-03-31'];
+            case 2:
+                return [$year . '-04-01', $year . '-06-30'];
+            case 3:
+                return [$year . '-07-01', $year . '-09-30'];
+            case 4:
+                return [$year . '-10-01', $year . '-12-31'];
+        }
+    }
 }

--- a/src/FormattingTrait.php
+++ b/src/FormattingTrait.php
@@ -211,4 +211,14 @@ trait FormattingTrait
     {
         return $this->format(DateTime::W3C);
     }
+
+    /**
+     * Returns a UNIX timestamp.
+     *
+     * @return string UNIX timestamp
+     */
+    public function toUnixString()
+    {
+        return $this->format('U');
+    }
 }

--- a/tests/DateTime/DiffTest.php
+++ b/tests/DateTime/DiffTest.php
@@ -739,4 +739,21 @@ class DiffTest extends TestCase
             $this->assertSame(0, $vanNow->diffInSeconds());
         }, $hereNow);
     }
+
+    /**
+     * Tests the "from now" time calculation.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testFromNow($class)
+    {
+        $date = $class::now();
+        $date = $date->modify('-1 year')
+            ->modify('-6 days')
+            ->modify('-51 seconds');
+        $interval = $class::fromNow($date);
+        $result = $interval->format("%y %m %d %H %i %s");
+        $this->assertEquals($result, '1 0 6 00 0 51');
+    }
 }

--- a/tests/DateTime/StringsTest.php
+++ b/tests/DateTime/StringsTest.php
@@ -225,4 +225,17 @@ class StringsTest extends TestCase
         $d = $class::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T14:15:16-05:00', $d->toW3cString());
     }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testToUnixString($class)
+    {
+        $time = $class::parse('2014-04-20 08:00:00');
+        $this->assertEquals('1397995200', $time->toUnixString());
+
+        $time = $class::parse('2021-12-11 07:00:01');
+        $this->assertEquals('1639224001', $time->toUnixString());
+    }
 }

--- a/tests/DateTime/StringsTest.php
+++ b/tests/DateTime/StringsTest.php
@@ -13,6 +13,7 @@
 
 namespace Cake\Chronos\Test\DateTime;
 
+use Cake\Chronos\Chronos;
 use TestCase;
 
 class StringsTest extends TestCase
@@ -237,5 +238,34 @@ class StringsTest extends TestCase
 
         $time = $class::parse('2021-12-11 07:00:01');
         $this->assertEquals('1639224001', $time->toUnixString());
+    }
+
+    /**
+     * Provides values and expectations for the toQuarter method
+     *
+     * @return array
+     */
+    public function toQuarterProvider()
+    {
+        return [
+            ['2007-12-25', 4],
+            ['2007-9-25', 3],
+            ['2007-3-25', 1],
+            ['2007-3-25', ['2007-01-01', '2007-03-31'], true],
+            ['2007-5-25', ['2007-04-01', '2007-06-30'], true],
+            ['2007-8-25', ['2007-07-01', '2007-09-30'], true],
+            ['2007-12-25', ['2007-10-01', '2007-12-31'], true],
+        ];
+    }
+
+    /**
+     * testToQuarter method
+     *
+     * @dataProvider toQuarterProvider
+     * @return void
+     */
+    public function testToQuarter($date, $expected, $range = false)
+    {
+        $this->assertEquals($expected, (new Chronos($date))->toQuarter($range));
     }
 }


### PR DESCRIPTION
I started to integrate chronos into CakePHP, and found a few methods that were defined on `Cake\I18n\Time` that don't really need to be there anymore. By moving these methods we add more features to this library, but allow the I18n subclasses to be more focused on i18n extensions.