### PR TITLE
[Improvement] - ChronosInterval - Display interval in readable format

### DIFF
--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -503,8 +503,7 @@ class ChronosInterval extends DateInterval
             static::PERIOD_MINUTES => $i,
             static::PERIOD_SECONDS => $s,
         ]);
-
-
+        
         $specString = static::PERIOD_PREFIX;
 
         foreach ($date as $key => $value) {
@@ -523,6 +522,5 @@ class ChronosInterval extends DateInterval
         }
 
         return $this->invert === 1 ? '-' . $specString : $specString;
-
     }
 }

--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -436,17 +436,74 @@ class ChronosInterval extends DateInterval
      */
     public function __toString()
     {
+        // equivalence
+        $oneMinuteInSeconds = 60;
+        $oneHourInSeconds = $oneMinuteInSeconds * 60;
+        $oneDayInSeconds = $oneHourInSeconds * 24;
+        $oneMonthInDdays = 365/12;
+        $oneMonthInSeconds = $oneDayInSeconds * $oneMonthInDdays;
+        $oneYearInSeconds = 12 * $oneMonthInSeconds;
+
+        // convert
+        $ySecs = $this->y * $oneYearInSeconds;
+        $mSecs = $this->m * $oneMonthInSeconds;
+        $dSecs = $this->d * $oneDayInSeconds;
+        $hSecs = $this->h * $oneHourInSeconds;
+        $iSecs = $this->i * $oneMinuteInSeconds;
+        $sSecs = $this->s;
+
+        $totalSecs = $ySecs + $mSecs + $dSecs + $hSecs + $iSecs + $sSecs;
+
+        $y = null;
+        $m = null;
+        $d = null;
+        $h = null;
+        $i = null;
+
+        // years
+        if ($totalSecs >= $oneYearInSeconds) {
+            $y = floor ($totalSecs / $oneYearInSeconds);
+            $totalSecs = $totalSecs - $y * $oneYearInSeconds;
+        }
+
+        // months
+        if ($totalSecs >= $oneMonthInSeconds) {
+            $m = floor ($totalSecs / $oneMonthInSeconds);
+            $totalSecs = $totalSecs - $m * $oneMonthInSeconds;
+        }
+
+        // days
+        if ($totalSecs >= $oneDayInSeconds) {
+            $d = floor ($totalSecs / $oneDayInSeconds);
+            $totalSecs = $totalSecs - $d * $oneDayInSeconds;
+        }
+
+        // hours
+        if ($totalSecs >= $oneHourInSeconds) {
+            $h = floor ($totalSecs / $oneHourInSeconds);
+            $totalSecs = $totalSecs - $h * $oneHourInSeconds;
+        }
+
+        // minutes
+        if ($totalSecs >= $oneMinuteInSeconds) {
+            $i = floor ($totalSecs / $oneMinuteInSeconds);
+            $totalSecs = $totalSecs - $i * $oneMinuteInSeconds;
+        }
+
+        $s = $totalSecs;
+
         $date = array_filter([
-            static::PERIOD_YEARS => $this->y,
-            static::PERIOD_MONTHS => $this->m,
-            static::PERIOD_DAYS => $this->d,
+            static::PERIOD_YEARS => $y,
+            static::PERIOD_MONTHS => $m,
+            static::PERIOD_DAYS => $d,
         ]);
 
         $time = array_filter([
-            static::PERIOD_HOURS => $this->h,
-            static::PERIOD_MINUTES => $this->i,
-            static::PERIOD_SECONDS => $this->s,
+            static::PERIOD_HOURS => $h,
+            static::PERIOD_MINUTES => $i,
+            static::PERIOD_SECONDS => $s,
         ]);
+
 
         $specString = static::PERIOD_PREFIX;
 
@@ -466,5 +523,6 @@ class ChronosInterval extends DateInterval
         }
 
         return $this->invert === 1 ? '-' . $specString : $specString;
+
     }
 }

--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -440,7 +440,7 @@ class ChronosInterval extends DateInterval
         $oneMinuteInSeconds = 60;
         $oneHourInSeconds = $oneMinuteInSeconds * 60;
         $oneDayInSeconds = $oneHourInSeconds * 24;
-        $oneMonthInDdays = 365/12;
+        $oneMonthInDdays = 365 / 12;
         $oneMonthInSeconds = $oneDayInSeconds * $oneMonthInDdays;
         $oneYearInSeconds = 12 * $oneMonthInSeconds;
 
