### PR TITLE
Fix: addWeekday(s) clears time

### DIFF
--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -470,9 +470,20 @@ trait ModifierTrait
      */
     public function addWeekday($value = 1)
     {
+        return $this->addWeekdays($value);
+    }
+
+    /**
+     * Remove weekdays from the instance
+     *
+     * @param int $value The number of weekdays to remove.
+     * @return static
+     */
+    public function subWeekdays($value)
+    {
         // Fix for https://bugs.php.net/bug.php?id=54909
         $string = $this->toTimeString();
-        $date = $this->modify((int)$value . " weekday");
+        $date = $this->modify('-' . (int)$value . ' weekday');
 
         return $date->setTimeFromTimeString($string);
     }
@@ -485,20 +496,7 @@ trait ModifierTrait
      */
     public function subWeekday($value = 1)
     {
-        $value = (int)$value;
-        return $this->modify("-$value weekday");
-    }
-
-    /**
-     * Remove weekdays from the instance
-     *
-     * @param int $value The number of weekdays to remove.
-     * @return static
-     */
-    public function subWeekdays($value)
-    {
-        $value = (int)$value;
-        return $this->modify("-$value weekday");
+        return $this->subWeekdays($value);
     }
 
     /**

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -470,7 +470,7 @@ trait ModifierTrait
      */
     public function addWeekday($value = 1)
     {
-    	// Fix for https://bugs.php.net/bug.php?id=54909
+        // Fix for https://bugs.php.net/bug.php?id=54909
         $string = $this->toTimeString();
         $date = $this->modify((int)$value . " weekday");
 

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -478,7 +478,7 @@ trait ModifierTrait
     public function subWeekdays($value)
     {
         $value = (int)$value;
-        return $this->modify("-$value weekdays " . $this->format('H:i:s'));
+        return $this->modify("$value weekdays ago, " . $this->format('H:i:s'));
     }
 
     /**

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -455,7 +455,7 @@ trait ModifierTrait
      */
     public function addWeekdays($value)
     {
-        return $this->modify((int)$value . " weekday " . $date->format('H:i:s'));
+        return $this->modify((int)$value . " weekday " . $this->format('H:i:s'));
     }
 
     /**
@@ -477,11 +477,7 @@ trait ModifierTrait
      */
     public function subWeekdays($value)
     {
-        // Fix for https://bugs.php.net/bug.php?id=54909
-        $string = $this->toTimeString();
-        $date = $this->modify('-' . (int)$value . ' weekday');
-
-        return $date->setTimeFromTimeString($string);
+        return $this->modify('-' . (int)$value . ' weekday ' . $this->format('H:i:s'));
     }
 
     /**

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -455,8 +455,10 @@ trait ModifierTrait
      */
     public function addWeekdays($value)
     {
-        $value = (int)$value;
-        return $this->modify("$value weekday");
+        // Fix for https://bugs.php.net/bug.php?id=54909
+        $string = $this->toTimeString();
+        $this->modify((int)$value . " weekday");
+        return $this->setTimeFromTimeString($string);
     }
 
     /**
@@ -467,8 +469,10 @@ trait ModifierTrait
      */
     public function addWeekday($value = 1)
     {
-        $value = (int)$value;
-        return $this->modify("$value weekday");
+    	// Fix for https://bugs.php.net/bug.php?id=54909
+        $string = $this->toTimeString();
+        $this->modify((int)$value . " weekday");
+        return $this->setTimeFromTimeString($string);
     }
 
     /**

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -455,7 +455,7 @@ trait ModifierTrait
      */
     public function addWeekdays($value)
     {
-        return $this->modify((int)$value . " weekday " . $this->format('H:i:s'));
+        return $this->modify((int)$value . ' weekdays ' . $this->format('H:i:s'));
     }
 
     /**
@@ -477,7 +477,8 @@ trait ModifierTrait
      */
     public function subWeekdays($value)
     {
-        return $this->modify('-' . (int)$value . ' weekday ' . $this->format('H:i:s'));
+        $value = (int)$value;
+        return $this->modify("-$value weekdays " . $this->format('H:i:s'));
     }
 
     /**

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -114,7 +114,7 @@ trait ModifierTrait
     {
         return $this->setDate($year, $month, $day)->setTime($hour, $minute, $second);
     }
-    
+
     /**
      * Set the time by time string
      *
@@ -457,8 +457,9 @@ trait ModifierTrait
     {
         // Fix for https://bugs.php.net/bug.php?id=54909
         $string = $this->toTimeString();
-        $this->modify((int)$value . " weekday");
-        return $this->setTimeFromTimeString($string);
+        $date = $this->modify((int)$value . " weekday");
+
+        return $date->setTimeFromTimeString($string);
     }
 
     /**
@@ -471,8 +472,9 @@ trait ModifierTrait
     {
     	// Fix for https://bugs.php.net/bug.php?id=54909
         $string = $this->toTimeString();
-        $this->modify((int)$value . " weekday");
-        return $this->setTimeFromTimeString($string);
+        $date = $this->modify((int)$value . " weekday");
+
+        return $date->setTimeFromTimeString($string);
     }
 
     /**

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -455,11 +455,7 @@ trait ModifierTrait
      */
     public function addWeekdays($value)
     {
-        // Fix for https://bugs.php.net/bug.php?id=54909
-        $string = $this->toTimeString();
-        $date = $this->modify((int)$value . " weekday");
-
-        return $date->setTimeFromTimeString($string);
+        return $this->modify((int)$value . " weekday " . $date->format('H:i:s'));
     }
 
     /**

--- a/tests/DateTime/AddTest.php
+++ b/tests/DateTime/AddTest.php
@@ -183,7 +183,13 @@ class AddTest extends TestCase
      */
     public function testAddWeekdaysPositive($class)
     {
-        $this->assertSame(17, $class::createFromDate(2012, 1, 4)->addWeekdays(9)->day);
+        $dt = $class::create(2012, 1, 4, 13, 2, 1)->addWeekdays(9);
+        $this->assertSame(17, $dt->day);
+
+        // Test for https://bugs.php.net/bug.php?id=54909
+        $this->assertSame(13, $dt->hour);
+        $this->assertSame(2, $dt->minute);
+        $this->assertSame(1, $dt->second);
     }
 
     /**

--- a/tests/DateTime/SubTest.php
+++ b/tests/DateTime/SubTest.php
@@ -141,7 +141,13 @@ class SubTest extends TestCase
      */
     public function testSubWeekdaysPositive($class)
     {
-        $this->assertSame(22, $class::createFromDate(2012, 1, 4)->subWeekdays(9)->day);
+        $dt = $class::createFromDate(2012, 1, 4, 13, 2, 1)->subWeekdays(9);
+        $this->assertSame(22, $dt->day);
+
+        // Test for https://bugs.php.net/bug.php?id=54909
+        $this->assertSame(13, $dt->hour);
+        $this->assertSame(2, $dt->minute);
+        $this->assertSame(1, $dt->second);
     }
 
     /**

--- a/tests/DateTime/SubTest.php
+++ b/tests/DateTime/SubTest.php
@@ -141,7 +141,7 @@ class SubTest extends TestCase
      */
     public function testSubWeekdaysPositive($class)
     {
-        $dt = $class::createFromDate(2012, 1, 4, 13, 2, 1)->subWeekdays(9);
+        $dt = $class::create(2012, 1, 4, 13, 2, 1)->subWeekdays(9);
         $this->assertSame(22, $dt->day);
 
         // Test for https://bugs.php.net/bug.php?id=54909


### PR DESCRIPTION
Resolves https://github.com/cakephp/chronos/issues/54

what about subWeekday and subWeekdays?
Those havent been fixed in carbon yet, but IMO should also be fixed.