### PR TITLE
Update Date.php

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -55,7 +55,6 @@ class Date extends DateTimeImmutable implements ChronosInterface
      */
     public function __construct($time = 'now', $tz = null)
     {
-        $tz = new DateTimeZone('UTC');
         if (static::$testNow === null) {
             $time = $this->stripTime($time);
 


### PR DESCRIPTION
Remove overwriting of time zone parameter.
The parameter of the constructor is overwritten in the first line. This does not make sense.