### PR TITLE
2.x - Allow timezone parameter for Date/MutableDate construction

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -108,13 +108,13 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
         }
 
         $testNow = clone $testNow;
-        if ($relative) {
-            $testNow = $testNow->modify($time);
-        }
-
         $relativetime = static::isTimeExpression($time);
         if (!$relativetime && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz ?? date_default_timezone_get());
+        }
+
+        if ($relative) {
+            $testNow = $testNow->modify($time);
         }
 
         $time = $testNow->format('Y-m-d H:i:s.u');

--- a/src/Date.php
+++ b/src/Date.php
@@ -71,6 +71,12 @@ class Date extends DateTimeImmutable implements ChronosInterface
     /**
      * Create a new Immutable Date instance.
      *
+     * You can specify the timezone for the $time parameter. This timezone will
+     * not be used in any future modifications to the Date instance.
+     *
+     * The $timezone parameter is ignored if $time is a DateTimeInterface
+     * instance.
+     *
      * Please see the testing aids section (specifically static::setTestNow())
      * for more on the possibility of this constructor returning a test instance.
      *
@@ -79,43 +85,31 @@ class Date extends DateTimeImmutable implements ChronosInterface
      * timezone will always be UTC. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
-     * @param string|int|null $time Fixed or relative time
+     * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
+     * @param \DateTimeZone|string|null $tz The timezone in which the date is taken
      */
