### PR TITLE
Add Mutable date object.

### DIFF
--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Chronos;
+
+use DateTime;
+use DateTimeZone;
+
+/**
+ * A mutable date object that converts all time components into 00:00:00.
+ *
+ * This class is useful when you want to represent a calendar date and ignore times.
+ * This means that timezone changes take no effect as a calendar date exists in all timezones
+ * in each respective date.
+ */
+class MutableDate extends DateTime implements ChronosInterface
+{
+    use Traits\ComparisonTrait;
+    use Traits\DifferenceTrait;
+    use Traits\FactoryTrait;
+    use Traits\FormattingTrait;
+    use Traits\FrozenTimeTrait;
+    use Traits\MagicPropertyTrait;
+    use Traits\ModifierTrait;
+    use Traits\RelativeKeywordTrait;
+    use Traits\TestingAidTrait;
+
+    /**
+     * Format to use for __toString method when type juggling occurs.
+     *
+     * @var string
+     */
+    protected static $toStringFormat = 'Y-m-d';
+
+    /**
+     * Create a new mutable Date instance.
+     *
+     * Please see the testing aids section (specifically static::setTestNow())
+     * for more on the possibility of this constructor returning a test instance.
+     *
+     * Date instances lack time components, however due to limitations in PHP's
+     * internal Datetime object the time will always be set to 00:00:00, and the
+     * timezone will always be UTC. Normalizing the timezone allows for
+     * subtraction/addition to have deterministic results.
+     *
+     * @param string|null $time Fixed or relative time
+     * @param DateTimeZone|string|null $tz The timezone for the instance
+     */
+    public function __construct($time = null, $tz = null)
+    {
+        $tz = new DateTimeZone('UTC');
+        if (static::$testNow === null) {
+            $time = $this->stripTime($time);
+            return parent::__construct($time, $tz);
+        }
+
+        $relative = static::hasRelativeKeywords($time);
+        if (!empty($time) && $time !== 'now' && !$relative) {
+            $time = $this->stripTime($time);
+            return parent::__construct($time, $tz);
+        }
+
+        $testInstance = static::getTestNow();
+        if ($relative) {
+            $testInstance = $testInstance->modify($time);
+        }
+
+        if ($tz !== $testInstance->getTimezone()) {
+            $testInstance = $testInstance->setTimezone($tz);
+        }
+
+        $time = $testInstance->format('Y-m-d 00:00:00');
+        parent::__construct($time, $tz);
+    }
+
+    /**
+     * Create a new immutable instance from current mutable instance.
+     *
+     * @return \Cake\Chronos\Date
+     */
+    public function toImmutable()
+    {
+        return Date::instance($this);
+    }
+}

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -9,77 +9,15 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-namespace Cake\Chronos;
-
-use DateTimeImmutable;
-use DateTimeZone;
+namespace Cake\Chronos\Traits;
 
 /**
- * An immutable date object that converts all time components into 00:00:00.
+ * A trait for freezing the time aspect of a DateTime.
  *
- * This class is useful when you want to represent a calendar date and ignore times.
- * This means that timezone changes take no effect as a calendar date exists in all timezones
- * in each respective date.
+ * Used in making calendar date objects, both mutable and immutable.
  */
