### PR TITLE
Fixed end of day time in docblocks

### DIFF
--- a/src/ChronosInterface.php
+++ b/src/ChronosInterface.php
@@ -996,7 +996,7 @@ interface ChronosInterface extends DateTimeInterface
     public function secondsSinceMidnight();
 
     /**
-     * The number of seconds until 23:23:59.
+     * The number of seconds until 23:59:59.
      *
      * @return int
      */

--- a/src/Traits/DifferenceTrait.php
+++ b/src/Traits/DifferenceTrait.php
@@ -231,7 +231,7 @@ trait DifferenceTrait
     }
 
     /**
-     * The number of seconds until 23:23:59.
+     * The number of seconds until 23:59:59.
      *
      * @return int
      */


### PR DESCRIPTION
Hi!

I noticed a bug in my code where I set the end of day to 23:23:59 instead of 23:59:59 and while fixing that bug I noticed the same misconception in the docblocks of some chronos methods.