### PR TITLE
Use Chronos instead of Date in hour/minute components example

### DIFF
--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -122,7 +122,7 @@ Les objets Chronos fournissent des méthodes de modification qui vous laissent
 modifier la valeur d'une façon assez précise::
 
     // Définit les composants de la valeur du datetime.
-    $halloween = Date::create()
+    $halloween = Chronos::create()
         ->year(2015)
         ->month(10)
         ->day(31)
@@ -131,7 +131,7 @@ modifier la valeur d'une façon assez précise::
 
 Vous pouvez aussi modifier les parties de la date de façon relative::
 
-    $future = Date::create()
+    $future = Chronos::create()
         ->addYear(1)
         ->subMonth(2)
         ->addDays(15)

--- a/docs/pt/index.rst
+++ b/docs/pt/index.rst
@@ -118,7 +118,7 @@ Objetos Chronos disponibilizam métodos que permitem a modificação de valores 
 forma granular::
 
     // Define componentes do valor datetime
-    $halloween = Date::create()
+    $halloween = Chronos::create()
         ->year(2015)
         ->month(10)
         ->day(31)
@@ -127,7 +127,7 @@ forma granular::
 
 Você também pode modificar partes da data relativamente::
 
-    $future = Date::create()
+    $future = Chronos::create()
         ->addYear(1)
         ->subMonth(2)
         ->addDays(15)


### PR DESCRIPTION
Updated fr and pt translations.  The text should be fine with this change so everyone is using the same example.