-class Date extends DateTimeImmutable implements ChronosInterface
+trait FrozenTimeTrait
 {
-    use Traits\ComparisonTrait;
-    use Traits\DifferenceTrait;
-    use Traits\FactoryTrait;
-    use Traits\FormattingTrait;
-    use Traits\MagicPropertyTrait;
-    use Traits\ModifierTrait;
-    use Traits\RelativeKeywordTrait;
-    use Traits\TestingAidTrait;
-
-    /**
-     * Format to use for __toString method when type juggling occurs.
-     *
-     * @var string
-     */
-    protected static $toStringFormat = 'Y-m-d';
-
-    /**
-     * Create a new Immutable Date instance.
-     *
-     * Please see the testing aids section (specifically static::setTestNow())
-     * for more on the possibility of this constructor returning a test instance.
-     *
-     * Date instances lack time components, however due to limitations in PHP's
-     * internal Datetime object the time will always be set to 00:00:00, and the
-     * timezone will always be UTC. Normalizing the timezone allows for
-     * subtraction/addition to have deterministic results.
-     *
-     * @param string|null $time Fixed or relative time
-     * @param DateTimeZone|string|null $tz The timezone for the instance
-     */
-    public function __construct($time = null, $tz = null)
-    {
-        $tz = new DateTimeZone('UTC');
-        if (static::$testNow === null) {
-            $time = $this->stripTime($time);
-            return parent::__construct($time, $tz);
-        }
-
-        $relative = static::hasRelativeKeywords($time);
-        if (!empty($time) && $time !== 'now' && !$relative) {
-            $time = $this->stripTime($time);
-            return parent::__construct($time, $tz);
-        }
-
-        $testInstance = static::getTestNow();
-        if ($relative) {
-            $testInstance = $testInstance->modify($time);
-        }
-
-        if ($tz !== $testInstance->getTimezone()) {
-            $testInstance = $testInstance->setTimezone($tz);
-        }
-
-        $time = $testInstance->format('Y-m-d 00:00:00');
-        parent::__construct($time, $tz);
-    }
-
     /**
      * Removes the time components from an input string.
      *
@@ -225,15 +163,5 @@ class Date extends DateTimeImmutable implements ChronosInterface
             return $new->setTime(0, 0, 0);
         }
         return $new;
-    }
-
-    /**
-     * Create a new mutable instance from current immutable instance.
-     *
-     * @return Cake\Chronos\MutableDate
-     */
-    public function toMutable()
-    {
-        return MutableDate::instance($this);
     }
 }

