### PR TITLE
Do not specialize zero in DifferenceFormatter

### DIFF
--- a/src/DifferenceFormatter.php
+++ b/src/DifferenceFormatter.php
@@ -77,11 +77,8 @@ class DifferenceFormatter
                 $unit = 'second';
                 break;
         }
-        if ($count === 0) {
-            $unit = 'just_now';
-        }
         $time = $this->translate->plural($unit, $count, ['count' => $count]);
-        if ($absolute || $count === 0) {
+        if ($absolute) {
             return $time;
         }
         $isFuture = $diffInterval->invert === 1;

--- a/src/DifferenceFormatter.php
+++ b/src/DifferenceFormatter.php
@@ -78,10 +78,10 @@ class DifferenceFormatter
                 break;
         }
         if ($count === 0) {
-            $count = 1;
+            $unit = 'just_now';
         }
         $time = $this->translate->plural($unit, $count, ['count' => $count]);
-        if ($absolute) {
+        if ($absolute || $count === 0) {
             return $time;
         }
         $isFuture = $diffInterval->invert === 1;

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -64,7 +64,7 @@ class Translator
      */
     public function plural($key, $count, array $vars = [])
     {
-        if ($count == 0 || $count == 1) {
+        if ($count === 0 || $count === 1) {
             return $this->singular($key, $vars);
         }
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -40,6 +40,7 @@ class Translator
         'from_now' => '{time} from now',
         'after' => '{time} after',
         'before' => '{time} before',
+        'just_now' => 'just now',
     ];
 
     /**
@@ -63,7 +64,7 @@ class Translator
      */
     public function plural($key, $count, array $vars = [])
     {
-        if ($count == 1) {
+        if ($count == 0 || $count == 1) {
             return $this->singular($key, $vars);
         }
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -58,7 +58,7 @@ class Translator
      * Get a plural message.
      *
      * @param string $key The key to use.
-     * @param string $count The number of items in the translation.
+     * @param int $count The number of items in the translation.
      * @param array $vars Additional context variables.
      * @return string The translated message or ''.
      */

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -40,7 +40,6 @@ class Translator
         'from_now' => '{time} from now',
         'after' => '{time} after',
         'before' => '{time} before',
-        'just_now' => 'just now',
     ];
 
     /**
@@ -64,7 +63,7 @@ class Translator
      */
     public function plural($key, $count, array $vars = [])
     {
-        if ($count === 0 || $count === 1) {
+        if ($count === 1) {
             return $this->singular($key, $vars);
         }
 

--- a/tests/DateTime/DiffTest.php
+++ b/tests/DateTime/DiffTest.php
@@ -817,18 +817,25 @@ class DiffTest extends TestCase
         });
     }
 
-    public function testDiffForHumansJustNow()
-    {
-        $this->wrapWithTestNow(function () {
-            $this->assertSame('just now', Chronos::now()->diffForHumans());
-        });
-    }
-
     public function testDiffForHumansWithNowAbsolute()
     {
         $this->wrapWithTestNow(function () {
             $this->assertSame('1 second', Chronos::now()->subSeconds(1)->diffForHumans(null, true));
             $this->assertSame('1 second', Chronos::now()->addSeconds(1)->diffForHumans(null, true));
+        });
+    }
+
+    public function testDiffForHumansWithoutDiff()
+    {
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('0 seconds ago', Chronos::now()->diffForHumans());
+        });
+    }
+
+    public function testDiffForHumansWithoutDiffAbsolute()
+    {
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('0 seconds', Chronos::now()->diffForHumans(null, true));
         });
     }
 

--- a/tests/DateTime/DiffTest.php
+++ b/tests/DateTime/DiffTest.php
@@ -817,6 +817,13 @@ class DiffTest extends TestCase
         });
     }
 
+    public function testDiffForHumansJustNow()
+    {
+        $this->wrapWithTestNow(function () {
+            $this->assertSame('just now', Chronos::now()->diffForHumans());
+        });
+    }
+
     public function testDiffForHumansWithNowAbsolute()
     {
         $this->wrapWithTestNow(function () {


### PR DESCRIPTION
Fixed that it was returned `1 second ago` even if there is no difference.
However, this modification affects the users of the library, so please consider it.

Thanks.