### PR TITLE
Update README.md to use new documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ a mutable variant of `Date`.
 
 # Documentation
 
-A more descriptive documentation can be found at [book.cakephp.org/3.0/en/chronos.html](http://book.cakephp.org/3.0/en/chronos.html).
+A more descriptive documentation can be found at [book.cakephp.org/chronos/1.x/en/](https://book.cakephp.org/chronos/1.x/en/).
 
 # API Documentation
 


### PR DESCRIPTION
The other link just shows "This has moved" with another link to this URL.