@@ -462,31 +462,31 @@ class ChronosInterval extends DateInterval
 
         // years
         if ($totalSecs >= $oneYearInSeconds) {
-            $y = floor ($totalSecs / $oneYearInSeconds);
+            $y = floor($totalSecs / $oneYearInSeconds);
             $totalSecs = $totalSecs - $y * $oneYearInSeconds;
         }
 
         // months
         if ($totalSecs >= $oneMonthInSeconds) {
-            $m = floor ($totalSecs / $oneMonthInSeconds);
+            $m = floor($totalSecs / $oneMonthInSeconds);
             $totalSecs = $totalSecs - $m * $oneMonthInSeconds;
         }
 
         // days
         if ($totalSecs >= $oneDayInSeconds) {
-            $d = floor ($totalSecs / $oneDayInSeconds);
+            $d = floor($totalSecs / $oneDayInSeconds);
             $totalSecs = $totalSecs - $d * $oneDayInSeconds;
         }
 
         // hours
         if ($totalSecs >= $oneHourInSeconds) {
-            $h = floor ($totalSecs / $oneHourInSeconds);
+            $h = floor($totalSecs / $oneHourInSeconds);
             $totalSecs = $totalSecs - $h * $oneHourInSeconds;
         }
 
         // minutes
         if ($totalSecs >= $oneMinuteInSeconds) {
-            $i = floor ($totalSecs / $oneMinuteInSeconds);
+            $i = floor($totalSecs / $oneMinuteInSeconds);
             $totalSecs = $totalSecs - $i * $oneMinuteInSeconds;
         }
 
@@ -503,7 +503,7 @@ class ChronosInterval extends DateInterval
             static::PERIOD_MINUTES => $i,
             static::PERIOD_SECONDS => $s,
         ]);
-        
+
         $specString = static::PERIOD_PREFIX;
 
         foreach ($date as $key => $value) {

--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -440,8 +440,8 @@ class ChronosInterval extends DateInterval
         $oneMinuteInSeconds = 60;
         $oneHourInSeconds = $oneMinuteInSeconds * 60;
         $oneDayInSeconds = $oneHourInSeconds * 24;
-        $oneMonthInDdays = 365 / 12;
-        $oneMonthInSeconds = $oneDayInSeconds * $oneMonthInDdays;
+        $oneMonthInDays = 365 / 12;
+        $oneMonthInSeconds = $oneDayInSeconds * $oneMonthInDays;
         $oneYearInSeconds = 12 * $oneMonthInSeconds;
 
         // convert

--- a/tests/Interval/IntervalToStringTest.php
+++ b/tests/Interval/IntervalToStringTest.php
@@ -25,51 +25,96 @@ class IntervalToStringTest extends TestCase
         $this->assertEquals('PT0S', (string)$ci);
     }
 
+    /**
+     * Date section
+     */
     public function testYearInterval()
     {
         $ci = new ChronosInterval();
+        $ci1 = new ChronosInterval(1);
+        $ci2 = new ChronosInterval(0, 12, 0, 0);
+        $ci3 = new ChronosInterval(0, 0, 0, 365);
+        $ci4 = new ChronosInterval(0, 0, 52, 1);
+
         $this->assertEquals('P1Y', (string)$ci);
+        $this->assertEquals('P1Y', (string)$ci1);
+        $this->assertEquals('P1Y', (string)$ci2);
+        $this->assertEquals('P1Y', (string)$ci3);
+        $this->assertEquals('P1Y', (string)$ci4);
     }
 
     public function testMonthInterval()
     {
-        $ci = new ChronosInterval(0, 1);
-        $this->assertEquals('P1M', (string)$ci);
+        $ci1 = new ChronosInterval(0, 1);
+        $ci2 = new ChronosInterval(0, 0, 0, 30, 10);
+        $ci3 = new ChronosInterval(0, 0, 4, 2, 10);
+
+        $this->assertEquals('P1M', (string)$ci1);
+        $this->assertEquals('P1M', (string)$ci2);
+        $this->assertEquals('P1M', (string)$ci3);
     }
 
     public function testWeekInterval()
     {
-        $ci = new ChronosInterval(0, 0, 1);
-        $this->assertEquals('P7D', (string)$ci);
+        $ci1 = new ChronosInterval(0, 0, 1);
+        $ci2 = new ChronosInterval(0, 0, 0, 7);
+        $ci3 = new ChronosInterval(0, 0, 0, 0, 7*24);
+        $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 7*24*60);
+
+        $this->assertEquals('P7D', (string)$ci1);
+        $this->assertEquals('P7D', (string)$ci2);
+        $this->assertEquals('P7D', (string)$ci3);
+        $this->assertEquals('P7D', (string)$ci4);
     }
 
     public function testDayInterval()
     {
-        $ci = new ChronosInterval(0, 0, 0, 1);
-        $this->assertEquals('P1D', (string)$ci);
+        $ci1 = new ChronosInterval(0, 0, 0, 1);
+        $ci2 = new ChronosInterval(0, 0, 0, 0, 24);
+        $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 24*60);
+        $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 0, 24*60*60);
+
+        $this->assertEquals('P1D', (string)$ci1);
+        $this->assertEquals('P1D', (string)$ci2);
+        $this->assertEquals('P1D', (string)$ci3);
+        $this->assertEquals('P1D', (string)$ci4);
     }
 
     public function testMixedDateInterval()
     {
-        $ci = new ChronosInterval(1, 2, 0, 3);
-        $this->assertEquals('P1Y2M3D', (string)$ci);
+        $ci1 = new ChronosInterval(1, 2, 0, 3);
+        $ci2 = new ChronosInterval(0, 14, 0, 3);
+        $this->assertEquals('P1Y2M3D', (string)$ci1);
+        $this->assertEquals('P1Y2M3D', (string)$ci2);
     }
 
