### PR TITLE
Add midnight to the list of relative keywords.

### DIFF
--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -18,7 +18,7 @@ namespace Cake\Chronos\Traits;
  */
 trait RelativeKeywordTrait
 {
-    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|today|[+-]|first|last|ago/i';
+    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|midnight|today|[+-]|first|last|ago/i';
 
     /**
      * Determine if there is a relative keyword in the time string, this is to

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -112,6 +112,7 @@ class TestingAidsTest extends TestCase
 
         $this->assertSame('2013-09-02 00:00:00', $class::parse('tomorrow')->toDateTimeString());
         $this->assertSame('2013-09-01 00:00:00', $class::parse('today')->toDateTimeString());
+        $this->assertSame('2013-09-01 00:00:00', $class::parse('midnight')->toDateTimeString());
         $this->assertSame('2013-08-31 00:00:00', $class::parse('yesterday')->toDateTimeString());
 
         $this->assertSame('2013-09-02 05:15:05', $class::parse('+1 day')->toDateTimeString());


### PR DESCRIPTION
Midnight is used by Chronos::today() which will now return the correct
testNow value. Fixes issue #133 