### PR TITLE
Adding today as a relative keyword pattern

### DIFF
--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -18,7 +18,7 @@ namespace Cake\Chronos\Traits;
  */
 trait RelativeKeywordTrait
 {
-    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|[+-]|first|last|ago/i';
+    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|today|[+-]|first|last|ago/i';
 
     /**
      * Determine if there is a relative keyword in the time string, this is to

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -100,6 +100,7 @@ class TestingAidsTest extends TestCase
         $this->assertSame('2013-08-25 05:15:05', $class::parse('1 week ago')->toDateTimeString());
 
         $this->assertSame('2013-09-02 00:00:00', $class::parse('tomorrow')->toDateTimeString());
+        $this->assertSame('2013-09-01 00:00:00', $class::parse('today')->toDateTimeString());
         $this->assertSame('2013-08-31 00:00:00', $class::parse('yesterday')->toDateTimeString());
 
         $this->assertSame('2013-09-02 05:15:05', $class::parse('+1 day')->toDateTimeString());


### PR DESCRIPTION
This makes the testNow work when using the `today` keyword in the constructor.

Refs https://github.com/briannesbitt/Carbon/pull/634