### PR TITLE
Optimize the magic properties getter

### DIFF
--- a/src/Traits/MagicPropertyTrait.php
+++ b/src/Traits/MagicPropertyTrait.php
@@ -57,22 +57,24 @@ trait MagicPropertyTrait
      */
     public function __get($name)
     {
+        static $formats = [
+            'year' => 'Y',
+            'yearIso' => 'o',
+            'month' => 'n',
+            'day' => 'j',
+            'hour' => 'G',
+            'minute' => 'i',
+            'second' => 's',
+            'micro' => 'u',
+            'dayOfWeek' => 'N',
+            'dayOfYear' => 'z',
+            'weekOfYear' => 'W',
+            'daysInMonth' => 't',
+            'timestamp' => 'U',
+        ];
+
         switch (true) {
-            case array_key_exists($name, $formats = [
-                'year' => 'Y',
-                'yearIso' => 'o',
-                'month' => 'n',
-                'day' => 'j',
-                'hour' => 'G',
-                'minute' => 'i',
-                'second' => 's',
-                'micro' => 'u',
-                'dayOfWeek' => 'N',
-                'dayOfYear' => 'z',
-                'weekOfYear' => 'W',
-                'daysInMonth' => 't',
-                'timestamp' => 'U',
-            ]):
+            case isset($formats[$name]):
                 return (int)$this->format($formats[$name]);
 
             case $name === 'weekOfMonth':


### PR DESCRIPTION
I think the optimization is worth it, as this method may be called thousands of times.

* Use the language construct `isset()` instead of the function `array_key_exists()`
* Use a static variable
----
(resubmit of https://github.com/briannesbitt/Carbon/pull/1017 which was targetted at Carbon)