### PR TITLE
Added microseconds support to ChronosInterval.

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,6 @@
 
     <file>./src</file>
     <file>./tests</file>
-    <file>./benchmarks</file>
 
     <arg phpcs-only="true" value="p"/>
     <arg name="extensions" value="php"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,5 @@ parameters:
     ignoreErrors:
         - '#Access to an undefined property Cake\\Chronos\\ChronosInterface::\$tz#'
         -
-            message: '#Call to an undefined static method DateInterval::__get\(\)#'
-            path: src/ChronosInterval.php
-        -
             message: '#If condition is always true#'
             path: src/Traits/FrozenTimeTrait.php

--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -50,7 +50,7 @@ use InvalidArgumentException;
  * @method static \Cake\Chronos\ChronosInterval seconds($seconds = 1) Create instance specifying a number of seconds.
  * @method static \Cake\Chronos\ChronosInterval second($seconds = 1) Alias for seconds
  * @method static \Cake\Chronos\ChronosInterval microseconds($microseconds = 1) Create instance specifying a number of microseconds.
- * @method static \Cake\Chronos\ChronosInterval microsecond($microseconds = 1) Alias for seconds
+ * @method static \Cake\Chronos\ChronosInterval microsecond($microseconds = 1) Alias for microseconds
  */
 class ChronosInterval extends DateInterval
 {

--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -29,6 +29,7 @@ use InvalidArgumentException;
  * @property int $hours Total hours of the current interval.
  * @property int $minutes Total minutes of the current interval.
  * @property int $seconds Total seconds of the current interval.
+ * @property int $microseconds Total microseconds of the current interval.
  *
  * @property-read int $dayzExcludeWeeks Total days remaining in the final week of the current instance (days % 7).
  * @property-read int $daysExcludeWeeks alias of dayzExcludeWeeks
@@ -48,6 +49,8 @@ use InvalidArgumentException;
  * @method static \Cake\Chronos\ChronosInterval minute($minutes = 1) Alias for minutes
  * @method static \Cake\Chronos\ChronosInterval seconds($seconds = 1) Create instance specifying a number of seconds.
  * @method static \Cake\Chronos\ChronosInterval second($seconds = 1) Alias for seconds
+ * @method static \Cake\Chronos\ChronosInterval microseconds($microseconds = 1) Create instance specifying a number of microseconds.
+ * @method static \Cake\Chronos\ChronosInterval microsecond($microseconds = 1) Alias for seconds
  */
 class ChronosInterval extends DateInterval
 {
@@ -64,12 +67,6 @@ class ChronosInterval extends DateInterval
     public const PERIOD_SECONDS = 'S';
 
     /**
-     * Before PHP 5.4.20/5.5.4 instead of `false` days will be set to -99999 when the interval instance
-     * was created by DateTime:diff().
-     */
-    public const PHP_DAYS_FALSE = -99999;
-
-    /**
      * Determine if the interval was created via DateTime:diff() or not.
      *
      * @param \DateInterval $interval The interval to check.
@@ -77,7 +74,7 @@ class ChronosInterval extends DateInterval
      */
     protected static function wasCreatedFromDiff(DateInterval $interval): bool
     {
-        return $interval->days !== false && $interval->days !== static::PHP_DAYS_FALSE;
+        return $interval->days !== false;
     }
 
     /**
@@ -90,6 +87,7 @@ class ChronosInterval extends DateInterval
      * @param int|null $hours The hours to use.
      * @param int|null $minutes The minutes to use.
      * @param int|null $seconds The seconds to use.
+     * @param int|null $microseconds The microseconds to use.
      */
     public function __construct(
         ?int $years = 1,
@@ -98,7 +96,8 @@ class ChronosInterval extends DateInterval
         ?int $days = null,
         ?int $hours = null,
         ?int $minutes = null,
-        ?int $seconds = null
+        ?int $seconds = null,
+        ?int $microseconds = null
     ) {
         $spec = static::PERIOD_PREFIX;
 
@@ -123,6 +122,10 @@ class ChronosInterval extends DateInterval
         }
 
         parent::__construct($spec);
+
+        if ($microseconds > 0) {
+            $this->f = $microseconds / 1000000;
+        }
     }
 
     /**
@@ -138,6 +141,7 @@ class ChronosInterval extends DateInterval
      * @param int|null $hours The hours to use.
      * @param int|null $minutes The minutes to use.
      * @param int|null $seconds The seconds to use.
+     * @param int|null $microseconds The microseconds to use.
      * @return static
      */
     public static function create(
@@ -147,9 +151,10 @@ class ChronosInterval extends DateInterval
         ?int $days = null,
         ?int $hours = null,
         ?int $minutes = null,
-        ?int $seconds = null
+        ?int $seconds = null,
+        ?int $microseconds = null
     ): self {
-        return new static($years, $months, $weeks, $days, $hours, $minutes, $seconds);
+        return new static($years, $months, $weeks, $days, $hours, $minutes, $seconds, $microseconds);
     }
 
     /**
@@ -201,6 +206,10 @@ class ChronosInterval extends DateInterval
             case 'seconds':
             case 'second':
                 return new static(null, null, null, null, null, null, $arg);
+
+            case 'microseconds':
+            case 'microsecond':
+                return new static(null, null, null, null, null, null, null, $arg);
         }
     }
 
@@ -222,6 +231,7 @@ class ChronosInterval extends DateInterval
         }
 
         $instance = new static($di->y, $di->m, 0, $di->d, $di->h, $di->i, $di->s);
+        $instance->f = $di->f;
         $instance->invert = $di->invert;
         $instance->days = $di->days;
 
@@ -256,22 +266,16 @@ class ChronosInterval extends DateInterval
             case 'seconds':
                 return $this->s;
 
+            case 'microseconds':
+                return (int)($this->f * 1000000);
+
             case 'weeks':
                 return (int)floor($this->d / ChronosInterface::DAYS_PER_WEEK);
 
             case 'daysExcludeWeeks':
             case 'dayzExcludeWeeks':
                 return $this->dayz % ChronosInterface::DAYS_PER_WEEK;
-            case 'days':
-                return $this->days;
-            case 'y':
-            case 'm':
-            case 'd':
-            case 'h':
-            case 'i':
-            case 's':
-            case 'invert':
-                return parent::__get($name);
+
             default:
                 throw new InvalidArgumentException(sprintf("Unknown getter '%s'", $name));
         }
@@ -315,6 +319,10 @@ class ChronosInterval extends DateInterval
 
             case 'seconds':
                 $this->s = $val;
+                break;
+
+            case 'microseconds':
+                $this->f = $val / 1000000;
                 break;
 
             case 'invert':
@@ -388,6 +396,11 @@ class ChronosInterval extends DateInterval
             case 'second':
                 $this->seconds = $arg;
                 break;
+
+            case 'microseconds':
+            case 'microsecond':
+                $this->microseconds = $arg;
+                break;
         }
 
         return $this;
@@ -412,6 +425,7 @@ class ChronosInterval extends DateInterval
             $this->hours = $this->hours + ($interval->h * $sign);
             $this->minutes = $this->minutes + ($interval->i * $sign);
             $this->seconds = $this->seconds + ($interval->s * $sign);
+            $this->microseconds = $this->microseconds + (int)($interval->f * 1000000 * $sign);
         }
 
         return $this;

--- a/tests/Interval/IntervalAddTest.php
+++ b/tests/Interval/IntervalAddTest.php
@@ -30,15 +30,17 @@ class IntervalAddTest extends TestCase
 
     public function testAddWithDiffDateInterval()
     {
-        $diff = Chronos::now()->diff(Chronos::now()->addWeeks(3));
-        $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11)->add($diff);
-        $this->assertDateTimeInterval($ci, 4, 3, 70, 8, 10, 11);
+        $now = Chronos::now();
+        $diff = $now->diff($now->addWeeks(3));
+        $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11, 123)->add($diff);
+        $this->assertDateTimeInterval($ci, 4, 3, 70, 8, 10, 11, 123);
     }
 
     public function testAddWithNegativeDiffDateInterval()
     {
-        $diff = Chronos::now()->diff(Chronos::now()->subWeeks(3));
-        $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11)->add($diff);
-        $this->assertDateTimeInterval($ci, 4, 3, 28, 8, 10, 11);
+        $now = Chronos::now();
+        $diff = $now->diff($now->subWeeks(3));
+        $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11, 123)->add($diff);
+        $this->assertDateTimeInterval($ci, 4, 3, 28, 8, 10, 11, 123);
     }
 }

--- a/tests/Interval/IntervalConstructTest.php
+++ b/tests/Interval/IntervalConstructTest.php
@@ -31,194 +31,213 @@ class IntervalConstructTest extends TestCase
 
     public function testNulls()
     {
-        $ci = new ChronosInterval(null, null, null, null, null, null);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0);
+        $ci = new ChronosInterval(null, null, null, null, null, null, null);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
 
         $ci = ChronosInterval::days(null);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
     }
 
     public function testZeroes()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 0, 0);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0);
+        $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
 
         $ci = ChronosInterval::days(0);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
     }
 
     public function testZeroesChained()
     {
         $ci = ChronosInterval::days(0)->week(0)->minutes(0);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
     }
 
     public function testYears()
     {
         $ci = new ChronosInterval(1);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0, 0);
 
         $ci = ChronosInterval::years(2);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 2, 0, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 2, 0, 0, 0, 0, 0, 0);
 
         $ci = ChronosInterval::year();
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0, 0);
 
         $ci = ChronosInterval::year(3);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 3, 0, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 3, 0, 0, 0, 0, 0, 0);
     }
 
     public function testMonths()
     {
         $ci = new ChronosInterval(0, 1);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 1, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 1, 0, 0, 0, 0, 0);
 
         $ci = ChronosInterval::months(2);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 2, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 2, 0, 0, 0, 0, 0);
 
         $ci = ChronosInterval::month();
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 1, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 1, 0, 0, 0, 0, 0);
 
         $ci = ChronosInterval::month(3);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 3, 0, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 3, 0, 0, 0, 0, 0);
     }
 
     public function testWeeks()
     {
         $ci = new ChronosInterval(0, 0, 1);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 7, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 7, 0, 0, 0, 0);
 
         $ci = ChronosInterval::weeks(2);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 14, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 14, 0, 0, 0, 0);
 
         $ci = ChronosInterval::week();
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 7, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 7, 0, 0, 0, 0);
 
         $ci = ChronosInterval::week(3);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 21, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 21, 0, 0, 0, 0);
     }
 
     public function testDays()
     {
         $ci = new ChronosInterval(0, 0, 0, 1);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 1, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 1, 0, 0, 0, 0);
 
         $ci = ChronosInterval::days(2);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 2, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 2, 0, 0, 0, 0);
 
         $ci = ChronosInterval::dayz(2);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 2, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 2, 0, 0, 0, 0);
 
         $ci = ChronosInterval::day();
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 1, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 1, 0, 0, 0, 0);
 
         $ci = ChronosInterval::day(3);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 3, 0, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 3, 0, 0, 0, 0);
     }
 
     public function testHours()
     {
         $ci = new ChronosInterval(0, 0, 0, 0, 1);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 1, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 1, 0, 0, 0);
 
         $ci = ChronosInterval::hours(2);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 2, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 2, 0, 0, 0);
 
         $ci = ChronosInterval::hour();
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 1, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 1, 0, 0, 0);
 
         $ci = ChronosInterval::hour(3);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 3, 0, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 3, 0, 0, 0);
     }
 
     public function testMinutes()
     {
         $ci = new ChronosInterval(0, 0, 0, 0, 0, 1);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 1, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 1, 0, 0);
 
         $ci = ChronosInterval::minutes(2);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 2, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 2, 0, 0);
 
         $ci = ChronosInterval::minute();
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 1, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 1, 0, 0);
 
         $ci = ChronosInterval::minute(3);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 3, 0);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 3, 0, 0);
     }
 
     public function testSeconds()
     {
         $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 1);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 1);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 1, 0);
 
         $ci = ChronosInterval::seconds(2);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 2);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 2, 0);
 
         $ci = ChronosInterval::second();
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 1);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 1, 0);
 
         $ci = ChronosInterval::second(3);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 3);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 3, 0);
+    }
+
+    public function testMicroseconds()
+    {
+        $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0, 123456);
+        $this->assertInstanceOf(ChronosInterval::class, $ci);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 123456);
+
+        $ci = ChronosInterval::microseconds(2);
+        $this->assertInstanceOf(ChronosInterval::class, $ci);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 2);
+
+        $ci = ChronosInterval::microsecond();
+        $this->assertInstanceOf(ChronosInterval::class, $ci);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 1);
+
+        $ci = ChronosInterval::microsecond(3);
+        $this->assertInstanceOf(ChronosInterval::class, $ci);
+        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 3);
     }
 
     public function testYearsAndHours()
     {
-        $ci = new ChronosInterval(5, 0, 0, 0, 3, 0, 0);
+        $ci = new ChronosInterval(5, 0, 0, 0, 3, 0, 0, 0);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 5, 0, 0, 3, 0, 0);
+        $this->assertDateTimeInterval($ci, 5, 0, 0, 3, 0, 0, 0);
     }
 
     public function testAll()
     {
-        $ci = new ChronosInterval(5, 6, 2, 5, 9, 10, 11);
+        $ci = new ChronosInterval(5, 6, 2, 5, 9, 10, 11, 123);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 5, 6, 19, 9, 10, 11);
+        $this->assertDateTimeInterval($ci, 5, 6, 19, 9, 10, 11, 123);
     }
 
     public function testAllWithCreate()
     {
-        $ci = ChronosInterval::create(5, 6, 2, 5, 9, 10, 11);
+        $ci = ChronosInterval::create(5, 6, 2, 5, 9, 10, 11, 123);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 5, 6, 19, 9, 10, 11);
+        $this->assertDateTimeInterval($ci, 5, 6, 19, 9, 10, 11, 123);
     }
 
     public function testInstance()
     {
         $ci = ChronosInterval::instance(new DateInterval('P2Y1M5DT22H33M44S'));
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 2, 1, 5, 22, 33, 44);
+        $this->assertDateTimeInterval($ci, 2, 1, 5, 22, 33, 44, 0);
         $this->assertTrue($ci->days === false || $ci->days === 0 || $ci->days === ChronosInterval::PHP_DAYS_FALSE);
     }
 
@@ -228,7 +247,7 @@ class IntervalConstructTest extends TestCase
         $di->invert = 1;
         $ci = ChronosInterval::instance($di);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 2, 1, 5, 22, 33, 44);
+        $this->assertDateTimeInterval($ci, 2, 1, 5, 22, 33, 44, 0);
         $this->assertTrue($ci->days === false || $ci->days === 0 || $ci->days === ChronosInterval::PHP_DAYS_FALSE);
         $this->assertSame(1, $ci->invert);
     }

--- a/tests/Interval/IntervalGettersTest.php
+++ b/tests/Interval/IntervalGettersTest.php
@@ -72,7 +72,13 @@ class IntervalGettersTest extends TestCase
 
     public function testSecondsGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
         $this->assertSame(10, $d->seconds);
+    }
+
+    public function testMicrosecondsGetter()
+    {
+        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
+        $this->assertSame(123, $d->microseconds);
     }
 }

--- a/tests/Interval/IntervalSettersTest.php
+++ b/tests/Interval/IntervalSettersTest.php
@@ -67,20 +67,27 @@ class IntervalSettersTest extends TestCase
 
     public function testSecondsSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
         $d->seconds = 34;
         $this->assertSame(34, $d->seconds);
     }
 
+    public function testMicroecondsSetter()
+    {
+        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
+        $d->microseconds = 456;
+        $this->assertSame(456, $d->microseconds);
+    }
+
     public function testFluentSetters()
     {
-        $ci = ChronosInterval::years(4)->months(2)->dayz(5)->hours(3)->minute()->seconds(59);
+        $ci = ChronosInterval::years(4)->months(2)->dayz(5)->hours(3)->minute()->seconds(59)->microseconds(123);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 4, 2, 5, 3, 1, 59);
+        $this->assertDateTimeInterval($ci, 4, 2, 5, 3, 1, 59, 123);
 
-        $ci = ChronosInterval::years(4)->months(2)->weeks(2)->hours(3)->minute()->seconds(59);
+        $ci = ChronosInterval::years(4)->months(2)->weeks(2)->hours(3)->minute()->seconds(59)->microseconds(123);
         $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 4, 2, 14, 3, 1, 59);
+        $this->assertDateTimeInterval($ci, 4, 2, 14, 3, 1, 59, 123);
     }
 
     public function testFluentSettersDaysOverwritesWeeks()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -80,7 +80,7 @@ abstract class TestCase extends BaseTestCase
         }
     }
 
-    protected function assertDateTimeInterval(ChronosInterval $ci, $years, $months = null, $days = null, $hours = null, $minutes = null, $seconds = null)
+    protected function assertDateTimeInterval(ChronosInterval $ci, $years, $months = null, $days = null, $hours = null, $minutes = null, $seconds = null, $microseconds = null)
     {
         $this->assertSame($years, $ci->years, 'ChronosInterval->years');
 
@@ -102,6 +102,10 @@ abstract class TestCase extends BaseTestCase
 
         if ($seconds !== null) {
             $this->assertSame($seconds, $ci->seconds, 'ChronosInterval->seconds');
+        }
+
+        if ($microseconds !== null) {
+            $this->assertSame($microseconds, $ci->microseconds, 'ChronosInterval->microseconds');
         }
     }
 


### PR DESCRIPTION
https://github.com/cakephp/chronos/issues/223

This does not add microseconds to `__toString()`.  There is an expectation that the spec string created can be passed to DateInterval constructor.  Unfortunately, DateInterval does not support decimals in the spec string contrary to the ISO spec.

We could add it as decimal seconds and simply not include microseconds in the unit test.  I'm not sure that's a good situation though.