### PR TITLE
Remove the unused tz argument from Date and MutableDate.

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -77,9 +77,8 @@ class Date extends DateTimeImmutable implements ChronosInterface
      * subtraction/addition to have deterministic results.
      *
      * @param string|null $time Fixed or relative time
-     * @param \DateTimeZone|string|null $tz The timezone for the instance
      */
-    public function __construct($time = 'now', $tz = null)
+    public function __construct($time = 'now')
     {
         $tz = new DateTimeZone('UTC');
         if (static::$testNow === null) {

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -77,9 +77,8 @@ class MutableDate extends DateTime implements ChronosInterface
      * subtraction/addition to have deterministic results.
      *
      * @param string|null $time Fixed or relative time
-     * @param \DateTimeZone|string|null $tz The timezone for the instance
      */
-    public function __construct($time = 'now', $tz = null)
+    public function __construct($time = 'now')
     {
         $tz = new DateTimeZone('UTC');
         if (static::$testNow === null) {


### PR DESCRIPTION
We don't allow the timezone to be changed in these classes so don't offer an argument that doesn't work.

Refs #136