### PR TITLE
Use PHP 5.6 in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ init:
 
 install:
   - cd c:\
-  - curl -fsS https://windows.php.net/downloads/releases/archives/php-5.5.29-nts-Win32-VC11-x86.zip -o php.zip
+  - curl -fsS https://windows.php.net/downloads/releases/archives/php-5.6.40-nts-Win32-VC11-x86.zip -o php.zip
   - 7z x php.zip -oc:\php
   - cd c:\php
   - copy php.ini-production php.ini


### PR DESCRIPTION
> This package requires php >=5.6 but your PHP version (5.5.29) does not satisfy that requirement