--- a/tests/Date/AddTest.php
+++ b/tests/Date/AddTest.php
@@ -18,6 +18,22 @@ use TestCase;
 
 class AddTest extends TestCase
 {
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testAddFullDay($class)
+    {
+        $interval = DateInterval::createFromDateString('1 day');
+        $date = $class::create(2001, 1, 1);
+        $new = $date->add($interval);
+
+        $this->assertEquals(0, $new->hour);
+        $this->assertEquals(0, $new->minute);
+        $this->assertEquals(0, $new->second);
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->second);
+    }
 
     /**
      * @dataProvider dateClassProvider
@@ -27,6 +43,23 @@ class AddTest extends TestCase
         $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
         $date = $class::create(2001, 1, 1);
         $new = $date->add($interval);
+
+        $this->assertEquals(0, $new->hour);
+        $this->assertEquals(0, $new->minute);
+        $this->assertEquals(0, $new->second);
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->second);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testSubFullDay($class)
+    {
+        $interval = DateInterval::createFromDateString('1 day');
+        $date = $class::create(2001, 1, 1);
+        $new = $date->sub($interval);
 
         $this->assertEquals(0, $new->hour);
         $this->assertEquals(0, $new->minute);

--- a/tests/Date/AddTest.php
+++ b/tests/Date/AddTest.php
@@ -18,10 +18,14 @@ use TestCase;
 
 class AddTest extends TestCase
 {
-    public function testAddIgnoreTime()
+
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testAddIgnoreTime($class)
     {
         $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
-        $date = Date::create(2001, 1, 1);
+        $date = $class::create(2001, 1, 1);
         $new = $date->add($interval);
 
         $this->assertEquals(0, $new->hour);
@@ -32,10 +36,13 @@ class AddTest extends TestCase
         $this->assertEquals(0, $date->second);
     }
 
-    public function testSubIgnoreTime()
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testSubIgnoreTime($class)
     {
         $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
-        $date = Date::create(2001, 1, 1);
+        $date = $class::create(2001, 1, 1);
         $new = $date->sub($interval);
 
         $this->assertEquals(0, $new->hour);
@@ -46,27 +53,39 @@ class AddTest extends TestCase
         $this->assertEquals(0, $date->second);
     }
 
-    public function testAddDay()
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testAddDay($class)
     {
-        $this->assertEquals(1, Date::create(1975, 5, 31)->addDays(1)->day);
-        $this->assertEquals(30, Date::create(1975, 5, 31)->addDays(-1)->day);
+        $this->assertEquals(1, $class::create(1975, 5, 31)->addDays(1)->day);
+        $this->assertEquals(30, $class::create(1975, 5, 31)->addDays(-1)->day);
     }
 
-    public function testAddMonth()
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testAddMonth($class)
     {
-        $this->assertEquals(6, Date::create(1975, 5, 31)->addMonths(1)->month);
-        $this->assertEquals(4, Date::create(1975, 5, 31)->addMonths(-1)->month);
+        $this->assertEquals(6, $class::create(1975, 5, 31)->addMonths(1)->month);
+        $this->assertEquals(4, $class::create(1975, 5, 31)->addMonths(-1)->month);
     }
 
-    public function testAddYear()
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testAddYear($class)
     {
-        $this->assertEquals(1976, Date::create(1975, 5, 31)->addYears(1)->year);
-        $this->assertEquals(1974, Date::create(1975, 5, 31)->addYears(-1)->year);
+        $this->assertEquals(1976, $class::create(1975, 5, 31)->addYears(1)->year);
+        $this->assertEquals(1974, $class::create(1975, 5, 31)->addYears(-1)->year);
     }
 
-    public function testAddWeekdays()
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testAddWeekdays($class)
     {
-        $this->assertEquals(2, Date::create(1975, 5, 31)->addWeekdays(1)->day);
-        $this->assertEquals(30, Date::create(1975, 5, 31)->addWeekdays(-1)->day);
+        $this->assertEquals(2, $class::create(1975, 5, 31)->addWeekdays(1)->day);
+        $this->assertEquals(30, $class::create(1975, 5, 31)->addWeekdays(-1)->day);
     }
 }

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -20,13 +20,8 @@ use TestCase;
  */
 class ConstructTest extends TestCase
 {
-    public function classNameProvider()
-    {
-        return [[Date::class]];
-    }
-
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testCreatesAnInstanceDefaultToNow($class)
@@ -39,7 +34,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testParseCreatesAnInstanceDefaultToNow($class)
@@ -52,7 +47,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testWithFancyString($class)
@@ -62,7 +57,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testParseWithFancyString($class)
@@ -72,7 +67,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testUsesUTC($class)
@@ -82,7 +77,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testParseUsesUTC($class)
@@ -92,7 +87,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testSettingTimezoneIgnored($class)
@@ -104,7 +99,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testParseSettingTimezoneIgnored($class)
@@ -117,7 +112,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testSettingTimezoneWithStringIgnored($class)
@@ -130,7 +125,7 @@ class ConstructTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testParseSettingTimezoneWithStringIgnored($class)
@@ -177,6 +172,9 @@ class ConstructTest extends TestCase
         $this->assertEquals(0, $dt->second);
     }
 
+    /**
+     * @dataProvider dateClassProvider
+     */
     public function testConstructWithTestNow()
     {
         Date::setTestNow(Date::create(2001, 1, 1));

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -12,6 +12,7 @@
 namespace Cake\Chronos\Test\Date;
 
 use Cake\Chronos\Date;
+use Cake\Chronos\MutableDate;
 use DateTimeZone;
 use TestCase;
 
@@ -173,15 +174,28 @@ class ConstructTest extends TestCase
     }
 
     /**
+     * @dataProvider inputTimeProvider
+     * @return void
+     */
+    public function testConstructMutableWithTimeParts($time)
+    {
+        $dt = new MutableDate($time);
+        $this->assertEquals(8, $dt->month);
+        $this->assertEquals(0, $dt->hour);
+        $this->assertEquals(0, $dt->minute);
+        $this->assertEquals(0, $dt->second);
+    }
+
+    /**
      * @dataProvider dateClassProvider
      */
