### PR TITLE
Introduce consistent DateTime class and use Chronos as alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,21 @@ You can then use Chronos:
 <?php
 require 'vendor/autoload.php';
 
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 
-printf("Now: %s", Chronos::now());
+printf("Now: %s", DateTime::now());
 ```
 
 # Differences with nesbot/carbon
 
-The biggest and main difference is that `Chronos` extends `DateTimeImmutable` instead of `DateTime`.
+The biggest and main difference is that `Cake\\Chronos\\DateTime` extends `DateTimeImmutable` instead of `DateTime`.
 Immutability for date values has proven to be a great way of avoiding bugs and reduce the amount of code,
 since developers don't have to manually copy the instance every time they need a change.
 
-Another important feature it offers is the `Date` class, which is used for representing dates without time (calendar dates).
+Another important feature it offers is the `Cake\\Chronos\\Date` class, which is used for representing dates without time (calendar dates).
 Any time method called on this type of object is basically a no-op.
 
-A minor but still noticeable difference is that `Chronos` has no external dependencies, it is completely standalone.
+A minor but still noticeable difference is that `Cake\\Chronos\\DateTime` has no external dependencies, it is completely standalone.
 
 Finally, Chronos is faster than Carbon as it has been optimized for the creation of hundreds of instances with minimal
 overhead.
@@ -45,8 +45,6 @@ overhead.
 Chronos also strives for HHVM compatibility, this library can be used safely with HHVM 3.11.
 
 # Migrating from Carbon
-
-
 First add `cakephp/chronos` to your `composer.json`:
 
 ```shell
@@ -57,7 +55,7 @@ By default Chronos includes a compatibility script that creates aliases for the
 relevant Carbon classes.  This will let most applications upgrade with very
 little effort. If you'd like to permanently update your code, you will
 need to update imports and typehints. Assuming `src` contains the files you
-want to migrate, we could use the following to update files:
+want to migrate, we could use the following to update files, using the `Cake\\Chronos\\Chronos` alias:
 
 ```
 # Replace imports
@@ -70,7 +68,10 @@ find ./src -type f -exec sed -i '' 's/Carbon/Chronos/g' {} \;
 ```
 
 At this point your code should mostly work as it did before. The biggest
-different is that Chronos instances are immutable.
+different is that `Chronos` instances are immutable.
+
+Note that `Cake\\Chronos\\Chronos` extends `Cake\\Chronos\\DateTime` to allow easier Carbon migration,
+as that name will less likely conflict with any existing core `DateTime` class names.
 
 ## Immutable Object Changes
 
@@ -83,12 +84,14 @@ With those benefits in mind, there are a few things you need to keep in mind
 when modifying immutable objects:
 
 ```php
+use Cake\Chronos\DateTime;
+
 // This will lose modifications
-$date = new Chronos('2015-10-21 16:29:00');
+$date = new DateTime('2015-10-21 16:29:00');
 $date->modify('+2 hours');
 
 // This will keep modifications
-$date = new Chronos('2015-10-21 16:29:00');
+$date = new DateTime('2015-10-21 16:29:00');
 $date = $date->modify('+2 hours');
 ```
 
@@ -97,7 +100,10 @@ $date = $date->modify('+2 hours');
 In the case that you need a mutable instance you can get one:
 
 ```php
-$time = new Chronos('2015-10-21 16:29:00');
+use Cake\Chronos\Date;
+use Cake\Chronos\DateTime;
+
+$time = new DateTime('2015-10-21 16:29:00');
 $mutable = $time->toMutable();
 
 $date = new Date('2015-10-21');
@@ -109,6 +115,9 @@ $mutable = $date->toMutable();
 If you have a mutable object and want an immutable variant you can do the following:
 
 ```php
+use Cake\Chronos\MutableDate;
+use Cake\Chronos\MutableDateTime;
+
 $time = new MutableDateTime('2015-10-21 16:29:00');
 $fixed = $time->toImmutable();
 
