### PR TITLE
Removed redundant escape characters

### DIFF
--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -18,7 +18,7 @@ namespace Cake\Chronos\Traits;
  */
 trait RelativeKeywordTrait
 {
-    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|\+|\-|first|last|ago/i';
+    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|\+|-|first|last|ago/i';
 
     /**
      * Determine if there is a relative keyword in the time string, this is to

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -18,7 +18,7 @@ namespace Cake\Chronos\Traits;
  */
 trait RelativeKeywordTrait
 {
-    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|\+|-|first|last|ago/i';
+    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|[+-]|first|last|ago/i';
 
     /**
      * Determine if there is a relative keyword in the time string, this is to


### PR DESCRIPTION
There is no need to escape a hyphen `-` in this context. A hyphen is only a metacharacter in a character class (`[]`) and only when it does not appear as the first or last character in the class.