### PR TITLE
Make 'test now' a singular thing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,7 @@ matrix:
   include:
     - php: 7.2
       env: PHPCS=1 DEFAULT=0
-    - php: 7.0
-      env: PHPSTAN=1 DEFAULT=0
-    - php: 7.1
+    - php: 7.2
       env: PHPSTAN=1 DEFAULT=0
 
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ init:
 
 install:
   - cd c:\
-  - appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.5.29-nts-Win32-VC11-x86.zip -FileName php.zip
+  - curl -fsS http://windows.php.net/downloads/releases/archives/php-5.5.29-nts-Win32-VC11-x86.zip -o php.zip
   - 7z x php.zip -oc:\php
   - cd c:\php
   - copy php.ini-production php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ init:
 
 install:
   - cd c:\
-  - curl -fsS http://windows.php.net/downloads/releases/archives/php-5.5.29-nts-Win32-VC11-x86.zip -o php.zip
+  - curl -fsS https://windows.php.net/downloads/releases/archives/php-5.5.29-nts-Win32-VC11-x86.zip -o php.zip
   - 7z x php.zip -oc:\php
   - cd c:\php
   - copy php.ini-production php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ init:
 
 install:
   - cd c:\
-  - appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.5.10-nts-Win32-VC11-x86.zip -FileName php.zip
+  - appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.5.29-nts-Win32-VC11-x86.zip -FileName php.zip
   - 7z x php.zip -oc:\php
   - cd c:\php
   - copy php.ini-production php.ini

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
 	ignoreErrors:
-		# Appears because interface can't describe properties and formally it doesen't have properties.
+		- '#Call to an undefined method Cake\\Chronos\\ChronosInterface::modify\(\).#'
+		# Appears because interface can't describe properties and formally it doesn't have properties.
 		- '#Call to an undefined static method Cake\\Chronos\\ChronosInterval::[a-zA-Z0-9_]+\(\)#'
 		- '#Access to an undefined property Cake\\Chronos\\ChronosInterface::\$tz#'

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -164,7 +164,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      * Get the ChronosInterface instance (real or mock) to be returned when a "now"
      * instance is created.
      *
