### PR TITLE
Fix toIso8601String(), which was previously returning ATOM strings.

### DIFF
--- a/src/Traits/FormattingTrait.php
+++ b/src/Traits/FormattingTrait.php
@@ -130,7 +130,7 @@ trait FormattingTrait
      */
     public function toIso8601String()
     {
-        return $this->format(DateTime::ATOM);
+        return $this->format(DateTime::ISO8601);
     }
 
     /**

--- a/tests/Date/StringsTest.php
+++ b/tests/Date/StringsTest.php
@@ -132,7 +132,7 @@ class StringsTest extends TestCase
     public function testToIso8601String($class)
     {
         $d = $class::create(1975, 12, 25, 14, 15, 16);
-        $this->assertSame('1975-12-25T00:00:00+00:00', $d->toIso8601String());
+        $this->assertSame('1975-12-25T00:00:00+0000', $d->toIso8601String());
     }
 
     /**

--- a/tests/DateTime/StringsTest.php
+++ b/tests/DateTime/StringsTest.php
@@ -144,7 +144,7 @@ class StringsTest extends TestCase
     public function testToIso8601String($class)
     {
         $d = $class::create(1975, 12, 25, 14, 15, 16);
-        $this->assertSame('1975-12-25T14:15:16-05:00', $d->toIso8601String());
+        $this->assertSame('1975-12-25T14:15:16-0500', $d->toIso8601String());
     }
 
     /**

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -156,9 +156,9 @@ class TestingAidsTest extends TestCase
         $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
         $class::setTestNow($notNow);
 
-        $this->assertSame('2013-07-01T12:00:00-04:00', $class::parse('now')->toIso8601String());
-        $this->assertSame('2013-07-01T11:00:00-05:00', $class::parse('now', 'America/Mexico_City')->toIso8601String());
-        $this->assertSame('2013-07-01T09:00:00-07:00', $class::parse('now', 'America/Vancouver')->toIso8601String());
+        $this->assertSame('2013-07-01T12:00:00-0400', $class::parse('now')->toIso8601String());
+        $this->assertSame('2013-07-01T11:00:00-0500', $class::parse('now', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T09:00:00-0700', $class::parse('now', 'America/Vancouver')->toIso8601String());
     }
 
     /**


### PR DESCRIPTION
toIso8601String() is returning ATOM strings, which are almost identical except for the colon in the TZ offset as documented [here](http://book.cakephp.org/3.0/en/chronos.html#formatting-strings) and [here](http://carbon.nesbot.com/docs/#api-commonformats).