### PR TITLE
Removed nightly from php build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.1
   - 7.3
   - 7.4snapshot
-  - nightly
 
 sudo: false
 
@@ -26,7 +25,6 @@ matrix:
       env: COVERAGE=1 DEFAULT=0
 
   allow_failures:
-    - php: nightly
     - php: 7.4snapshot
 
   fast_finish: true


### PR DESCRIPTION
Nightly tries to run PHP 8.0.0-dev now which isn't supported by anything.