### PR TITLE
Allow PHP 5.5.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "source": "https://github.com/cakephp/chronos"
   },
   "require": {
-    "php": ">=5.5.10"
+    "php": ">=5.5.9"
   },
   "require-dev": {
     "phpunit/phpunit": "*",


### PR DESCRIPTION
This allows chronos to install on Ubuntu 14.04. Which is pretty important.

See cakephp/cakephp#7952