### PR TITLE
Remove microseconds from Date instances.

### DIFF
--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -45,7 +45,7 @@ trait FrozenTimeTrait
             return date('Y-m-d 00:00:00', strtotime($time));
         }
 
-        return preg_replace('/\d{1,2}:\d{1,2}:\d{1,2}/', '00:00:00', $time);
+        return preg_replace('/\d{1,2}:\d{1,2}:\d{1,2}(?:\.\d+)?/', '00:00:00', $time);
     }
 
     /**

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -96,6 +96,19 @@ class ConstructTest extends TestCase
      * @dataProvider dateClassProvider
      * @return void
      */
+    public function testParseWithMicroSeconds($class)
+    {
+        $date = $class::parse('2016-12-08 18:06:46.510954');
+        $this->assertEquals(0, $date->hour);
+        $this->assertEquals(0, $date->second);
+        $this->assertEquals(0, $date->minute);
+        $this->assertEquals(0, $date->micro);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
     public function testUsesUTC($class)
     {
         $c = new $class('now');


### PR DESCRIPTION
Strip out microseconds like other time components.

Refs #111