### PR TITLE
Workaround for php bug 72338 with setTimezone('HH:MM')

### DIFF
--- a/src/Traits/TimezoneTrait.php
+++ b/src/Traits/TimezoneTrait.php
@@ -48,6 +48,13 @@ trait TimezoneTrait
      */
     public function setTimezone($value)
     {
-        return parent::setTimezone(static::safeCreateDateTimeZone($value));
+        $date = parent::setTimezone(static::safeCreateDateTimeZone($value));
+
+        // https://bugs.php.net/bug.php?id=72338
+        // this is workaround for this bug
+        // Needed for PHP below 7.0 version
+        $date->getTimestamp();
+
+        return $date;
     }
 }

--- a/tests/DateTime/PhpBug72338Test.php
+++ b/tests/DateTime/PhpBug72338Test.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @copyright     Copyright (c) Brian Nesbitt <brian@nesbot.com>
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Chronos\Test\DateTime;
+
+use TestCase;
+
+class PhpBug72338Test extends TestCase
+{
+
+    /**
+     * Ensures that $date->format('U') returns unchanged timestamp
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testTimestamp($class)
+    {
+        $date = $class::createFromTimestamp(0)->setTimezone('+02:00');
+        $this->assertSame('0', $date->format('U'));
+    }
+
+    /**
+     * Ensures that date created from string with timezone and with same timezone set by setTimezone() is equal
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testEqualSetAndCreate($class)
+    {
+        $date = $class::createFromTimestamp(0)->setTimezone('+02:00');
+        $date1 = new $class('1970-01-01T02:00:00+02:00');
+        $this->assertEquals($date->format('U'), $date1->format('U'));
+    }
+
+    /**
+     * Ensures that second call to setTimezone() dont changing timestamp
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testSecondSetTimezone($class)
+    {
+        $date = $class::createFromTimestamp(0)->setTimezone('+02:00')->setTimezone('Europe/Moscow');
+        $this->assertEquals('0', $date->format('U'));
+    }
+}


### PR DESCRIPTION
You can see the failed tests for php 5.5, 5.6 in [this build](https://travis-ci.org/Ovsyanka/chronos/builds/218826064)