### PR TITLE
Run appveyor on php 5.5.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,34 +2,31 @@ build: false
 shallow_clone: false
 platform: 'x86'
 clone_folder: c:\projects\chronos
+
 branches:
   only:
     - master
+
 environment:
   global:
     PHP: "C:/PHP"
+
 init:
   - SET PATH=C:\php\;%PATH%
+
 install:
   - cd c:\
-  - ps: Start-FileDownload 'http://ci.cakephp.org/php.zip'
-  - 7z x php.zip -oc:\php
+  - appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.5.8-nts-Win32-VC11-x86.zip
+  - 7z x php-5.5.8-nts-Win32-VC11-x86.zip -oc:\php
   - cd c:\php
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini
   - echo extension=php_openssl.dll >> php.ini
-  - echo extension=php_sqlsrv.dll >> php.ini
-  - echo extension=php_pdo_sqlsrv.dll >> php.ini
-  - echo extension=php_pdo_mysql.dll >> php.ini
-  - echo extension=php_intl.dll >> php.ini
-  - echo extension=php_mbstring.dll >> php.ini
-  - echo extension=php_fileinfo.dll >> php.ini
   - cd C:\projects\chronos
-  - php -r "readfile('https://getcomposer.org/installer');" | php
-  - php composer.phar install --prefer-dist --no-interaction
-  - php -v
-  - php -i | grep "ICU version"
+  - appveyor DownloadFile https://getcomposer.org/composer.phar
+  - php composer.phar install --prefer-dist --no-interaction --ansi --no-progress
+
 test_script:
   - cd C:\projects\chronos
   - vendor\bin\phpunit.bat


### PR DESCRIPTION
This solution can't be applied directly to cakephp/cakephp as SQLServer driver are not included but it's still valid for Chronos.

I will look later in the week if there's a place where we could get the dll for cakephp and download them directly to the ext directory.