### PR TITLE
Make ChronosInterval::toString() prepend '-' for negative intervals.

### DIFF
--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -461,6 +461,10 @@ class ChronosInterval extends DateInterval
             }
         }
 
-        return $specString === static::PERIOD_PREFIX ? 'PT0S' : $specString;
+        if ($specString === static::PERIOD_PREFIX) {
+            return 'PT0S';
+        } else {
+            return $this->invert === 1 ? '-' . $specString : $specString;
+        }
     }
 }

--- a/tests/Interval/IntervalToStringTest.php
+++ b/tests/Interval/IntervalToStringTest.php
@@ -93,4 +93,11 @@ class IntervalToStringTest extends TestCase
             ChronosInterval::instance(new DateInterval((string)$ci))
         );
     }
+
+    public function testNegativeInterval()
+    {
+        $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
+        $ci->invert = 1;
+        $this->assertEquals('-P1Y2M3DT4H5M6S', (string) $ci);
+    }
 }

--- a/tests/Interval/IntervalToStringTest.php
+++ b/tests/Interval/IntervalToStringTest.php
@@ -98,6 +98,6 @@ class IntervalToStringTest extends TestCase
     {
         $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
         $ci->invert = 1;
-        $this->assertEquals('-P1Y2M3DT4H5M6S', (string) $ci);
+        $this->assertEquals('-P1Y2M3DT4H5M6S', (string)$ci);
     }
 }


### PR DESCRIPTION
Fix for #114 