### PR TITLE
Fix relative and fixed time parsing with timezones

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -110,7 +110,8 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
             $testNow = $testNow->modify($time);
         }
 
-        if (!$relative && $tz !== $testNow->getTimezone()) {
+        $relativetime = static::hasRelativeTime($time);
+        if (!$relativetime && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -110,7 +110,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
             $testNow = $testNow->modify($time);
         }
 
-        $relativetime = static::hasRelativeTime($time);
+        $relativetime = static::isTimeExpression($time);
         if (!$relativetime && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -110,7 +110,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
             $testNow = $testNow->modify($time);
         }
 
-        if ($tz !== $testNow->getTimezone()) {
+        if (!$relative && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -101,7 +101,7 @@ class MutableDateTime extends DateTime implements ChronosInterface
             $testNow = $testNow->modify($time);
         }
 
-        $relativetime = static::hasRelativeTime($time);
+        $relativetime = static::isTimeExpression($time);
         if (!$relativetime && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -101,7 +101,7 @@ class MutableDateTime extends DateTime implements ChronosInterface
             $testNow = $testNow->modify($time);
         }
 
-        if ($tz !== $testNow->getTimezone()) {
+        if (!$relative && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
 

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -101,10 +101,10 @@ class MutableDateTime extends DateTime implements ChronosInterface
             $testNow = $testNow->modify($time);
         }
 
-        if (!$relative && $tz !== $testNow->getTimezone()) {
+        $relativetime = static::hasRelativeTime($time);
+        if (!$relativetime && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz === null ? date_default_timezone_get() : $tz);
         }
-
         $time = $testNow->format('Y-m-d H:i:s.u');
         parent::__construct($time, $tz);
     }

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -26,7 +26,7 @@ trait RelativeKeywordTrait
      * @param string $time The time string to check.
      * @return bool true if there is a keyword, otherwise false
      */
-    public static function hasRelativeTime($time)
+    private static function isTimeExpression($time)
     {
         // Just a time
         if (preg_match('/^[0-2]?[0-9]:[0-5][0-9](?::[0-5][0-9])?$/', $time)) {
@@ -43,9 +43,9 @@ trait RelativeKeywordTrait
      * @param string $time The time string to check.
      * @return bool true if there is a keyword, otherwise false
      */
-    public static function hasRelativeKeywords($time)
+    private static function hasRelativeKeywords($time)
     {
-        if (self::hasRelativeTime($time)) {
+        if (self::isTimeExpression($time)) {
             return true;
         }
         // skip common format with a '-' in it

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -21,6 +21,22 @@ trait RelativeKeywordTrait
     protected static $relativePattern = '/this|next|last|tomorrow|yesterday|midnight|today|[+-]|first|last|ago/i';
 
     /**
+     * Determine if there is just a time in the time string
+     *
+     * @param string $time The time string to check.
+     * @return bool true if there is a keyword, otherwise false
+     */
+    public static function hasRelativeTime($time)
+    {
+        // Just a time
+        if (preg_match('/^[0-2]?[0-9]:[0-5][0-9](?::[0-5][0-9])?$/', $time)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if there is a relative keyword in the time string, this is to
      * create dates relative to now for test instances. e.g.: next tuesday
      *
@@ -29,11 +45,9 @@ trait RelativeKeywordTrait
      */
     public static function hasRelativeKeywords($time)
     {
-        // Just a time
-        if (preg_match('/^[0-2]?[0-9]:[0-5][0-9](?::[0-5][0-9])?$/', $time)) {
-            return true;
-        }
-
+		if (self::hasRelativeTime($time)) {
+			return true;
+		}
         // skip common format with a '-' in it
         if (preg_match('/[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}/', $time) !== 1) {
             return preg_match(static::$relativePattern, $time) > 0;

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -45,9 +45,9 @@ trait RelativeKeywordTrait
      */
     public static function hasRelativeKeywords($time)
     {
-		if (self::hasRelativeTime($time)) {
-			return true;
-		}
+        if (self::hasRelativeTime($time)) {
+            return true;
+        }
         // skip common format with a '-' in it
         if (preg_match('/[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}/', $time) !== 1) {
             return preg_match(static::$relativePattern, $time) > 0;

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -43,7 +43,7 @@ trait RelativeKeywordTrait
      * @param string $time The time string to check.
      * @return bool true if there is a keyword, otherwise false
      */
-    private static function hasRelativeKeywords($time)
+    public static function hasRelativeKeywords($time)
     {
         if (self::isTimeExpression($time)) {
             return true;

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -238,6 +238,19 @@ class TestingAidsTest extends TestCase
     }
 
     /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseRelativeWithTimeZone($class)
+    {
+        $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
+        $class::setTestNow($notNow);
+
+        $this->assertSame('2013-07-01T10:55:00-05:00', $class::parse('5 minutes ago', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01 10:55:00', $class::parse('5 minutes ago', 'America/Mexico_City')->toDateTimeString());
+    }
+
+    /**
      * Test parse() with relative values and timezones
      *
      * @dataProvider classNameProvider

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -227,7 +227,7 @@ class TestingAidsTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testTimeZoneWithTestValueSet($class)
+    public function testParseWithTimeZone($class)
     {
         $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
         $class::setTestNow($notNow);
@@ -235,6 +235,31 @@ class TestingAidsTest extends TestCase
         $this->assertSame('2013-07-01T12:00:00-04:00', $class::parse('now')->toIso8601String());
         $this->assertSame('2013-07-01T11:00:00-05:00', $class::parse('now', 'America/Mexico_City')->toIso8601String());
         $this->assertSame('2013-07-01T09:00:00-07:00', $class::parse('now', 'America/Vancouver')->toIso8601String());
+    }
+
+    /**
+     * Test parse() with relative values and timezones
+     *
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testParseRelativeWithTimezoneAndTestValueSet($class)
+    {
+        $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
+        $class::setTestNow($notNow);
+
+        $this->assertSame('06:30:00', $class::parse('2013-07-01 06:30:00', 'America/Mexico_City')->toTimeString());
+        $this->assertSame('06:30:00', $class::parse('6:30', 'America/Mexico_City')->toTimeString());
+
+        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('2013-07-01 06:30:00')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('2013-07-01 06:30:00', 'America/Mexico_City')->toIso8601String());
+
+        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('06:30')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('6:30')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('6:30', 'America/Mexico_City')->toIso8601String());
+
+        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('6:30:00', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('06:30:00', 'America/Mexico_City')->toIso8601String());
     }
 
     /**


### PR DESCRIPTION
Complete fix for #203 - includes pull request #204 by @markstory 
Separated the test for a time string to a relative time keywords (e.g. 5 minutes ago) and only avoid applying timezone variances for fixed time-of-day strings.