### PR TITLE
When i was doing pull-request i has problems vith validating code style. I has to look at travis jobs to see how to validate it properly.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,14 @@
       "Cake\\Chronos\\Test\\": "tests"
     },
     "files": ["tests/TestCase.php"]
+  },
+  "scripts": {
+    "check": [
+      "@test",
+      "@cs-check"
+    ],
+    "test": "phpunit",
+    "cs-check": "phpcs",
+    "cs-fix": "phpcbf"
   }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+ <description>Default configuration</description>
+
+ <rule ref="vendor/cakephp/cakephp-codesniffer/CakePHP"/>
+
+ <file>./src</file>
+ <file>./tests</file>
+
+ <arg phpcs-only="true" value="p"/>
+ <arg name="extensions" value="php"/>
+
+ <config name="colors" value="1"/>
+</ruleset>


### PR DESCRIPTION
So i suggest to add this phpcs config and composer scripts to make it simpler to newcomers.
Besides that now i dont need to search (if i forgot it) and write the whole comman: `vendor\bin\phpcs -p --extensions=php --standard=vendor\cakephp\cakephp-codesniffer\CakePHP .\tests .\src`, i can just write `composer phpcs` or even `phpcs` if i have phpcs installed.