### PR TITLE
Port behavior from CakePHP in.

### DIFF
--- a/src/ComparisonTrait.php
+++ b/src/ComparisonTrait.php
@@ -378,6 +378,10 @@ trait ComparisonTrait
      */
     public function wasWithinLast($timeInterval)
     {
+        $tmp = trim($timeInterval);
+        if (is_numeric($tmp)) {
+            $timeInterval = $tmp . ' days';
+        }
         $now = new static();
         $interval = $now->copy()->modify('-' . $timeInterval);
 
@@ -393,6 +397,10 @@ trait ComparisonTrait
      */
     public function isWithinNext($timeInterval)
     {
+        $tmp = trim($timeInterval);
+        if (is_numeric($tmp)) {
+            $timeInterval = $tmp . ' days';
+        }
         $now = new static();
         $interval = $now->copy()->modify('+' . $timeInterval);
 

--- a/tests/DateTime/IsTest.php
+++ b/tests/DateTime/IsTest.php
@@ -465,6 +465,8 @@ class IsTest extends TestCase
         $this->assertFalse((new $class('-1 year'))->wasWithinLast('1 second'));
         $this->assertFalse((new $class('-1 year'))->wasWithinLast('0 year'));
         $this->assertFalse((new $class('-1 weeks'))->wasWithinLast('1 day'));
+        $this->assertTrue((new $class('-1 day'))->wasWithinLast('1 '));
+        $this->assertTrue((new $class('-5 days'))->wasWithinLast('5  '));
     }
 
     /**
@@ -488,5 +490,7 @@ class IsTest extends TestCase
         $this->assertTrue((new $class('+1 week'))->isWithinNext('7 day'));
         $this->assertTrue((new $class('+1 second'))->isWithinNext('1 minute'));
         $this->assertTrue((new $class('+1 month'))->isWithinNext('1 month'));
+        $this->assertTrue((new $class('+1 day'))->isWithinNext('1 '));
+        $this->assertTrue((new $class('+5 days'))->isWithinNext('5  '));
     }
 }


### PR DESCRIPTION
The Cake\I18n\Time has this bizarre behavior, and since I'd rather avoid causing possibly breaking changes I figured it made sense to add this here. Without this change we will end up failing ~10 tests in the TimeHelper suite.