### PR TITLE
Fix setDate() not working on some relative dates.

### DIFF
--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -14,6 +14,7 @@ namespace Cake\Chronos\Traits;
 
 use Cake\Chronos\ChronosInterface;
 use DateTime;
+use DateTimeImmutable;
 
 /**
  * Provides a suite of modifier methods.
@@ -97,6 +98,31 @@ trait ModifierTrait
     public static function setWeekEndsAt($day)
     {
         static::$weekEndsAt = $day;
+    }
+
+    /**
+     * Set the date to a different date.
+     *
+     * Workaround for a PHP bug related to the first day of a month
+     *
+     * @param int $year The year to set.
+     * @param int $month The month to set.
+     * @param int $day The day to set.
+     * @return static
+     * @see https://bugs.php.net/bug.php?id=63863
+     */
+    public function setDate($year, $month, $day)
+    {
+        // Workaround for PHP issue.
+        $date = $this->modify('+0 day');
+
+        if ($this instanceof DateTimeImmutable) {
+            // Reflection is necessary to access the parent method
+            // of the immutable object
+            $method = new \ReflectionMethod('DateTimeImmutable', 'setDate');
+            return $method->invoke($date, $year, $month, $day);
+        }
+        return parent::setDate($year, $month, $day);
     }
 
     /**

--- a/tests/DateTime/SettersTest.php
+++ b/tests/DateTime/SettersTest.php
@@ -13,6 +13,7 @@
 
 namespace Cake\Chronos\Test;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\MutableDateTime;
 use InvalidArgumentException;
 use TestCase;
@@ -115,6 +116,18 @@ class SettersTest extends TestCase
         $d = MutableDateTime::now();
         $d->setTime(1, 1);
         $this->assertSame(0, $d->second);
+    }
+
+    public function testSetDateAfterStringCreation()
+    {
+        $d = new MutableDateTime('first day of this month');
+        $this->assertEquals(1, $d->day);
+        $d->setDate($d->year, $d->month, 12);
+        $this->assertEquals(12, $d->day);
+
+        $d = new Chronos('first day of this month');
+        $this->assertEquals(1, $d->day);
+        $this->assertEquals(12, $d->setDate($d->year, $d->month, 12)->day);
     }
 
     public function testDateTimeSetter()
@@ -253,7 +266,7 @@ class SettersTest extends TestCase
         $d = MutableDateTime::now();
         $d->doesNotExit = 'bb';
     }
-    
+
     public function testSetTimeFromTimeString()
     {
         $d = MutableDateTime::now();


### PR DESCRIPTION
When relative dates are created from last day of month, or first day of month expressions, the setDate() method does not work. This adds a workaround for a PHP issue. Sadly reflection was needed to access the `parent::setDate()` on an immutable object.

Refs #62