-    public function testConstructWithTestNow()
+    public function testConstructWithTestNow($class)
     {
-        Date::setTestNow(Date::create(2001, 1, 1));
-        $date = new Date('+2 days');
+        $class::setTestNow($class::create(2001, 1, 1));
+        $date = new $class('+2 days');
         $this->assertDateTime($date, 2001, 1, 3);
 
-        $date = new Date('2015-12-12');
+        $date = new $class('2015-12-12');
         $this->assertDateTime($date, 2015, 12, 12);
     }
 }

--- a/tests/Date/DateMutabilityConversionTest.php
+++ b/tests/Date/DateMutabilityConversionTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Brian Nesbitt <brian@nesbot.com>
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+use Cake\Chronos\Date;
+use Cake\Chronos\MutableDate;
+
+class DateMutabilityConversionTest extends TestCase
+{
+    public function testImmutableInstanceFromMutable()
+    {
+        $dt1 = MutableDate::create(2001, 2, 3, 10, 20, 30);
+        $dt2 = Date::instance($dt1);
+        $this->checkBothInstances($dt1, $dt2);
+    }
+
+    public function testMutableInstanceFromImmutable()
+    {
+        $dt1 = Date::create(2001, 2, 3, 10, 20, 30);
+        $dt2 = MutableDate::instance($dt1);
+        $this->checkBothInstances($dt2, $dt1);
+    }
+
+    public function testToImmutable()
+    {
+        $dt1 = MutableDate::create(2001, 2, 3, 10, 20, 30);
+        $dt2 = $dt1->toImmutable();
+        $this->checkBothInstances($dt1, $dt2);
+    }
+
+    public function testToMutable()
+    {
+        $dt1 = Date::create(2001, 2, 3, 10, 20, 30);
+        $dt2 = $dt1->toMutable();
+        $this->checkBothInstances($dt2, $dt1);
+    }
+
+    public function testMutableFromImmutable()
+    {
+        $dt1 = Date::create(2001, 2, 3, 10, 20, 30);
+        $dt2 = MutableDate::instance($dt1);
+        $this->checkBothInstances($dt2, $dt1);
+    }
+
+    public function testIsMutableMethod()
+    {
+        $dt1 = MutableDate::now();
+        $this->assertTrue($dt1->isMutable());
+
+        $dt2 = Date::now();
+        $this->assertFalse($dt2->isMutable());
+    }
+
+    protected function checkBothInstances(MutableDate$dt1, Date $dt2)
+    {
+        $this->assertDateTime($dt1, 2001, 2, 3, 0, 0, 0);
+        $this->assertInstanceOf(Date::class, $dt2);
+        $this->assertDateTime($dt2, 2001, 2, 3, 0, 0, 0);
+    }
+}

--- a/tests/Date/DateMutabilityConversionTest.php
+++ b/tests/Date/DateMutabilityConversionTest.php
@@ -59,7 +59,7 @@ class DateMutabilityConversionTest extends TestCase
         $this->assertFalse($dt2->isMutable());
     }
 
