### PR TITLE
Fix typing errors that make updating CakePHP hard.

### DIFF
--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -11,6 +11,8 @@
  */
 namespace Cake\Chronos\Traits;
 
+use DateTimeInterface;
+
 /**
  * A trait for freezing the time aspect of a DateTime.
  *
@@ -18,7 +20,6 @@ namespace Cake\Chronos\Traits;
  */
 trait FrozenTimeTrait
 {
-
     use RelativeKeywordTrait;
 
     /**
@@ -32,11 +33,14 @@ trait FrozenTimeTrait
      */
     protected function stripTime($time)
     {
-        if (substr($time, 0, 1) === '@') {
-            return gmdate('Y-m-d 00:00:00', substr($time, 1));
-        }
         if (is_int($time) || ctype_digit($time)) {
             return gmdate('Y-m-d 00:00:00', $time);
+        }
+        if ($time instanceof DateTimeInterface) {
+            $time = $time->format('Y-m-d 00:00:00');
+        }
+        if (substr($time, 0, 1) === '@') {
+            return gmdate('Y-m-d 00:00:00', substr($time, 1));
         }
         if ($time === null || $time === 'now' || $time === '') {
             return date('Y-m-d 00:00:00');


### PR DESCRIPTION
chronos has some underlying typing errors that are making updating I18n package hard.