-     * @return static the current instance used for testing
+     * @return \Cake\Chronos\ChronosInterface The current instance used for testing
      */
     public static function getTestNow()
     {

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -56,8 +56,17 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
     use Traits\MagicPropertyTrait;
     use Traits\ModifierTrait;
     use Traits\RelativeKeywordTrait;
-    use Traits\TestingAidTrait;
     use Traits\TimezoneTrait;
+
+    /**
+     * A test ChronosInterface instance to be returned when now instances are created
+     *
+     * There is a single test now for all date/time classes provided by Chronos.
+     * This aims to emulate stubbing out 'now' which is a single global fact.
+     *
+     * @var \Cake\Chronos\ChronosInterface
+     */
+    protected static $testNow;
 
     /**
      * Format to use for __toString method when type juggling occurs.
@@ -82,7 +91,8 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
         }
 
         static::$_lastErrors = [];
-        if (static::$testNow === null) {
+        $testNow = static::getTestNow();
+        if ($testNow === null) {
             parent::__construct($time === null ? 'now' : $time, $tz);
 
             return;
@@ -95,16 +105,15 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
             return;
         }
 
-        $testInstance = static::getTestNow();
         if ($relative) {
-            $testInstance = $testInstance->modify($time);
+            $testNow = $testNow->modify($time);
         }
 
-        if ($tz !== $testInstance->getTimezone()) {
-            $testInstance = $testInstance->setTimezone($tz === null ? date_default_timezone_get() : $tz);
+        if ($tz !== $testNow->getTimezone()) {
+            $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 
-        $time = $testInstance->format('Y-m-d H:i:s.u');
+        $time = $testNow->format('Y-m-d H:i:s.u');
         parent::__construct($time, $tz);
     }
 
@@ -129,6 +138,51 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
     }
 
     /**
+     * Set a ChronosInterface instance (real or mock) to be returned when a "now"
+     * instance is created.  The provided instance will be returned
+     * specifically under the following conditions:
+     *   - A call to the static now() method, ex. ChronosInterface::now()
+     *   - When a null (or blank string) is passed to the constructor or parse(), ex. new Chronos(null)
+     *   - When the string "now" is passed to the constructor or parse(), ex. new Chronos('now')
+     *   - When a string containing the desired time is passed to ChronosInterface::parse()
+     *
+     * Note the timezone parameter was left out of the examples above and
+     * has no affect as the mock value will be returned regardless of its value.
+     *
+     * To clear the test instance call this method using the default
+     * parameter of null.
+     *
+     * @param \Cake\Chronos\ChronosInterface|string|null $testNow The instance to use for all future instances.
+     * @return void
+     */
+    public static function setTestNow($testNow = null)
+    {
+        static::$testNow = is_string($testNow) ? static::parse($testNow) : $testNow;
+    }
+
+    /**
+     * Get the ChronosInterface instance (real or mock) to be returned when a "now"
+     * instance is created.
+     *
+     * @return static the current instance used for testing
+     */
+    public static function getTestNow()
+    {
+        return static::$testNow;
+    }
+
+    /**
+     * Determine if there is a valid test instance set. A valid test instance
+     * is anything that is not null.
+     *
+     * @return bool True if there is a test instance, otherwise false
+     */
+    public static function hasTestNow()
+    {
+        return static::$testNow !== null;
+    }
+
+    /**
      * Return properties for debugging.
      *
      * @return array
@@ -138,7 +192,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
         $properties = [
             'time' => $this->format('Y-m-d H:i:s.u'),
             'timezone' => $this->getTimezone()->getName(),
-            'hasFixedNow' => isset(self::$testNow)
+            'hasFixedNow' => self::hasTestNow()
         ];
 
         return $properties;

--- a/src/ChronosInterface.php
+++ b/src/ChronosInterface.php
@@ -17,10 +17,11 @@ use DateTimeZone;
 
 /**
  * An extension to the DateTimeInterface for a friendlier API
+ *
+ * @method static modify(string $relative)
  */
 interface ChronosInterface extends DateTimeInterface
 {
-
     /**
      * The day constants
      */

--- a/src/Date.php
+++ b/src/Date.php
@@ -81,7 +81,8 @@ class Date extends DateTimeImmutable implements ChronosInterface
     public function __construct($time = 'now')
     {
         $tz = new DateTimeZone('UTC');
-        if (static::$testNow === null) {
+        $testNow = Chronos::getTestNow();
+        if ($testNow === null) {
             $time = $this->stripTime($time);
 
             parent::__construct($time, $tz);
@@ -98,16 +99,15 @@ class Date extends DateTimeImmutable implements ChronosInterface
             return;
         }
 
-        $testInstance = static::getTestNow();
         if ($relative) {
-            $testInstance = $testInstance->modify($time);
+            $testNow = $testNow->modify($time);
         }
 
-        if ($tz !== $testInstance->getTimezone()) {
-            $testInstance = $testInstance->setTimezone($tz === null ? date_default_timezone_get() : $tz);
+        if ($tz !== $testNow->getTimezone()) {
+            $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 
-        $time = $testInstance->format('Y-m-d 00:00:00');
+        $time = $testNow->format('Y-m-d 00:00:00');
         parent::__construct($time, $tz);
     }
 
@@ -130,7 +130,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
     {
         $properties = [
             'date' => $this->format('Y-m-d'),
-            'hasFixedNow' => isset(self::$testNow)
+            'hasFixedNow' => static::hasTestNow(),
         ];
 
         return $properties;

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -81,9 +81,10 @@ class MutableDate extends DateTime implements ChronosInterface
     public function __construct($time = 'now')
     {
         $tz = new DateTimeZone('UTC');
-        if (static::$testNow === null) {
-            $time = $this->stripTime($time);
 
+        $testNow = Chronos::getTestNow();
+        if ($testNow === null) {
+            $time = $this->stripTime($time);
             parent::__construct($time, $tz);
 
             return;
@@ -98,16 +99,16 @@ class MutableDate extends DateTime implements ChronosInterface
             return;
         }
 
-        $testInstance = clone static::getTestNow();
+        $testNow = clone $testNow;
         if ($relative) {
-            $testInstance = $testInstance->modify($time);
+            $testNow = $testNow->modify($time);
         }
 
-        if ($tz !== $testInstance->getTimezone()) {
-            $testInstance = $testInstance->setTimezone($tz === null ? date_default_timezone_get() : $tz);
+        if ($tz !== $testNow->getTimezone()) {
+            $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 
-        $time = $testInstance->format('Y-m-d 00:00:00');
+        $time = $testNow->format('Y-m-d 00:00:00');
         parent::__construct($time, $tz);
     }
 
@@ -130,7 +131,7 @@ class MutableDate extends DateTime implements ChronosInterface
     {
         $properties = [
             'date' => $this->format('Y-m-d'),
-            'hasFixedNow' => isset(self::$testNow)
+            'hasFixedNow' => static::hasTestNow()
         ];
 
         return $properties;

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -82,7 +82,8 @@ class MutableDateTime extends DateTime implements ChronosInterface
             $tz = $tz instanceof DateTimeZone ? $tz : new DateTimeZone($tz);
         }
 
-        if (static::$testNow === null) {
+        $testNow = Chronos::getTestNow();
+        if ($testNow === null) {
             parent::__construct($time === null ? 'now' : $time, $tz);
 
             return;
@@ -95,16 +96,16 @@ class MutableDateTime extends DateTime implements ChronosInterface
             return;
         }
 
-        $testInstance = clone static::getTestNow();
+        $testNow = clone $testNow;
         if ($relative) {
-            $testInstance = $testInstance->modify($time);
+            $testNow = $testNow->modify($time);
         }
 
-        if ($tz !== $testInstance->getTimezone()) {
-            $testInstance = $testInstance->setTimezone($tz === null ? date_default_timezone_get() : $tz);
+        if ($tz !== $testNow->getTimezone()) {
+            $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 
-        $time = $testInstance->format('Y-m-d H:i:s.u');
+        $time = $testNow->format('Y-m-d H:i:s.u');
         parent::__construct($time, $tz);
     }
 
@@ -177,7 +178,7 @@ class MutableDateTime extends DateTime implements ChronosInterface
         $properties = [
             'time' => $this->format('Y-m-d H:i:s.u'),
             'timezone' => $this->getTimezone()->getName(),
-            'hasFixedNow' => isset(self::$testNow)
+            'hasFixedNow' => static::hasTestNow(),
         ];
 
         return $properties;

--- a/src/Traits/TestingAidTrait.php
+++ b/src/Traits/TestingAidTrait.php
@@ -13,6 +13,7 @@
  */
 namespace Cake\Chronos\Traits;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosInterface;
 
 /**
@@ -21,55 +22,38 @@ use Cake\Chronos\ChronosInterface;
  */
 trait TestingAidTrait
 {
-    /**
-     * A test ChronosInterface instance to be returned when now instances are created
-     *
-     * @var \Cake\Chronos\ChronosInterface
-     */
-    protected static $testNow;
 
     /**
-     * Set a ChronosInterface instance (real or mock) to be returned when a "now"
-     * instance is created.  The provided instance will be returned
-     * specifically under the following conditions:
-     *   - A call to the static now() method, ex. ChronosInterface::now()
-     *   - When a null (or blank string) is passed to the constructor or parse(), ex. new Chronos(null)
-     *   - When the string "now" is passed to the constructor or parse(), ex. new Chronos('now')
-     *   - When a string containing the desired time is passed to ChronosInterface::parse()
+     * Set the test now used by Date and Time classes provided by Chronos
      *
-     * Note the timezone parameter was left out of the examples above and
-     * has no affect as the mock value will be returned regardless of its value.
-     *
-     * To clear the test instance call this method using the default
-     * parameter of null.
-     *
+     * @see \Cake\Chronos\Chronos::setTestNow()
      * @param \Cake\Chronos\ChronosInterface|string|null $testNow The instance to use for all future instances.
      * @return void
      */
     public static function setTestNow($testNow = null)
     {
-        static::$testNow = is_string($testNow) ? static::parse($testNow) : $testNow;
+        Chronos::setTestNow($testNow);
     }
 
     /**
-     * Get the ChronosInterface instance (real or mock) to be returned when a "now"
-     * instance is created.
+     * Get the test instance stored in Chronos
      *
-     * @return static the current instance used for testing
+     * @see \Cake\Chronos\Chronos::getTestNow()
+     * @return static|null the current instance used for testing or null.
      */
     public static function getTestNow()
     {
-        return static::$testNow;
+        return Chronos::getTestNow();
     }
 
     /**
-     * Determine if there is a valid test instance set. A valid test instance
-     * is anything that is not null.
+     * Get whether or not Chronos has a test instance set.
      *
+     * @see \Cake\Chronos\Chronos::hasTestNow()
      * @return bool True if there is a test instance, otherwise false
      */
     public static function hasTestNow()
     {
-        return static::getTestNow() !== null;
+        return Chronos::hasTestNow();
     }
 }

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -13,6 +13,10 @@
 
 namespace Cake\Chronos\Test\DateTime;
 
+use Cake\Chronos\Chronos;
+use Cake\Chronos\Date;
+use Cake\Chronos\MutableDate;
+use Cake\Chronos\MutableDateTime;
 use DateTimeZone;
 use TestCase;
 
@@ -186,5 +190,22 @@ class TestingAidsTest extends TestCase
         $this->assertEquals(new DateTimeZone('America/Toronto'), $result->tz);
         $this->assertEquals('2015-12-31 18:00:00', $result->format('Y-m-d H:i:s'));
         $this->assertEquals(new DateTimeZone('Europe/Copenhagen'), $class::getTestNow()->tz);
+    }
+
+    /**
+     * Test that setting testNow() on one class sets it on all of the chronos classes.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testSetTestNowSingular($class)
+    {
+        $c = new $class('2016-01-03 00:00:00', 'Europe/Copenhagen');
+        $class::setTestNow($c);
+
+        $this->assertSame($c, MutableDate::getTestNow());
+        $this->assertSame($c, Date::getTestNow());
+        $this->assertSame($c, Chronos::getTestNow());
+        $this->assertSame($c, MutableDateTime::getTestNow());
     }
 }


### PR DESCRIPTION
Having to manage and align 4 test now instances was pretty awkward and led to annoying issues like cakephp/cakephp#11908. By having only one test now we avoid that issue entirely as there is only one place for 'now' to live.

Refs cakephp/cakephp#11908