### PR TITLE
Test now times

### DIFF
--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -30,7 +30,7 @@ trait RelativeKeywordTrait
     public static function hasRelativeKeywords($time)
     {
         // Just a time
-        if (preg_match('/^[0-2][0-9]:[0-5][0-9](?::[0-5][0-9])?$/', $time) > 0) {
+        if (preg_match('/^[0-2][0-9]:[0-5][0-9](?::[0-5][0-9])?$/', $time)) {
             return true;
         }
 

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -29,6 +29,11 @@ trait RelativeKeywordTrait
      */
     public static function hasRelativeKeywords($time)
     {
+        // Just a time
+        if (preg_match('/^[0-2][0-9]:[0-5][0-9](?::[0-5][0-9])?$/', $time) > 0) {
+            return true;
+        }
+
         // skip common format with a '-' in it
         if (preg_match('/[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}/', $time) !== 1) {
             return preg_match(static::$relativePattern, $time) > 0;

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -166,6 +166,8 @@ class TestingAidsTest extends TestCase
         $notNow = $class::parse('2013-09-01 05:15:05');
         $class::setTestNow($notNow);
 
+        $this->assertSame('2013-09-01 06:30:00', $class::parse('06:30:00')->toDateTimeString());
+
         $this->assertSame('2013-09-01 05:10:05', $class::parse('5 minutes ago')->toDateTimeString());
 
         $this->assertSame('2013-08-25 05:15:05', $class::parse('1 week ago')->toDateTimeString());


### PR DESCRIPTION
When using the test now, and creating a time object with a time, the test date is ignored.

This changes that behaviour.