### PR TITLE
Fix casing on method name

### DIFF
--- a/src/Traits/DifferenceTrait.php
+++ b/src/Traits/DifferenceTrait.php
@@ -272,7 +272,7 @@ trait DifferenceTrait
      * @param bool $absolute removes time difference modifiers ago, after, etc
      * @return string
      */
-    public function diffForhumans(ChronosInterface $other = null, $absolute = false)
+    public function diffForHumans(ChronosInterface $other = null, $absolute = false)
     {
         return static::diffFormatter()->diffForHumans($this, $other, $absolute);
     }


### PR DESCRIPTION
To avoid errors like `PHP Strict standards:  Declaration of Cake\I18n\Time::diffForHumans() should be compatible with Cake\Chronos\MutableDateTime::diffForhumans(Cake\Chronos\ChronosInterface $other = NULL, $absolute = false)`

See the interface: https://github.com/cakephp/chronos/blob/master/src/ChronosInterface.php#L868