### PR TITLE
Fix relative parsing with timezones.

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -110,7 +110,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
             $testNow = $testNow->modify($time);
         }
 
-        if ($tz !== $testNow->getTimezone()) {
+        if (!$relative && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -101,7 +101,7 @@ class MutableDateTime extends DateTime implements ChronosInterface
             $testNow = $testNow->modify($time);
         }
 
-        if ($tz !== $testNow->getTimezone()) {
+        if (!$relative && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -227,7 +227,7 @@ class TestingAidsTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testTimeZoneWithTestValueSet($class)
+    public function testParseWithTimeZone($class)
     {
         $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
         $class::setTestNow($notNow);
@@ -235,6 +235,31 @@ class TestingAidsTest extends TestCase
         $this->assertSame('2013-07-01T12:00:00-04:00', $class::parse('now')->toIso8601String());
         $this->assertSame('2013-07-01T11:00:00-05:00', $class::parse('now', 'America/Mexico_City')->toIso8601String());
         $this->assertSame('2013-07-01T09:00:00-07:00', $class::parse('now', 'America/Vancouver')->toIso8601String());
+    }
+
+    /**
+     * Test parse() with relative values and timezones
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseRelativeWithTimezoneAndTestValueSet($class)
+    {
+        $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
+        $class::setTestNow($notNow);
+
+        $this->assertSame('06:30:00', $class::parse('2013-07-01 06:30:00', 'America/Mexico_City')->toTimeString());
+        $this->assertSame('06:30:00', $class::parse('6:30', 'America/Mexico_City')->toTimeString());
+
+        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('2013-07-01 06:30:00')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('2013-07-01 06:30:00', 'America/Mexico_City')->toIso8601String());
+
+        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('06:30')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('6:30')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('6:30', 'America/Mexico_City')->toIso8601String());
+
+        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('6:30:00', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('06:30:00', 'America/Mexico_City')->toIso8601String());
     }
 
     /**


### PR DESCRIPTION
When parsing relative times + timezones the intent is to have a relative time in the provided timezone. This means we don't want to apply a timezone adjustment before creating the final result.

Fixes #203