### PR TITLE
Limited PHP version constraint upper bound

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "source": "https://github.com/cakephp/chronos"
   },
   "require": {
-    "php": ">=5.5.9"
+    "php": "^5.5.9|^7"
   },
   "require-dev": {
     "phpunit/phpunit": "<6.0",


### PR DESCRIPTION
We cannot possibly know we're compatible with versions of PHP never before created, so we should not claim to be.

For example, PHP 7.1 support was added in [version `1.0.1`](https://github.com/cakephp/chronos/releases/tag/1.0.1), but users of earlier versions don't know they need to upgrade because earlier versions claim to be compatible with `"php": ">=5.5.9"`, meaning version 5.5.9 *and every future version of PHP*, which is strictly incorrect unless you possess profound time travelling capabilities.

This PR only seeks to claim compatibility with future versions of the same major version of PHP as we have tested compatibility for, but even that is a bit risky. It may be better to specify `<7.2` instead of `^7` and enforce the rule that we **do not claim to be compatible with any version of PHP we have not tested against**, instead.