### PR TITLE
Fix Error: debugInfo must return an array #164

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -44,8 +44,8 @@ use DateTimeZone;
  * @property-read bool $dst daylight savings time indicator, true if DST, false otherwise
  * @property-read bool $local checks if the timezone is local, true if local, false otherwise
  * @property-read bool $utc checks if the timezone is UTC, true if UTC, false otherwise
- * @property-read string  $timezoneName
- * @property-read string  $tzName
+ * @property-read string $timezoneName
+ * @property-read string $tzName
  */
 class Chronos extends DateTimeImmutable implements ChronosInterface
 {
@@ -190,12 +190,16 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      */
     public function __debugInfo()
     {
-        $properties = [
+        if (!property_exists($this, 'date') || !property_exists($this, 'timezone')) {
+            return [
+                'hasFixedNow' => self::hasTestNow(),
+            ];
+        }
+
+        return [
             'time' => $this->format('Y-m-d H:i:s.u'),
             'timezone' => $this->getTimezone()->getName(),
             'hasFixedNow' => self::hasTestNow()
         ];
-
-        return $properties;
     }
 }

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -190,16 +190,20 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      */
     public function __debugInfo()
     {
-        if (!property_exists($this, 'date') || !property_exists($this, 'timezone')) {
-            return [
-                'hasFixedNow' => self::hasTestNow(),
-            ];
+        $vars = get_object_vars($this);
+
+        $properties = [
+            'hasFixedNow' => static::hasTestNow(),
+        ];
+
+        if (isset($vars['date'])) {
+            $properties['time'] = $this->format('Y-m-d H:i:s.u');
         }
 
-        return [
-            'time' => $this->format('Y-m-d H:i:s.u'),
-            'timezone' => $this->getTimezone()->getName(),
-            'hasFixedNow' => self::hasTestNow()
-        ];
+        if (isset($vars['timezone'])) {
+            $properties['timezone'] = $this->getTimezone()->getName();
+        }
+
+        return $properties;
     }
 }

--- a/src/Date.php
+++ b/src/Date.php
@@ -9,6 +9,7 @@
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace Cake\Chronos;
 
 use DateTimeImmutable;
@@ -44,8 +45,8 @@ use DateTimeZone;
  * @property-read bool $dst daylight savings time indicator, true if DST, false otherwise
  * @property-read bool $local checks if the timezone is local, true if local, false otherwise
  * @property-read bool $utc checks if the timezone is UTC, true if UTC, false otherwise
- * @property-read string  $timezoneName
- * @property-read string  $tzName
+ * @property-read string $timezoneName
+ * @property-read string $tzName
  */
 class Date extends DateTimeImmutable implements ChronosInterface
 {
@@ -132,15 +133,16 @@ class Date extends DateTimeImmutable implements ChronosInterface
      */
     public function __debugInfo()
     {
-        if (!property_exists($this, 'date')) {
-            return [
-                'hasFixedNow' => self::hasTestNow(),
-            ];
-        }
+        $vars = get_object_vars($this);
 
-        return [
-            'date' => $this->format('Y-m-d'),
+        $properties = [
             'hasFixedNow' => static::hasTestNow(),
         ];
+
+        if (isset($vars['date'])) {
+            $properties['date'] = $this->format('Y-m-d');
+        }
+
+        return $properties;
     }
 }

--- a/src/Date.php
+++ b/src/Date.php
@@ -132,11 +132,15 @@ class Date extends DateTimeImmutable implements ChronosInterface
      */
     public function __debugInfo()
     {
-        $properties = [
+        if (!property_exists($this, 'date')) {
+            return [
+                'hasFixedNow' => self::hasTestNow(),
+            ];
+        }
+
+        return [
             'date' => $this->format('Y-m-d'),
             'hasFixedNow' => static::hasTestNow(),
         ];
-
-        return $properties;
     }
 }

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -44,8 +44,8 @@ use DateTimeZone;
  * @property-read bool $dst daylight savings time indicator, true if DST, false otherwise
  * @property-read bool $local checks if the timezone is local, true if local, false otherwise
  * @property-read bool $utc checks if the timezone is UTC, true if UTC, false otherwise
- * @property-read string  $timezoneName
- * @property-read string  $tzName
+ * @property-read string $timezoneName
+ * @property-read string $tzName
  */
 class MutableDate extends DateTime implements ChronosInterface
 {
@@ -132,11 +132,15 @@ class MutableDate extends DateTime implements ChronosInterface
      */
     public function __debugInfo()
     {
-        $properties = [
+        if (!property_exists($this, 'date')) {
+            return [
+                'hasFixedNow' => self::hasTestNow(),
+            ];
+        }
+
+        return [
             'date' => $this->format('Y-m-d'),
             'hasFixedNow' => static::hasTestNow()
         ];
-
-        return $properties;
     }
 }

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -132,15 +132,16 @@ class MutableDate extends DateTime implements ChronosInterface
      */
     public function __debugInfo()
     {
-        if (!property_exists($this, 'date')) {
-            return [
-                'hasFixedNow' => self::hasTestNow(),
-            ];
+        $vars = get_object_vars($this);
+
+        $properties = [
+            'hasFixedNow' => static::hasTestNow(),
+        ];
+
+        if (isset($vars['date'])) {
+            $properties['date'] = $this->format('Y-m-d');
         }
 
-        return [
-            'date' => $this->format('Y-m-d'),
-            'hasFixedNow' => static::hasTestNow()
-        ];
+        return $properties;
     }
 }

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -45,8 +45,8 @@ use InvalidArgumentException;
  * @property-read bool $dst daylight savings time indicator, true if DST, false otherwise
  * @property-read bool $local checks if the timezone is local, true if local, false otherwise
  * @property-read bool $utc checks if the timezone is UTC, true if UTC, false otherwise
- * @property-read string  $timezoneName
- * @property-read string  $tzName
+ * @property-read string $timezoneName
+ * @property-read string $tzName
  */
 class MutableDateTime extends DateTime implements ChronosInterface
 {
@@ -175,12 +175,16 @@ class MutableDateTime extends DateTime implements ChronosInterface
      */
     public function __debugInfo()
     {
-        $properties = [
+        if (!property_exists($this, 'date') || !property_exists($this, 'timezone')) {
+            return [
+                'hasFixedNow' => self::hasTestNow(),
+            ];
+        }
+
+        return [
             'time' => $this->format('Y-m-d H:i:s.u'),
             'timezone' => $this->getTimezone()->getName(),
             'hasFixedNow' => static::hasTestNow(),
         ];
-
-        return $properties;
     }
 }

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -175,16 +175,20 @@ class MutableDateTime extends DateTime implements ChronosInterface
      */
     public function __debugInfo()
     {
-        if (!property_exists($this, 'date') || !property_exists($this, 'timezone')) {
-            return [
-                'hasFixedNow' => self::hasTestNow(),
-            ];
-        }
+        $vars = get_object_vars($this);
 
-        return [
-            'time' => $this->format('Y-m-d H:i:s.u'),
-            'timezone' => $this->getTimezone()->getName(),
+        $properties = [
             'hasFixedNow' => static::hasTestNow(),
         ];
+
+        if (isset($vars['date'])) {
+            $properties['time'] = $this->format('Y-m-d H:i:s.u');
+        }
+
+        if (isset($vars['timezone'])) {
+            $properties['timezone'] = $this->getTimezone()->getName();
+        }
+
+        return $properties;
     }
 }


### PR DESCRIPTION
### Description

When you try to inspect a variable with Xdebug, the magic method `__debugInfo()` is getting called because Xdebug tries to load the variable via `var_dump()`. If the internal state of your object is not initialized (depends on the breakpoint), you receive errors like this:

* `Warning: DateTimeImmutable::format(): The DateTime object has not been correctly initialized by its constructor in vendor\cakephp\chronos\src\Chronos.php on line 195`
* `Warning: DateTimeImmutable::getTimezone(): The DateTime object has not been correctly initialized by its constructor`

The reason is, that a unfinished (Chronos) object has no `date` and `timezone` property set and the current `__debugInfo()` works only for fully a initialized Chronos objects.

### The fix

The fix checks whether the object properties exist. If not, the affected functions are not executed.

### Tests

It's technically impossible (for me) to cover this PR by unit tests, because it's not possible to simulate xdebug breakpoints with phpunit. I have tested this PR with PhpStorm and Xdebug to make sure the fix works.

### General thoughts on the use of `__debugInfo`

Using `__debugInfo` is a problem for all XDebug users because it causes debugging and stability issues. In the long run, the only sensible solution would be to remove the magic method `__debugInfo` from the complete Chronos codebase. If you think so, I would be happy to create a PR.

