### PR TITLE
setDate refactoring to fix HHVM failing tests

### DIFF
--- a/benchmarks/Chronos/SetDateBench.php
+++ b/benchmarks/Chronos/SetDateBench.php
@@ -8,9 +8,10 @@ class SetDateBench
     /**
      * @Revs(100000)
      * @Iterations(5)
+     * @return void
      */
     public function benchSetDate()
     {
-       $date = (new Chronos())->setDate(1, 1, 1);
+        $date = (new Chronos())->setDate(1, 1, 1);
     }
 }

--- a/benchmarks/Chronos/SetDateBench.php
+++ b/benchmarks/Chronos/SetDateBench.php
@@ -1,0 +1,16 @@
+<?php
+namespace Cake\Chronos\Benchmarks\Chronos;
+
+use Cake\Chronos\Chronos;
+
+class SetDateBench
+{
+    /**
+     * @Revs(100000)
+     * @Iterations(5)
+     */
+    public function benchSetDate()
+    {
+       $date = (new Chronos())->setDate(1, 1, 1);
+    }
+}

--- a/benchmarks/DateTime/SetDateBench.php
+++ b/benchmarks/DateTime/SetDateBench.php
@@ -8,9 +8,10 @@ class SetDateBench
     /**
      * @Revs(100000)
      * @Iterations(5)
+     * @return void
      */
     public function benchSetDate()
     {
-       $date = (new MutableDateTime())->setDate(1, 1, 1);
+        $date = (new MutableDateTime())->setDate(1, 1, 1);
     }
 }

