### PR TITLE
Test against PHP nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 7.0
   - 7.1
   - hhvm
+  - nightly
 
 sudo: false
 
@@ -30,6 +31,7 @@ matrix:
 
   allow_failures:
     - php: hhvm
+    - php: nightly
 
   fast_finish: true
 


### PR DESCRIPTION
As discussed on Slack with savant and jeremyharris this adds nightly testing (which is PHP 7.2 at the moment) which is allowed to fail to keep an eye on any possible breaks in future versions.