@@ -135,7 +144,7 @@ echo $today->modify('+3 hours');
 // Outputs '2015-10-21'
 ```
 
-Like instances of `Chronos`, `Date` objects are also *immutable*. The `MutableDate` class provides
+Like instances of `DateTime`, `Date` objects are also *immutable*. The `MutableDate` class provides
 a mutable variant of `Date`.
 
 # Documentation

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Brian Nesbitt <brian@nesbot.com>
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Cake\Chronos;
+
+use DateTimeZone;
+
+/**
+ * An Immutable extension on the native DateTime object.
+ *
+ * This is an alias of the Chronos DateTime class, in case you
+ * rather want to use a different name than DateTime, e.g. when
+ * working with both native core DateTime and Chronos DateTime.
+ *
+ * Adds a number of convenience APIs methods and the ability
+ * to easily convert into a mutable object.
+ *
+ * @property-read int $year
+ * @property-read int $yearIso
+ * @property-read int $month
+ * @property-read int $day
+ * @property-read int $hour
+ * @property-read int $minute
+ * @property-read int $second
+ * @property-read int $timestamp seconds since the Unix Epoch
+ * @property-read DateTimeZone $timezone the current timezone
+ * @property-read DateTimeZone $tz alias of timezone
+ * @property-read int $micro
+ * @property-read int $dayOfWeek 0 (for Sunday) through 6 (for Saturday)
+ * @property-read int $dayOfYear 0 through 365
+ * @property-read int $weekOfMonth 1 through 5
+ * @property-read int $weekOfYear ISO-8601 week number of year, weeks starting on Monday
+ * @property-read int $daysInMonth number of days in the given month
+ * @property-read int $age does a diffInYears() with default parameters
+ * @property-read int $quarter the quarter of this instance, 1 - 4
+ * @property-read int $offset the timezone offset in seconds from UTC
+ * @property-read int $offsetHours the timezone offset in hours from UTC
+ * @property-read bool $dst daylight savings time indicator, true if DST, false otherwise
+ * @property-read bool $local checks if the timezone is local, true if local, false otherwise
+ * @property-read bool $utc checks if the timezone is UTC, true if UTC, false otherwise
+ * @property-read string  $timezoneName
+ * @property-read string  $tzName
+ */
+class Chronos extends DateTime
+{
+}

--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -47,7 +47,7 @@ use DateTimeZone;
  * @property-read string  $timezoneName
  * @property-read string  $tzName
  */
-class Chronos extends DateTimeImmutable implements ChronosInterface
+class DateTime extends DateTimeImmutable implements ChronosInterface
 {
     use Traits\ComparisonTrait;
     use Traits\DifferenceTrait;

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -11,7 +11,6 @@
  */
 namespace Cake\Chronos;
 
-use DateTime;
 use DateTimeZone;
 
 /**
@@ -21,7 +20,7 @@ use DateTimeZone;
  * This means that timezone changes take no effect as a calendar date exists in all timezones
  * in each respective date.
  */
-class MutableDate extends DateTime implements ChronosInterface
+class MutableDate extends \DateTime implements ChronosInterface
 {
     use Traits\ComparisonTrait;
     use Traits\DifferenceTrait;

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -12,7 +12,6 @@
  */
 namespace Cake\Chronos;
 
-use DateTime;
 use DateTimeZone;
 use InvalidArgumentException;
 
@@ -22,7 +21,7 @@ use InvalidArgumentException;
  * This object can be mutated in place using any setter method,
  * or __set().
  */
-class MutableDateTime extends DateTime implements ChronosInterface
+class MutableDateTime extends \DateTime implements ChronosInterface
 {
     use Traits\ComparisonTrait;
     use Traits\DifferenceTrait;
@@ -82,11 +81,11 @@ class MutableDateTime extends DateTime implements ChronosInterface
     /**
      * Create a new immutable instance from current mutable instance.
      *
-     * @return Chronos
+     * @return DateTime
      */
     public function toImmutable()
     {
-        return Chronos::instance($this);
+        return DateTime::instance($this);
     }
 
     /**

--- a/src/carbon_compat.php
+++ b/src/carbon_compat.php
@@ -13,5 +13,5 @@
 
 // Create class aliases for Carbon so applications
 // can upgrade more easily.
-class_alias('Cake\Chronos\Chronos', 'Carbon\MutableDateTime');
+class_alias('Cake\Chronos\DateTime', 'Carbon\MutableDateTime');
 class_alias('Cake\Chronos\ChronosInterface', 'Carbon\CarbonInterface');

--- a/tests/Benchmark/RelativeTimeEvent.php
+++ b/tests/Benchmark/RelativeTimeEvent.php
@@ -2,7 +2,7 @@
 namespace Cake\Chronos\Test\Benchmark;
 
 use Athletic\AthleticEvent;
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 
 /**
  * Benchmark relative time parsing.
@@ -14,7 +14,7 @@ class RelativeTimeEvent extends AthleticEvent
      */
     public function hasRelativeKeywordPlus()
     {
-        Chronos::hasRelativeKeywords('+3 days');
+        DateTime::hasRelativeKeywords('+3 days');
     }
 
     /**
@@ -22,6 +22,6 @@ class RelativeTimeEvent extends AthleticEvent
      */
     public function hasRelativeKeywordWords()
     {
-        Chronos::hasRelativeKeywords('first day of month');
+        DateTime::hasRelativeKeywords('first day of month');
     }
 }

--- a/tests/DateTime/ChronosTest.php
+++ b/tests/DateTime/ChronosTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Brian Nesbitt <brian@nesbot.com>
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Chronos\Test\DateTime;
+
+use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
+use TestCase;
+
+class ChronosTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testChronosAliasInstance()
+    {
+        $d = new Chronos();
+        $this->assertTrue($d instanceof DateTime);
+    }
+}

--- a/tests/DateTime/CopyTest.php
+++ b/tests/DateTime/CopyTest.php
@@ -13,7 +13,7 @@
 
 namespace Cake\Chronos\Test\DateTime;
 
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 use Cake\Chronos\MutableDateTime;
 use TestCase;
 

--- a/tests/DateTime/DiffTest.php
+++ b/tests/DateTime/DiffTest.php
@@ -12,7 +12,7 @@
  */
 namespace Cake\Chronos\Test\DateTime;
 
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 use Cake\Chronos\ChronosInterval;
 use Closure;
 use TestCase;
@@ -22,7 +22,7 @@ class DiffTest extends TestCase
 
     protected function wrapWithTestNow(Closure $func, $dt = null)
     {
-        parent::wrapWithTestNow($func, ($dt === null) ? Chronos::createFromDate(2012, 1, 1) : $dt);
+        parent::wrapWithTestNow($func, ($dt === null) ? DateTime::createFromDate(2012, 1, 1) : $dt);
     }
 
     /**
@@ -758,7 +758,7 @@ class DiffTest extends TestCase
 
     public function diffForHumansProvider()
     {
-        $now = Chronos::now();
+        $now = DateTime::now();
         return [
             [$now, $now->addYears(11), '11 years before'],
             [$now, $now->addYears(1), '1 year before'],
@@ -810,16 +810,16 @@ class DiffTest extends TestCase
     public function testDiffForHumansWithNow()
     {
         $this->wrapWithTestNow(function () {
-            $this->assertSame('1 second ago', Chronos::now()->subSeconds(1)->diffForHumans());
-            $this->assertSame('1 second from now', Chronos::now()->addSeconds(1)->diffForHumans());
+            $this->assertSame('1 second ago', DateTime::now()->subSeconds(1)->diffForHumans());
+            $this->assertSame('1 second from now', DateTime::now()->addSeconds(1)->diffForHumans());
         });
     }
 
     public function testDiffForHumansWithNowAbsolute()
     {
         $this->wrapWithTestNow(function () {
-            $this->assertSame('1 second', Chronos::now()->subSeconds(1)->diffForHumans(null, true));
-            $this->assertSame('1 second', Chronos::now()->addSeconds(1)->diffForHumans(null, true));
+            $this->assertSame('1 second', DateTime::now()->subSeconds(1)->diffForHumans(null, true));
+            $this->assertSame('1 second', DateTime::now()->addSeconds(1)->diffForHumans(null, true));
         });
     }
 }

--- a/tests/DateTime/DiffTest.php
+++ b/tests/DateTime/DiffTest.php
@@ -12,8 +12,8 @@
  */
 namespace Cake\Chronos\Test\DateTime;
 
-use Cake\Chronos\DateTime;
 use Cake\Chronos\ChronosInterval;
+use Cake\Chronos\DateTime;
 use Closure;
 use TestCase;
 

--- a/tests/DateTime/StringsTest.php
+++ b/tests/DateTime/StringsTest.php
@@ -13,7 +13,7 @@
 
 namespace Cake\Chronos\Test\DateTime;
 
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 use TestCase;
 
 class StringsTest extends TestCase
@@ -266,6 +266,6 @@ class StringsTest extends TestCase
      */
     public function testToQuarter($date, $expected, $range = false)
     {
-        $this->assertEquals($expected, (new Chronos($date))->toQuarter($range));
+        $this->assertEquals($expected, (new DateTime($date))->toQuarter($range));
     }
 }

--- a/tests/Interval/IntervalAddTest.php
+++ b/tests/Interval/IntervalAddTest.php
@@ -13,7 +13,7 @@
 
 namespace Cake\Chronos\Test\Interval;
 
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 use Cake\Chronos\ChronosInterval;
 use DateInterval;
 use TestCase;
@@ -29,14 +29,14 @@ class IntervalAddTest extends TestCase
 
     public function testAddWithDiffDateInterval()
     {
-        $diff = Chronos::now()->diff(Chronos::now()->addWeeks(3));
+        $diff = DateTime::now()->diff(DateTime::now()->addWeeks(3));
         $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11)->add($diff);
         $this->assertDateTimeInterval($ci, 4, 3, 70, 8, 10, 11);
     }
 
     public function testAddWithNegativeDiffDateInterval()
     {
-        $diff = Chronos::now()->diff(Chronos::now()->subWeeks(3));
+        $diff = DateTime::now()->diff(DateTime::now()->subWeeks(3));
         $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11)->add($diff);
         $this->assertDateTimeInterval($ci, 4, 3, 28, 8, 10, 11);
     }

--- a/tests/Interval/IntervalAddTest.php
+++ b/tests/Interval/IntervalAddTest.php
@@ -13,8 +13,8 @@
 
 namespace Cake\Chronos\Test\Interval;
 
-use Cake\Chronos\DateTime;
 use Cake\Chronos\ChronosInterval;
+use Cake\Chronos\DateTime;
 use DateInterval;
 use TestCase;
 

--- a/tests/Interval/IntervalConstructTest.php
+++ b/tests/Interval/IntervalConstructTest.php
@@ -13,7 +13,7 @@
 
 namespace Interval;
 
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 use Cake\Chronos\ChronosInterval;
 use DateInterval;
 use Exception;
@@ -239,6 +239,6 @@ class IntervalConstructTest extends TestCase
      */
     public function testInstanceWithDaysThrowsException()
     {
-        $ci = ChronosInterval::instance(Chronos::now()->diff(Chronos::now()->addWeeks(3)));
+        $ci = ChronosInterval::instance(DateTime::now()->diff(DateTime::now()->addWeeks(3)));
     }
 }

--- a/tests/Interval/IntervalConstructTest.php
+++ b/tests/Interval/IntervalConstructTest.php
@@ -13,10 +13,9 @@
 
 namespace Interval;
 
-use Cake\Chronos\DateTime;
 use Cake\Chronos\ChronosInterval;
+use Cake\Chronos\DateTime;
 use DateInterval;
-use Exception;
 use InvalidArgumentException;
 use TestCase;
 

--- a/tests/MutabilityConversionTest.php
+++ b/tests/MutabilityConversionTest.php
@@ -11,7 +11,7 @@
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 use Cake\Chronos\MutableDateTime;
 
 class MutabilityConversionTest extends TestCase
@@ -19,13 +19,13 @@ class MutabilityConversionTest extends TestCase
     public function testImmutableInstanceFromMutable()
     {
         $dt1 = MutableDateTime::create(2001, 2, 3, 10, 20, 30);
-        $dt2 = Chronos::instance($dt1);
+        $dt2 = DateTime::instance($dt1);
         $this->checkBothInstances($dt1, $dt2);
     }
 
     public function testMutableInstanceFromImmutable()
     {
-        $dt1 = Chronos::create(2001, 2, 3, 10, 20, 30);
+        $dt1 = DateTime::create(2001, 2, 3, 10, 20, 30);
         $dt2 = MutableDateTime::instance($dt1);
         $this->checkBothInstances($dt2, $dt1);
     }
@@ -39,14 +39,14 @@ class MutabilityConversionTest extends TestCase
 
     public function testToMutable()
     {
-        $dt1 = Chronos::create(2001, 2, 3, 10, 20, 30);
+        $dt1 = DateTime::create(2001, 2, 3, 10, 20, 30);
         $dt2 = $dt1->toMutable();
         $this->checkBothInstances($dt2, $dt1);
     }
 
     public function testMutableFromImmutable()
     {
-        $dt1 = Chronos::create(2001, 2, 3, 10, 20, 30);
+        $dt1 = DateTime::create(2001, 2, 3, 10, 20, 30);
         $dt2 = MutableDateTime::instance($dt1);
         $this->checkBothInstances($dt2, $dt1);
     }
@@ -56,14 +56,14 @@ class MutabilityConversionTest extends TestCase
         $dt1 = MutableDateTime::now();
         $this->assertTrue($dt1->isMutable());
 
-        $dt2 = Chronos::now();
+        $dt2 = DateTime::now();
         $this->assertFalse($dt2->isMutable());
     }
 
-    protected function checkBothInstances(MutableDateTime $dt1, Chronos $dt2)
+    protected function checkBothInstances(MutableDateTime $dt1, DateTime $dt2)
     {
         $this->assertDateTime($dt1, 2001, 2, 3, 10, 20, 30);
-        $this->assertInstanceOf(Chronos::class, $dt2);
+        $this->assertInstanceOf(DateTime::class, $dt2);
         $this->assertDateTime($dt2, 2001, 2, 3, 10, 20, 30);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@
  */
 require __DIR__ . '/../vendor/autoload.php';
 
-use Cake\Chronos\Chronos;
+use Cake\Chronos\DateTime;
 use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\Date;
 use Cake\Chronos\MutableDate;
@@ -34,7 +34,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     {
         date_default_timezone_set($this->saveTz);
         MutableDateTime::setTestNow(null);
-        Chronos::setTestNow(null);
+        DateTime::setTestNow(null);
         MutableDate::setTestNow(null);
         Date::setTestNow(null);
     }
@@ -43,7 +43,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     {
         return [
             'mutable' => [MutableDateTime::class],
-            'immutable' => [Chronos::class]
+            'immutable' => [DateTime::class]
         ];
     }
 
@@ -101,8 +101,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function wrapWithTestNow(Closure $func, $dt = null)
     {
-        Chronos::setTestNow(($dt === null) ? Chronos::now() : $dt);
+        DateTime::setTestNow(($dt === null) ? DateTime::now() : $dt);
         $func();
-        Chronos::setTestNow();
+        DateTime::setTestNow();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,9 +12,9 @@
  */
 require __DIR__ . '/../vendor/autoload.php';
 
-use Cake\Chronos\DateTime;
 use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\Date;
+use Cake\Chronos\DateTime;
 use Cake\Chronos\MutableDate;
 use Cake\Chronos\MutableDateTime;
 


### PR DESCRIPTION
Resolves https://github.com/cakephp/chronos/issues/71
```
Cake\Chronos\Date;
Cake\Chronos\DateTime;
Cake\Chronos\MutableDate;
Cake\Chronos\MutableDateTime;

// Alias of DateTime
Cake\Chronos\Chronos;
```

The [README](https://github.com/cakephp/chronos/tree/master-date-time-class) points out the alias and that it is useful for migrating from Carbon, as it makes the process less likely to collide with stray core DateTime class usage.