### PR TITLE
Make toIso8601 output an ISO-8601 formatted string.

### DIFF
--- a/src/FormattingTrait.php
+++ b/src/FormattingTrait.php
@@ -129,7 +129,7 @@ trait FormattingTrait
      */
     public function toIso8601String()
     {
-        return $this->format(DateTime::ISO8601);
+        return $this->format(DateTime::ATOM);
     }
 
     /**

--- a/tests/Date/StringsTest.php
+++ b/tests/Date/StringsTest.php
@@ -137,7 +137,7 @@ class StringsTest extends TestCase
     public function testToIso8601String($class)
     {
         $d = $class::create(1975, 12, 25, 14, 15, 16);
-        $this->assertSame('1975-12-25T00:00:00+0000', $d->toIso8601String());
+        $this->assertSame('1975-12-25T00:00:00+00:00', $d->toIso8601String());
     }
 
     /**

--- a/tests/DateTime/StringsTest.php
+++ b/tests/DateTime/StringsTest.php
@@ -144,7 +144,7 @@ class StringsTest extends TestCase
     public function testToIso8601String($class)
     {
         $d = $class::create(1975, 12, 25, 14, 15, 16);
-        $this->assertSame('1975-12-25T14:15:16-0500', $d->toIso8601String());
+        $this->assertSame('1975-12-25T14:15:16-05:00', $d->toIso8601String());
     }
 
     /**

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -154,8 +154,8 @@ class TestingAidsTest extends TestCase
         $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
         $class::setTestNow($notNow);
 
-        $this->assertSame('2013-07-01T12:00:00-0400', $class::parse('now')->toIso8601String());
-        $this->assertSame('2013-07-01T11:00:00-0500', $class::parse('now', 'America/Mexico_City')->toIso8601String());
-        $this->assertSame('2013-07-01T09:00:00-0700', $class::parse('now', 'America/Vancouver')->toIso8601String());
+        $this->assertSame('2013-07-01T12:00:00-04:00', $class::parse('now')->toIso8601String());
+        $this->assertSame('2013-07-01T11:00:00-05:00', $class::parse('now', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T09:00:00-07:00', $class::parse('now', 'America/Vancouver')->toIso8601String());
     }
 }


### PR DESCRIPTION
PHP's internal constant is *wrong*. Thankfully the ATOM format is *actually* ISO-8601 compliant.

Refs #44