-    public function __construct($time = 'now')
+    public function __construct($time = 'now', $tz = null)
     {
-        $tz = new DateTimeZone('UTC');
-        $testNow = Chronos::getTestNow();
-        if ($testNow === null) {
-            $time = $this->stripTime($time);
-
-            parent::__construct($time, $tz);
-
-            return;
+        if ($tz !== null) {
+            $tz = $tz instanceof DateTimeZone ? $tz : new DateTimeZone($tz);
         }
 
-        $relative = static::hasRelativeKeywords($time);
-        if (!empty($time) && $time !== 'now' && !$relative) {
-            $time = $this->stripTime($time);
-
-            parent::__construct($time, $tz);
+        $testNow = Chronos::getTestNow();
+        if ($testNow === null || !static::isRelativeOnly($time)) {
+            $time = $this->stripTime($time, $tz);
+            parent::__construct($time, new DateTimeZone('UTC'));
 
             return;
         }
 
         $testNow = clone $testNow;
-        if ($relative) {
-            $time = $this->stripRelativeTime($time);
-            if (strlen($time) > 0) {
-                $testNow = $testNow->modify($time);
-            }
-        }
-
         if ($tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz ?? date_default_timezone_get());
         }
+        $testNow = $testNow->modify($time);
 
         $time = $testNow->format('Y-m-d 00:00:00');
-        parent::__construct($time, $tz);
+        parent::__construct($time, new DateTimeZone('UTC'));
     }
 
     /**

--- a/src/Date.php
+++ b/src/Date.php
@@ -106,7 +106,9 @@ class Date extends DateTimeImmutable implements ChronosInterface
         if ($tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz ?? date_default_timezone_get());
         }
-        $testNow = $testNow->modify($time);
+        if (!empty($time)) {
+            $testNow = $testNow->modify($time);
+        }
 
         $time = $testNow->format('Y-m-d 00:00:00');
         parent::__construct($time, new DateTimeZone('UTC'));

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -105,7 +105,9 @@ class MutableDate extends DateTime implements ChronosInterface
         if ($tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz ?? date_default_timezone_get());
         }
-        $testNow = $testNow->modify($time);
+        if (!empty($time)) {
+            $testNow = $testNow->modify($time);
+        }
 
         $time = $testNow->format('Y-m-d 00:00:00');
         parent::__construct($time, new DateTimeZone('UTC'));

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -99,14 +99,15 @@ class MutableDateTime extends DateTime implements ChronosInterface
         }
 
         $testNow = clone $testNow;
-        if ($relative) {
-            $testNow = $testNow->modify($time);
-        }
-
         $relativetime = static::isTimeExpression($time);
         if (!$relativetime && $tz !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($tz ?? date_default_timezone_get());
         }
+
+        if ($relative) {
+            $testNow = $testNow->modify($time);
+        }
+
         $time = $testNow->format('Y-m-d H:i:s.u');
         parent::__construct($time, $tz);
     }

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Cake\Chronos\Traits;
 
 use Cake\Chronos\ChronosInterface;
+use DateTimeImmutable;
 use DateTimeInterface;
 
 /**
@@ -30,29 +31,26 @@ trait FrozenTimeTrait
      *
      * Used to ensure constructed objects always lack time.
      *
-     * @param \DateTimeInterface|string|int|null $time The input time. Integer values will be assumed
+     * @param \DateTime|\DateTimeImmutable|string|int|null $time The input time. Integer values will be assumed
      *   to be in UTC. The 'now' and '' values will use the current local time.
+     * @param \DateTimeZone|null $tz The timezone in which the date is taken
      * @return string The date component of $time.
      */
-    protected function stripTime($time): string
+    protected function stripTime($time, $tz): string
     {
         if (is_int($time) || ctype_digit($time)) {
             return gmdate('Y-m-d 00:00:00', $time);
         }
-        if ($time instanceof DateTimeInterface) {
-            $time = $time->format('Y-m-d 00:00:00');
-        }
-        if ($time === null || $time === 'now' || $time === '') {
-            return date('Y-m-d 00:00:00');
-        }
-        if (substr($time, 0, 1) === '@') {
+
+        if (is_string($time) && substr($time, 0, 1) === '@') {
             return gmdate('Y-m-d 00:00:00', (int)substr($time, 1));
         }
-        if ($this->hasRelativeKeywords($time)) {
-            return date('Y-m-d 00:00:00', strtotime($time));
+
+        if (!($time instanceof DateTimeInterface)) {
+            $time = new DateTimeImmutable($time, $tz);
         }
 
-        return preg_replace('/\d{1,2}:\d{1,2}:\d{1,2}(?:\.\d+)?/', '00:00:00', $time);
+        return $time->format('Y-m-d 00:00:00');
     }
 
     /**

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -47,7 +47,7 @@ trait FrozenTimeTrait
         }
 
         if (!($time instanceof DateTimeInterface)) {
-            $time = new DateTimeImmutable($time, $tz);
+            $time = new DateTimeImmutable($time ?? 'now', $tz);
         }
 
         return $time->format('Y-m-d 00:00:00');

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -36,7 +36,7 @@ trait RelativeKeywordTrait
     private static function isTimeExpression($time)
     {
         // Just a time
-        if (is_string($time) && preg_match('/^[0-2]?[0-9]:[0-5][0-9](?::[0-5][0-9])?$/', $time)) {
+        if (is_string($time) && preg_match('/^[0-2]?[0-9]:[0-5][0-9](?::[0-5][0-9](?:\.[0-9]{1,6})?)?$/', $time)) {
             return true;
         }
 
@@ -61,5 +61,21 @@ trait RelativeKeywordTrait
         }
 
         return false;
+    }
+
+    /**
+     * Determines if there is no fixed date in the time string.
+     *
+     * @param \DateTimeInterface|string|null $time The time string to check
+     * @return bool true if doesn't contain a fixed date
+     */
+    private static function isRelativeOnly($time): bool
+    {
+        if (!is_string($time)) {
+            return false;
+        }
+
+        // must not contain fixed date before relative keywords or time expression
+        return preg_match('/[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}/', $time) !== 1;
     }
 }

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -71,6 +71,10 @@ trait RelativeKeywordTrait
      */
     private static function isRelativeOnly($time): bool
     {
+        if ($time === null) {
+            return true;
+        }
+
         if (!is_string($time)) {
             return false;
         }

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -303,12 +303,7 @@ class ConstructTest extends TestCase
         $this->assertEquals($london->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame('UTC', $c->tzName);
 
-        // Confirm that timezone is adjusted before midnight is set.
-        // This implies that the relative time used by Date helpers
-        // is affected by the timezone parameter properly.
-        $london = new DateTimeImmutable('midnight', $londonTimezone);
-        $this->assertEquals('00:00:00', $london->format('H:i:s'));
-
+        // now adjusted to London time
         $c = $class::today($londonTimezone);
         $this->assertEquals(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
 

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Test\Date;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Date;
 use Cake\Chronos\MutableDate;
 use Cake\Chronos\Test\TestCase;
+use DateTimeImmutable;
+use DateTimeZone;
 
 /**
  * Test constructors for Date objects.
@@ -27,18 +30,6 @@ class ConstructTest extends TestCase
      * @return void
      */
     public function testCreateFromTimestamp($class)
-    {
-        $ts = 1454284800;
-        $date = $class::createFromTimestamp($ts);
-        $this->assertEquals('UTC', $date->tzName);
-        $this->assertEquals('2016-02-01', $date->format('Y-m-d'));
-    }
-
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testCreateFromTimestampUtc($class)
     {
         $ts = 1454284800;
         $date = $class::createFromTimestamp($ts);
@@ -258,5 +249,110 @@ class ConstructTest extends TestCase
     {
         $c = new $class('+7 days');
         $this->assertEquals('00:00:00', $c->format('H:i:s'));
+
+        $c = new $class('+10 minutes');
+        $this->assertEquals('00:00:00', $c->format('H:i:s'));
+
+        $c = new $class('2001-01-01 +7 days');
+        $this->assertEquals('2001-01-08', $c->format('Y-m-d'));
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testConstructWithLocalTimezone($class)
+    {
+        $londonTimezone = new DateTimeZone('Europe/London');
+
+        // now adjusted to London time
+        // This test could have different results depending on when now is
+        $c = new $class('now', $londonTimezone);
+        $london = new DateTimeImmutable('now', $londonTimezone);
+        $this->assertEquals($london->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame('UTC', $c->tzName);
+
+        // Confirm that timezone is adjusted before midnight is set.
+        // This implies that the relative time used by Date helpers
+        // is affected by the timezone parameter properly.
+        $london = new DateTimeImmutable('midnight', $londonTimezone);
+        $this->assertEquals('00:00:00', $london->format('H:i:s'));
+
+        $c = $class::today($londonTimezone);
+        $this->assertEquals(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
+
+        // London timezone is used instead of local timezone
+        $c = new $class('2001-01-02 01:00:00', $londonTimezone);
+        $this->assertEquals('2001-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('UTC', $c->tzName);
+
+        // London timezone is ignored when timezone is provided in time string
+        $c = new $class('2001-01-01 23:00:00-400', $londonTimezone);
+        $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('UTC', $c->tzName);
+
+        // London timezone is ignored when DateTimeInterface instance is provided
+        $c = new $class(new DateTimeImmutable('2001-01-01 23:00:00-400'), $londonTimezone);
+        $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('UTC', $c->tzName);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testConstructWithLocalTimezoneTestNow($class)
+    {
+        $class::setTestNow(new Chronos('2010-01-01 23:00:00'));
+
+        $londonTimezone = new DateTimeZone('Europe/London');
+
+        // TestNow is adjusted to London time
+        $c = new $class('now', $londonTimezone);
+        $this->assertEquals('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('UTC', $c->tzName);
+
+        // TestNow is adjusted to London time
+        $c = new $class('+2 days', $londonTimezone);
+        $this->assertEquals('2010-01-04 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('UTC', $c->tzName);
+
+        // TestNow is adjusted to London time
+        $c = $class::today($londonTimezone);
+        $this->assertEquals('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertEquals(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame('UTC', $c->tzName);
+
+        // TestNow is ajusted to London time
+        $c = $class::tomorrow($londonTimezone);
+        $this->assertEquals('2010-01-03 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertEquals(Chronos::tomorrow($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame('UTC', $c->tzName);
+
+        // TestNow is ignored when specific date is provided
+        $c = new $class('2001-01-05 01:00:00', $londonTimezone);
+        $this->assertEquals('2001-01-05 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('UTC', $c->tzName);
+    }
+
+    /**
+     * This tests with a large difference between local timezone and
+     * timezone provided as parameter.  This is to help guarantee a date
+     * change would occur so the tests are more consistent.
+     *
+     * @dataProvider dateClassProvider
+     */
+    public function testConstructWithLargeTimzoneChange($class)
+    {
+        $savedTz = date_default_timezone_get();
+        date_default_timezone_set('Pacific/Kiritimati');
+
+        $samoaTimezone = new DateTimeZone('Pacific/Samoa');
+
+        // Pacific/Samoa -11:00 is used intead of local timezone +14:00
+        $c = $class::today($samoaTimezone);
+        $Samoa = new DateTimeImmutable('now', $samoaTimezone);
+        $this->assertEquals($Samoa->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame('UTC', $c->tzName);
+
+        date_default_timezone_set($savedTz);
     }
 }

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -29,6 +29,38 @@ class ConstructTest extends TestCase
      * @dataProvider dateClassProvider
      * @return void
      */
+    public function testCreateFromEmpty($class)
+    {
+        $c = $class::parse(null);
+        $this->assertEquals('00:00:00', $c->format('H:i:s'));
+        $this->assertEquals('UTC', $c->tzName);
+
+        $c = $class::parse('');
+        $this->assertEquals('00:00:00', $c->format('H:i:s'));
+        $this->assertEquals('UTC', $c->tzName);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testCreateFromEmptyWithTestNow($class)
+    {
+        $class::setTestNow($class::create(2001, 1, 1));
+
+        $c = $class::parse(null);
+        $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertEquals('UTC', $c->tzName);
+
+        $c = $class::parse('');
+        $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertEquals('UTC', $c->tzName);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
     public function testCreateFromTimestamp($class)
     {
         $ts = 1454284800;
@@ -321,7 +353,7 @@ class ConstructTest extends TestCase
         $this->assertEquals(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame('UTC', $c->tzName);
 
-        // TestNow is ajusted to London time
+        // TestNow is adjusted to London time
         $c = $class::tomorrow($londonTimezone);
         $this->assertEquals('2010-01-03 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertEquals(Chronos::tomorrow($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));

--- a/tests/DateTime/TestingAidsTest.php
+++ b/tests/DateTime/TestingAidsTest.php
@@ -123,24 +123,9 @@ class TestingAidsTest extends TestCase
 
         $instance = new $class('-1 day');
         $this->assertSame('2018-06-20 00:00:00', $instance->format('Y-m-d H:i:s'));
-    }
-
-    /**
-     * Ensure that setting a datetime into test now doesn't violate date semantics
-     *
-     * Modifying date instances by hours should not change the date.
-     *
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testNowTestDateTimeConstraints($class)
-    {
-        $value = '2018-06-21 10:11:12';
-        $notNow = new MutableDateTime($value);
-        $class::setTestNow($notNow);
 
         $instance = new $class('-23 hours');
-        $this->assertSame('2018-06-21 00:00:00', $instance->format('Y-m-d H:i:s'));
+        $this->assertSame('2018-06-20 00:00:00', $instance->format('Y-m-d H:i:s'));
     }
 
     /**


### PR DESCRIPTION
https://github.com/cakephp/chronos/issues/149

This allows specifying the timezone for a time passed to Date and MutableDate constructors.  The timezone is used to grab the date before storing it in UTC as before. 

With this change Chronos::today(timezone) and Date::today(timezone) will match (assuming time() hasn't adjusted past a date change of course).

This also fixes a couple missing test case issues where the time was not set to 00:00:00 for Date instances such as using a fixed date + relative time: '2001-01-01 +10 minutes'

The timezone for TestNow instances is also adjusted before the relative time change to support things like 'midnight' being correct in the target timezone (e.g. 00:00:00 regardless of timezone).  This matches PHP's DateTime behavior when passing such values with a timezone parameter.