-    protected function checkBothInstances(MutableDate$dt1, Date $dt2)
+    protected function checkBothInstances(MutableDate $dt1, Date $dt2)
     {
         $this->assertDateTime($dt1, 2001, 2, 3, 0, 0, 0);
         $this->assertInstanceOf(Date::class, $dt2);

--- a/tests/Date/StringsTest.php
+++ b/tests/Date/StringsTest.php
@@ -16,13 +16,8 @@ use TestCase;
 
 class StringsTest extends TestCase
 {
-    public function classNameProvider()
-    {
-        return [[Date::class]];
-    }
-
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToString($class)
@@ -32,7 +27,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testSetToStringFormat($class)
@@ -43,7 +38,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testResetToStringFormat($class)
@@ -55,7 +50,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToDateString($class)
@@ -65,7 +60,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToFormattedDateString($class)
@@ -75,7 +70,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToTimeString($class)
@@ -85,7 +80,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToDateTimeString($class)
@@ -95,7 +90,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToDayDateTimeString($class)
@@ -105,7 +100,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToAtomString($class)
@@ -115,7 +110,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToCOOKIEString($class)
@@ -131,7 +126,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToIso8601String($class)
@@ -141,7 +136,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToRC822String($class)
@@ -151,7 +146,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToRfc850String($class)
@@ -161,7 +156,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToRfc1036String($class)
@@ -171,7 +166,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToRfc1123String($class)
@@ -181,7 +176,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToRfc2822String($class)
@@ -191,7 +186,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToRfc3339String($class)
@@ -201,7 +196,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToRssString($class)
@@ -211,7 +206,7 @@ class StringsTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
+     * @dataProvider dateClassProvider
      * @return void
      */
     public function testToW3cString($class)

--- a/tests/Date/TimezoneTest.php
+++ b/tests/Date/TimezoneTest.php
@@ -12,6 +12,7 @@
 namespace Cake\Chronos\Test\Date;
 
 use Cake\Chronos\Date;
+use Cake\Chronos\MutableDate;
 use DateTimeZone;
 use TestCase;
 
@@ -34,6 +35,20 @@ class TimezoneTest extends TestCase
     {
         $tz = new DateTimeZone('Pacific/Honolulu');
         $date = new Date('2015-01-01');
+        $new = $date->{$method}($tz);
+        $this->assertSame($new, $date);
+        $this->assertNotEquals($tz, $date->timezone);
+    }
+
+    /**
+     * Test that all the timezone methods do nothing.
+     *
+     * @dataProvider methodNameProvider
+     */
+    public function testNoopOnTimezoneChangeMutableDate($method)
+    {
+        $tz = new DateTimeZone('Pacific/Honolulu');
+        $date = new MutableDate('2015-01-01');
         $new = $date->{$method}($tz);
         $this->assertSame($new, $date);
         $this->assertNotEquals($tz, $date->timezone);

--- a/tests/DateTime/ComparisonTest.php
+++ b/tests/DateTime/ComparisonTest.php
@@ -13,10 +13,27 @@
 
 namespace Cake\Chronos\Test\DateTime;
 
+use Cake\Chronos\ChronosInterface;
 use TestCase;
 
 class ComparisonTest extends TestCase
 {
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testGetSetWeekendDays($class)
+    {
+        $expected = [ChronosInterface::SATURDAY, ChronosInterface::SUNDAY];
+        $this->assertEquals($expected, $class::getWeekendDays());
+
+        $replace = [ChronosInterface::SUNDAY];
+        $class::setWeekendDays($replace);
+        $this->assertEquals($replace, $class::getWeekendDays());
+
+        $class::setWeekendDays($expected);
+    }
 
     /**
      * @dataProvider classNameProvider

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,10 +13,10 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Cake\Chronos\Chronos;
-use Cake\Chronos\Date;
 use Cake\Chronos\ChronosInterval;
-use Cake\Chronos\MutableDateTime;
+use Cake\Chronos\Date;
 use Cake\Chronos\MutableDate;
+use Cake\Chronos\MutableDateTime;
 
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,8 +13,10 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Cake\Chronos\Chronos;
+use Cake\Chronos\Date;
 use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\MutableDateTime;
+use Cake\Chronos\MutableDate;
 
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
@@ -38,6 +40,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         return [
             'mutable' => [MutableDateTime::class],
             'immutable' => [Chronos::class]
+        ];
+    }
+
+    public function dateClassProvider()
+    {
+        return [
+            'mutable' => [MutableDate::class],
+            'immutable' => [Date::class]
         ];
     }
 


### PR DESCRIPTION
A mutable date object is necessary for backwards compatibility in CakePHP. Without this class we cannot provide backwards compatible typehints and behaviors for Date column types.