### PR TITLE
Phpstan updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.2  
-  - hhvm
+  - 7.2
   - nightly
 
 sudo: false
@@ -23,7 +22,7 @@ env:
 
 matrix:
   include:
-    - php: 7.0
+    - php: 7.2
       env: PHPCS=1 DEFAULT=0
     - php: 7.0
       env: PHPSTAN=1 DEFAULT=0
@@ -31,7 +30,6 @@ matrix:
       env: PHPSTAN=1 DEFAULT=0
 
   allow_failures:
-    - php: hhvm
     - php: nightly
 
   fast_finish: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,9 +3,3 @@ parameters:
 		# Appears because interface can't describe properties and formally it doesen't have properties.
 		- '#Call to an undefined static method Cake\\Chronos\\ChronosInterval::[a-zA-Z0-9_]+\(\)#'
 		- '#Access to an undefined property Cake\\Chronos\\ChronosInterface::\$tz#'
-		
-		# I don't know why it appears. Maybe because of https://github.com/phpstan/phpstan/issues/100 ?
-		- '#Property Cake\\Chronos\\MutableDateTime::\$(tz|timezone) \(DateTimeZone\) does not accept string#'
-		
-		# This attempt is correct because it is just test for an Exception
-		- '#Access to an undefined property Cake\\Chronos\\MutableDateTime::\$doesNotExit#'


### PR DESCRIPTION
* Remove ignored errors as phpstan no longer emits them.
* Remove hhvm tests, we haven't had them passing in a long time and hhvm is no longer in vogue.