### PR TITLE
Fix Date constructor with relative strings.

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -30,7 +30,6 @@ class Date extends DateTimeImmutable implements ChronosInterface
     use Traits\FrozenTimeTrait;
     use Traits\MagicPropertyTrait;
     use Traits\ModifierTrait;
-    use Traits\RelativeKeywordTrait;
     use Traits\TestingAidTrait;
 
     /**

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -30,7 +30,6 @@ class MutableDate extends DateTime implements ChronosInterface
     use Traits\FrozenTimeTrait;
     use Traits\MagicPropertyTrait;
     use Traits\ModifierTrait;
-    use Traits\RelativeKeywordTrait;
     use Traits\TestingAidTrait;
 
     /**

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -11,7 +11,6 @@
  */
 namespace Cake\Chronos\Traits;
 
-
 /**
  * A trait for freezing the time aspect of a DateTime.
  *
@@ -19,6 +18,7 @@ namespace Cake\Chronos\Traits;
  */
 trait FrozenTimeTrait
 {
+
     use RelativeKeywordTrait;
 
     /**

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -11,6 +11,7 @@
  */
 namespace Cake\Chronos\Traits;
 
+
 /**
  * A trait for freezing the time aspect of a DateTime.
  *
@@ -18,6 +19,7 @@ namespace Cake\Chronos\Traits;
  */
 trait FrozenTimeTrait
 {
+    use RelativeKeywordTrait;
 
     /**
      * Removes the time components from an input string.
@@ -38,6 +40,9 @@ trait FrozenTimeTrait
         }
         if ($time === null || $time === 'now' || $time === '') {
             return date('Y-m-d 00:00:00');
+        }
+        if ($this->hasRelativeKeywords($time)) {
+            return date('Y-m-d 00:00:00', strtotime($time));
         }
         return preg_replace('/\d{1,2}:\d{1,2}:\d{1,2}/', '00:00:00', $time);
     }

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -231,9 +231,18 @@ class ConstructTest extends TestCase
     {
         $class::setTestNow($class::create(2001, 1, 1));
         $date = new $class('+2 days');
-        $this->assertDateTime($date, 2001, 1, 3);
+        $this->assertDateTime($date, 2001, 1, 3, 0, 0, 0);
 
         $date = new $class();
         $this->assertNotEquals('2001-01-03', $date->format('Y-m-d'));
+        $class::setTestNow(null);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testConstructWithRelative($class) {
+        $c = new $class('+7 days');
+        $this->assertEquals('00:00:00', $c->format('H:i:s'));
     }
 }

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -241,7 +241,8 @@ class ConstructTest extends TestCase
     /**
      * @dataProvider dateClassProvider
      */
-    public function testConstructWithRelative($class) {
+    public function testConstructWithRelative($class)
+    {
         $c = new $class('+7 days');
         $this->assertEquals('00:00:00', $c->format('H:i:s'));
     }


### PR DESCRIPTION
Check for relative strings when creating Date & MutableDate instances. Ensure that time values are removed from this constructor path.

Refs #91