### PR TITLE
use a copy of  date/time for testNow

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -105,6 +105,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
             return;
         }
 
+        $testNow = clone $testNow;
         if ($relative) {
             $testNow = $testNow->modify($time);
         }
@@ -168,7 +169,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      */
     public static function getTestNow()
     {
-        return is_object(static::$testNow) ? clone static::$testNow : static::$testNow;
+        return static::$testNow;
     }
 
     /**

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -168,7 +168,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      */
     public static function getTestNow()
     {
-        return static::$testNow;
+        return is_object(static::$testNow) ? clone static::$testNow : static::$testNow;
     }
 
     /**

--- a/src/Date.php
+++ b/src/Date.php
@@ -99,8 +99,12 @@ class Date extends DateTimeImmutable implements ChronosInterface
             return;
         }
 
+        $testNow = clone $testNow;
         if ($relative) {
-            $testNow = $testNow->modify($time);
+            $time = $this->stripRelativeTime($time);
+            if (strlen($time) > 0) {
+                $testNow = $testNow->modify($time);
+            }
         }
 
         if ($tz !== $testNow->getTimezone()) {

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -101,7 +101,10 @@ class MutableDate extends DateTime implements ChronosInterface
 
         $testNow = clone $testNow;
         if ($relative) {
-            $testNow = $testNow->modify($time);
+            $time = $this->stripRelativeTime($time);
+            if (strlen($time) > 0) {
+                $testNow = $testNow->modify($time);
+            }
         }
 
         if ($tz !== $testNow->getTimezone()) {

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -49,6 +49,17 @@ trait FrozenTimeTrait
     }
 
     /**
+     * Remove time components from strtotime relative strings.
+     *
+     * @param string $time The input expression
+     * @return string The output expression with no time modifiers.
+     */
+    protected function stripRelativeTime($time)
+    {
+        return preg_replace('/([-+]\s*\d+\s(?:minutes|seconds|hours|microseconds))/', '', $time);
+    }
+
+    /**
      * Modify the time on the Date.
      *
      * This method ignores all inputs and forces all inputs to 0.

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -87,6 +87,62 @@ class TestingAidsTest extends TestCase
     }
 
     /**
+     * Ensure that using test now doesn't mutate test now.
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testNowNoMutateDateTime($class)
+    {
+        $value = '2018-06-21 10:11:12';
+        $notNow = new MutableDateTime($value);
+        $class::setTestNow($notNow);
+
+        $instance = new $class('-10 minutes');
+        $this->assertSame('10:01:12', $instance->format('H:i:s'));
+
+        $instance = new $class('-10 minutes');
+        $this->assertSame('10:01:12', $instance->format('H:i:s'));
+    }
+
+    /**
+     * Ensure that using test now doesn't mutate test now.
+     *
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testNowNoMutateDate($class)
+    {
+        $value = '2018-06-21 10:11:12';
+        $notNow = new MutableDateTime($value);
+        $class::setTestNow($notNow);
+
+        $instance = new $class('-1 day');
+        $this->assertSame('2018-06-20 00:00:00', $instance->format('Y-m-d H:i:s'));
+
+        $instance = new $class('-1 day');
+        $this->assertSame('2018-06-20 00:00:00', $instance->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * Ensure that setting a datetime into test now doesn't violate date semantics
+     *
+     * Modifying date instances by hours should not change the date.
+     *
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testNowTestDateTimeConstraints($class)
+    {
+        $value = '2018-06-21 10:11:12';
+        $notNow = new MutableDateTime($value);
+        $class::setTestNow($notNow);
+
+        $instance = new $class('-23 hours');
+        $this->assertSame('2018-06-21 00:00:00', $instance->format('Y-m-d H:i:s'));
+    }
+
+    /**
      * @dataProvider classNameProvider
      * @return void
      */

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -45,7 +45,7 @@ class TestingAidsTest extends TestCase
         $class::setTestNow($notNow);
 
         $this->assertTrue($class::hasTestNow());
-        $this->assertSame($notNow, $class::getTestNow());
+        $this->assertEquals($notNow, $class::getTestNow());
     }
 
     /**
@@ -203,9 +203,9 @@ class TestingAidsTest extends TestCase
         $c = new $class('2016-01-03 00:00:00', 'Europe/Copenhagen');
         $class::setTestNow($c);
 
-        $this->assertSame($c, MutableDate::getTestNow());
-        $this->assertSame($c, Date::getTestNow());
-        $this->assertSame($c, Chronos::getTestNow());
-        $this->assertSame($c, MutableDateTime::getTestNow());
+        $this->assertEquals($c, MutableDate::getTestNow());
+        $this->assertEquals($c, Date::getTestNow());
+        $this->assertEquals($c, Chronos::getTestNow());
+        $this->assertEquals($c, MutableDateTime::getTestNow());
     }
 }


### PR DESCRIPTION
this would solve most issues in core's testCases

but remains 
```php
1) Cake\Test\TestCase\I18n\TimeTest::testTimeAgoInWords with data set #0 ('-12 seconds', '12 seconds ago')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'12 seconds ago'
+'just now'

5) Cake\Test\TestCase\I18n\TimeTest::testTimeAgoInWordsFrozenTime with data set #0 ('-12 seconds', '12 seconds ago')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'12 seconds ago'
+'just now'


9) Cake\Test\TestCase\I18n\TimeTest::testTimeAgoInWordsAccuracy with data set "mutable" ('Cake\I18n\Time')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'in about an hour'
+'just now'


12) Cake\Test\TestCase\I18n\TimeTest::testTimeAgoInWordsNegativeValues with data set "immutable" ('Cake\I18n\FrozenTime')
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'about an hour ago'
+'just now'

```

Refs : https://github.com/cakephp/chronos/issues/173