### PR TITLE
Exclude more files from being exported

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,4 @@ appveyor.yml export-ignore
 phpbench.json export-ignore
 phpcs.xml.dist export-ignore
 phpstan.neon export-ignore
+benchmarks export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,9 @@
 .travis.yml export-ignore
 phpunit.xml.dist export-ignore
 tests export-ignore
+.editorconfig export-ignore
+.stickler.yml export-ignore
+appveyor.yml export-ignore
+phpbench.json export-ignore
+phpcs.xml.dist export-ignore
+phpstan.neon export-ignore


### PR DESCRIPTION
I was toying around with a deployment script and noticed these unnecessary (in a deployment context) files.