### PR TITLE
fixed doc of ’dayOfWeek’

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -32,7 +32,7 @@ use DateTimeZone;
  * @property-read DateTimeZone $timezone the current timezone
  * @property-read DateTimeZone $tz alias of timezone
  * @property-read int $micro
- * @property-read int $dayOfWeek 0 (for Sunday) through 6 (for Saturday)
+ * @property-read int $dayOfWeek 1 (for Monday) through 7 (for Sunday)
  * @property-read int $dayOfYear 0 through 365
  * @property-read int $weekOfMonth 1 through 5
  * @property-read int $weekOfYear ISO-8601 week number of year, weeks starting on Monday


### PR DESCRIPTION
refs [MagicPropertyTrait.php line44] (https://github.com/cakephp/chronos/blob/4e1dacba2e5e92283581c7fec195c652c9e99d09/src/Traits/MagicPropertyTrait.php#L44) 



|  |  |  |
|---|---|----|
| N  |  ISO-8601 numeric representation of the day of the week (added in PHP 5.1.0)  |   1 (for Monday) through 7 (for Sunday) |
> http://php.net/manual/en/function.date.php