+    /**
+     * Time section
+     */
     public function testHourInterval()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 1);
-        $this->assertEquals('PT1H', (string)$ci);
+        $ci1 = new ChronosInterval(0, 0, 0, 0, 1);
+        $ci2 = new ChronosInterval(0, 0, 0, 0, 0, 60);
+        $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 0, 3600);
+
+        $this->assertEquals('PT1H', (string)$ci1);
+        $this->assertEquals('PT1H', (string)$ci2);
+        $this->assertEquals('PT1H', (string)$ci3);
     }
 
     public function testMinuteInterval()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 0, 1);
-        $this->assertEquals('PT1M', (string)$ci);
+        $ci1 = new ChronosInterval(0, 0, 0, 0, 0, 1);
+        $ci2 = new ChronosInterval(0, 0, 0, 0, 0, 0, 60);
+
+        $this->assertEquals('PT1M', (string)$ci1);
+        $this->assertEquals('PT1M', (string)$ci2);
     }
 
     public function testSecondInterval()
     {
         $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 1);
+
         $this->assertEquals('PT1S', (string)$ci);
     }
 
@@ -79,10 +124,16 @@ class IntervalToStringTest extends TestCase
         $this->assertEquals('PT1H2M3S', (string)$ci);
     }
 
+    /**
+     * Date and Time sections
+     */
     public function testMixedDateAndTimeInterval()
     {
-        $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
-        $this->assertEquals('P1Y2M3DT4H5M6S', (string)$ci);
+        $ci1 = new ChronosInterval(0, 0, 0, 0, 48, 120);
+        $ci2 = new ChronosInterval(0, 24, 0, 0, 48, 120);
+
+        $this->assertEquals('P2DT2H', (string)$ci1);
+        $this->assertEquals('P2Y2DT2H', (string)$ci2);
     }
 
     public function testCreatingInstanceEquals()

--- a/tests/Interval/IntervalToStringTest.php
+++ b/tests/Interval/IntervalToStringTest.php
@@ -58,8 +58,8 @@ class IntervalToStringTest extends TestCase
     {
         $ci1 = new ChronosInterval(0, 0, 1);
         $ci2 = new ChronosInterval(0, 0, 0, 7);
-        $ci3 = new ChronosInterval(0, 0, 0, 0, 7*24);
-        $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 7*24*60);
+        $ci3 = new ChronosInterval(0, 0, 0, 0, 7 * 24);
+        $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 7 * 24 * 60);
 
         $this->assertEquals('P7D', (string)$ci1);
         $this->assertEquals('P7D', (string)$ci2);
@@ -71,8 +71,8 @@ class IntervalToStringTest extends TestCase
     {
         $ci1 = new ChronosInterval(0, 0, 0, 1);
         $ci2 = new ChronosInterval(0, 0, 0, 0, 24);
-        $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 24*60);
-        $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 0, 24*60*60);
+        $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 24 * 60);
+        $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 0, 24 * 60 * 60);
 
         $this->assertEquals('P1D', (string)$ci1);
         $this->assertEquals('P1D', (string)$ci2);

--- a/tests/Interval/IntervalToStringTest.php
+++ b/tests/Interval/IntervalToStringTest.php
@@ -25,6 +25,12 @@ class IntervalToStringTest extends TestCase
         $this->assertEquals('PT0S', (string)$ci);
     }
 
+    public function testNegativeArguments()
+    {
+        $ci = new ChronosInterval(1, -2, 0, 15);
+        $this->assertEquals('P1Y15D', (string)$ci, 'Negative arguments are not considered');
+    }
+
     /**
      * Date section
      */


### PR DESCRIPTION
# Why this improvement
So far ChronosInterval displays any duration that you want but in a very basic way. So durations like ```P7000D3000S``` (7.000 days and 3.000 seconds) are totally fine with the current implementation, but makes little sense for the normal person.

So with this improvement instead of having: ```P1835D``` (1.835 days) we will have ```P5Y10D``` (5 years and 10 days), for example.

