### PR TITLE
Fix isNextWeek(), isLastWeek(), isNextMonth() and isLastMonth()

### DIFF
--- a/src/Traits/ComparisonTrait.php
+++ b/src/Traits/ComparisonTrait.php
@@ -246,7 +246,7 @@ trait ComparisonTrait
      */
     public function isNextWeek()
     {
-        return $this->weekOfYear === static::now($this->tz)->addWeek()->weekOfYear;
+        return $this->format('W o') === static::now($this->tz)->addWeek()->format('W o');
     }
 
     /**
@@ -256,7 +256,7 @@ trait ComparisonTrait
      */
     public function isLastWeek()
     {
-        return $this->weekOfYear === static::now($this->tz)->subWeek()->weekOfYear;
+        return $this->format('W o') === static::now($this->tz)->subWeek()->format('W o');
     }
 
     /**
@@ -266,7 +266,7 @@ trait ComparisonTrait
      */
     public function isNextMonth()
     {
-        return $this->month === static::now($this->tz)->addMonth()->month;
+        return $this->format('m Y') === static::now($this->tz)->addMonth()->format('m Y');
     }
 
     /**
@@ -276,7 +276,7 @@ trait ComparisonTrait
      */
     public function isLastMonth()
     {
-        return $this->month === static::now($this->tz)->subMonth()->month;
+        return $this->format('m Y') === static::now($this->tz)->subMonth()->format('m Y');
     }
 
     /**

--- a/tests/DateTime/IsTest.php
+++ b/tests/DateTime/IsTest.php
@@ -169,6 +169,10 @@ class IsTest extends TestCase
     public function testIsNextWeekFalse($class)
     {
         $this->assertFalse($class::now()->addWeek(2)->isNextWeek());
+
+        $class::setTestNow('2017-W01');
+        $time = new $class('2018-W02');
+        $this->assertFalse($time->isNextWeek());
     }
 
     /**
@@ -178,6 +182,10 @@ class IsTest extends TestCase
     public function testIsLastWeekFalse($class)
     {
         $this->assertFalse($class::now()->subWeek(2)->isLastWeek());
+
+        $class::setTestNow('2018-W02');
+        $time = new $class('2017-W01');
+        $this->assertFalse($time->isLastWeek());
     }
 
     /**
@@ -205,6 +213,10 @@ class IsTest extends TestCase
     public function testIsNextMonthFalse($class)
     {
         $this->assertFalse($class::now()->addMonth(2)->isNextMonth());
+
+        $class::setTestNow('2017-12-31');
+        $time = new $class('2017-01-01');
+        $this->assertFalse($time->isNextMonth());
     }
 
     /**
@@ -214,6 +226,10 @@ class IsTest extends TestCase
     public function testIsLastMonthFalse($class)
     {
         $this->assertFalse($class::now()->subMonth(2)->isLastMonth());
+
+        $class::setTestNow('2017-01-01');
+        $time = new $class('2017-12-31');
+        $this->assertFalse($time->isLastMonth());
     }
 
     /**


### PR DESCRIPTION
Currently these methods ignore the year. For example, if poeple do:
```php
(new Chronos('2000-01-01'))->isNextMonth();
```
on 2017-12-01, it will return true unexpectedly.