--- a/benchmarks/DateTime/SetDateBench.php
+++ b/benchmarks/DateTime/SetDateBench.php
@@ -1,0 +1,16 @@
+<?php
+namespace Cake\Chronos\Benchmarks\MutableDateTime;
+
+use Cake\Chronos\MutableDateTime;
+
+class SetDateBench
+{
+    /**
+     * @Revs(100000)
+     * @Iterations(5)
+     */
+    public function benchSetDate()
+    {
+       $date = (new MutableDateTime())->setDate(1, 1, 1);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
   "require-dev": {
     "phpunit/phpunit": "<6.0",
     "athletic/athletic": "~0.1",
-    "cakephp/cakephp-codesniffer": "~2.3"
+    "cakephp/cakephp-codesniffer": "~2.3",
+    "phpbench/phpbench": "@dev"
   },
   "autoload": {
     "psr-4": {
@@ -52,6 +53,7 @@
     ],
     "test": "phpunit",
     "cs-check": "phpcs",
-    "cs-fix": "phpcbf"
+    "cs-fix": "phpcbf",
+    "bench": "phpbench run"
   }
 }

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,3 @@
+{
+    "bootstrap": "vendor/autoload.php"
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,6 +6,7 @@
 
  <file>./src</file>
  <file>./tests</file>
+ <file>./benchmarks</file>
 
  <arg phpcs-only="true" value="p"/>
  <arg name="extensions" value="php"/>

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -113,17 +113,20 @@ trait ModifierTrait
      */
     public function setDate($year, $month, $day)
     {
-        // Workaround for PHP issue.
-        $date = $this->modify('+0 day');
+        return $this->modify('+0 day')->setDateParent($year, $month, $day);
+    }
 
-        if ($this instanceof DateTimeImmutable) {
-            // Reflection is necessary to access the parent method
-            // of the immutable object
-            $method = new \ReflectionMethod('DateTimeImmutable', 'setDate');
-
-            return $method->invoke($date, $year, $month, $day);
-        }
-
+    /**
+     * Just calling to parent setDate
+     * It used in overwritten setDate
+     *
+     * @param int $year The year to set.
+     * @param int $month The month to set.
+     * @param int $day The day to set.
+     * @return static
+     */
+    private function setDateParent($year, $month, $day)
+    {
         return parent::setDate($year, $month, $day);
     }
 


### PR DESCRIPTION
I noticed the failing tests for HHVM:
`Fatal error: Stack overflow in /home/travis/build/Ovsyanka/chronos/src/Traits/ModifierTrait.php on line 122`

And i made this change to solve it. Now there is a lot of another failing tests for HHVM, but it is another story - there no any new fails.

I wrote some performance tests, but i am not sure about it. I am completely newb in that matters. If you have suggestions to improve it - i will be glad to do it.

In this tests i didn't notice measurable performance changes. here is outputs of command `composer bench -- benchmarks --report=default`:

Before:
```
> composer bench -- benchmarks --report=default
> phpbench run "benchmarks" "--report=default"
PhpBench 0.11-dev (@git_sha@). Running benchmarks.
Using configuration file: E:\works\vendors\php\chronos/phpbench.json

\Cake\Chronos\Benchmarks\Chronos\SetDateBench

    benchSetDate                  I4 P0         [μ Mo]/r: 10.995 10.999 (μs)    [μSD μRSD]/r: 0.031μs 0.29%

\Cake\Chronos\Benchmarks\MutableDateTime\SetDateBench

    benchSetDate                  I4 P0         [μ Mo]/r: 9.739 9.605 (μs)      [μSD μRSD]/r: 0.273μs 2.81%

2 subjects, 10 iterations, 200,000 revs, 0 rejects
(best [mean mode] worst) = 9.551 [10.367 10.302] 10.281 (μs)
⅀T: 103.666μs μSD/r 0.152μs μRSD/r: 1.546%
suite: 133c6a571362b3472b5a9b10534ace9f9b69006f, date: 2017-04-05, stime: 17:02:20
+--------------+--------------+--------+--------+--------+------+-----+------------+----------+---------+---------+
| benchmark    | subject      | groups | params | revs   | iter | rej | mem        | time     | z-value | diff    |
+--------------+--------------+--------+--------+--------+------+-----+------------+----------+---------+---------+
| SetDateBench | benchSetDate |        | []     | 100000 | 0    | 0   | 2,095,336b | 10.951μs | -1.4σ   | +12.79% |
| SetDateBench | benchSetDate |        | []     | 100000 | 1    | 0   | 2,095,336b | 11.011μs | +0.51σ  | +13.26% |
| SetDateBench | benchSetDate |        | []     | 100000 | 2    | 0   | 2,095,336b | 11.001μs | +0.19σ  | +13.18% |
| SetDateBench | benchSetDate |        | []     | 100000 | 3    | 0   | 2,095,336b | 10.971μs | -0.77σ  | +12.94% |
| SetDateBench | benchSetDate |        | []     | 100000 | 4    | 0   | 2,095,336b | 11.041μs | +1.47σ  | +13.50% |
| SetDateBench | benchSetDate |        | []     | 100000 | 0    | 0   | 2,095,336b | 9.551μs  | -0.69σ  | 0.00%   |
| SetDateBench | benchSetDate |        | []     | 100000 | 1    | 0   | 2,095,336b | 9.611μs  | -0.47σ  | +0.62%  |
| SetDateBench | benchSetDate |        | []     | 100000 | 2    | 0   | 2,095,336b | 9.661μs  | -0.29σ  | +1.14%  |
| SetDateBench | benchSetDate |        | []     | 100000 | 3    | 0   | 2,095,336b | 9.591μs  | -0.54σ  | +0.42%  |
| SetDateBench | benchSetDate |        | []     | 100000 | 4    | 0   | 2,095,336b | 10.281μs | +1.98σ  | +7.10%  |
+--------------+--------------+--------+--------+--------+------+-----+------------+----------+---------+---------+
```

After:
```
> composer bench -- benchmarks --report=default
> phpbench run "benchmarks" "--report=default"
PhpBench 0.11-dev (@git_sha@). Running benchmarks.
Using configuration file: E:\works\vendors\php\chronos/phpbench.json

\Cake\Chronos\Benchmarks\Chronos\SetDateBench

    benchSetDate                  I4 P0         [μ Mo]/r: 10.163 10.148 (μs)    [μSD μRSD]/r: 0.036μs 0.35%

\Cake\Chronos\Benchmarks\MutableDateTime\SetDateBench

    benchSetDate                  I4 P0         [μ Mo]/r: 9.789 9.778 (μs)      [μSD μRSD]/r: 0.032μs 0.33%

2 subjects, 10 iterations, 200,000 revs, 0 rejects
(best [mean mode] worst) = 9.751 [9.976 9.963] 9.841 (μs)
⅀T: 99.756μs μSD/r 0.034μs μRSD/r: 0.340%
suite: 133c6a5cf6cd648f2960aaa9ceb1fc18a047d199, date: 2017-04-05, stime: 17:06:53
+--------------+--------------+--------+--------+--------+------+-----+------------+----------+---------+--------+
| benchmark    | subject      | groups | params | revs   | iter | rej | mem        | time     | z-value | diff   |
+--------------+--------------+--------+--------+--------+------+-----+------------+----------+---------+--------+
| SetDateBench | benchSetDate |        | []     | 100000 | 0    | 0   | 2,095,312b | 10.121μs | -1.17σ  | +3.66% |
| SetDateBench | benchSetDate |        | []     | 100000 | 1    | 0   | 2,095,312b | 10.221μs | +1.61σ  | +4.60% |
| SetDateBench | benchSetDate |        | []     | 100000 | 2    | 0   | 2,095,312b | 10.161μs | -0.06σ  | +4.04% |
| SetDateBench | benchSetDate |        | []     | 100000 | 3    | 0   | 2,095,312b | 10.181μs | +0.50σ  | +4.22% |
| SetDateBench | benchSetDate |        | []     | 100000 | 4    | 0   | 2,095,312b | 10.131μs | -0.89σ  | +3.75% |
| SetDateBench | benchSetDate |        | []     | 100000 | 0    | 0   | 2,095,312b | 9.761μs  | -0.88σ  | +0.10% |
| SetDateBench | benchSetDate |        | []     | 100000 | 1    | 0   | 2,095,312b | 9.841μs  | +1.63σ  | +0.91% |
| SetDateBench | benchSetDate |        | []     | 100000 | 2    | 0   | 2,095,312b | 9.791μs  | +0.06σ  | +0.41% |
| SetDateBench | benchSetDate |        | []     | 100000 | 3    | 0   | 2,095,312b | 9.751μs  | -1.19σ  | 0.00%  |
| SetDateBench | benchSetDate |        | []     | 100000 | 4    | 0   | 2,095,312b | 9.801μs  | +0.38σ  | +0.51% |
+--------------+--------------+--------+--------+--------+------+-----+------------+----------+---------+--------+
```