### PR TITLE
2.x - Added microseconds to FactoryTrait::create()

### DIFF
--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -134,9 +134,10 @@ trait FactoryTrait
      * will be used.
      *
      * If $hour is null it will be set to its now() value and the default values
-     * for $minute, $second and $microsecond will be their now() values.
-     * If $hour is not null then the default values for $minute and $second
+     * for $minute and $second will be their now() values. The default for milliseconds
      * will be 0.
+     * If $hour is not null then the default values for $minute, $second
+     * and $microsecond will be 0.
      *
      * @param int|null $year The year to create an instance with.
      * @param int|null $month The month to create an instance with.
@@ -158,15 +159,16 @@ trait FactoryTrait
         ?int $microsecond = null,
         $tz = null
     ): ChronosInterface {
-        $year = $year ?? (int)date('Y');
-        $month = $month ?? date('m');
-        $day = $day ?? date('d');
+        $now = time();
+        $year = $year ?? (int)date('Y', $now);
+        $month = $month ?? date('m', $now);
+        $day = $day ?? date('d', $now);
 
         if ($hour === null) {
-            $hour = date('H');
-            $minute = $minute ?? date('i');
-            $second = $second ?? date('s');
-            $microsecond = $microsecond ?? date('u');
+            $hour = date('H', $now);
+            $minute = $minute ?? date('i', $now);
+            $second = $second ?? date('s', $now);
+            $microsecond = $microsecond ?? 0;
         } else {
             $minute = $minute ?? 0;
             $second = $second ?? 0;

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -134,8 +134,7 @@ trait FactoryTrait
      * will be used.
      *
      * If $hour is null it will be set to its now() value and the default values
-     * for $minute and $second will be their now() values. The default for milliseconds
-     * will be 0.
+     * for $minute, $second and $microsecond will be their now() values.
      * If $hour is not null then the default values for $minute, $second
      * and $microsecond will be 0.
      *
@@ -159,16 +158,16 @@ trait FactoryTrait
         ?int $microsecond = null,
         $tz = null
     ): ChronosInterface {
-        $now = time();
-        $year = $year ?? (int)date('Y', $now);
-        $month = $month ?? date('m', $now);
-        $day = $day ?? date('d', $now);
+        $now = static::now();
+        $year = $year ?? (int)$now->format('Y');
+        $month = $month ?? $now->format('m');
+        $day = $day ?? $now->format('d');
 
         if ($hour === null) {
-            $hour = date('H', $now);
-            $minute = $minute ?? date('i', $now);
-            $second = $second ?? date('s', $now);
-            $microsecond = $microsecond ?? 0;
+            $hour = $now->format('H');
+            $minute = $minute ?? $now->format('i');
+            $second = $second ?? $now->format('s');
+            $microsecond = $microsecond ?? $now->format('u');
         } else {
             $minute = $minute ?? 0;
             $second = $second ?? 0;

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -134,7 +134,7 @@ trait FactoryTrait
      * will be used.
      *
      * If $hour is null it will be set to its now() value and the default values
-     * for $minute and $second will be their now() values.
+     * for $minute, $second and $microsecond will be their now() values.
      * If $hour is not null then the default values for $minute and $second
      * will be 0.
      *
@@ -144,6 +144,7 @@ trait FactoryTrait
      * @param int|null $hour The hour to create an instance with.
      * @param int|null $minute The minute to create an instance with.
      * @param int|null $second The second to create an instance with.
+     * @param int|null $microsecond The microsecond to create an instance with.
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
@@ -154,24 +155,27 @@ trait FactoryTrait
         ?int $hour = null,
         ?int $minute = null,
         ?int $second = null,
+        ?int $microsecond = null,
         $tz = null
     ): ChronosInterface {
         $year = $year ?? (int)date('Y');
-        $month = $month ?? date('n');
-        $day = $day ?? date('j');
+        $month = $month ?? date('m');
+        $day = $day ?? date('d');
 
         if ($hour === null) {
-            $hour = date('G');
+            $hour = date('H');
             $minute = $minute ?? date('i');
             $second = $second ?? date('s');
+            $microsecond = $microsecond ?? date('u');
         } else {
             $minute = $minute ?? 0;
             $second = $second ?? 0;
+            $microsecond = $microsecond ?? 0;
         }
 
         $instance = static::createFromFormat(
-            'Y-n-j G:i:s',
-            sprintf('%s-%s-%s %s:%02s:%02s', 0, $month, $day, $hour, $minute, $second),
+            'Y-m-d H:i:s.u',
+            sprintf('%s-%s-%s %s:%02s:%02s.%06s', 0, $month, $day, $hour, $minute, $second, $microsecond),
             $tz
         );
 
@@ -193,7 +197,7 @@ trait FactoryTrait
         ?int $day = null,
         $tz = null
     ): ChronosInterface {
-        return static::create($year, $month, $day, null, null, null, $tz);
+        return static::create($year, $month, $day, null, null, null, null, $tz);
     }
 
     /**
@@ -202,6 +206,7 @@ trait FactoryTrait
      * @param int|null $hour The hour to create an instance with.
      * @param int|null $minute The minute to create an instance with.
      * @param int|null $second The second to create an instance with.
+     * @param int|null $microsecond The microsecond to create an instance with.
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
@@ -209,9 +214,10 @@ trait FactoryTrait
         ?int $hour = null,
         ?int $minute = null,
         ?int $second = null,
+        ?int $microsecond = null,
         $tz = null
     ): ChronosInterface {
-        return static::create(null, null, null, $hour, $minute, $second, $tz);
+        return static::create(null, null, null, $hour, $minute, $second, $microsecond, $tz);
     }
 
     /**

--- a/src/Traits/MagicPropertyTrait.php
+++ b/src/Traits/MagicPropertyTrait.php
@@ -68,6 +68,7 @@ trait MagicPropertyTrait
             'minute' => 'i',
             'second' => 's',
             'micro' => 'u',
+            'microsecond' => 'u',
             'dayOfWeek' => 'N',
             'dayOfYear' => 'z',
             'weekOfYear' => 'W',

--- a/tests/DateTime/ComparisonTest.php
+++ b/tests/DateTime/ComparisonTest.php
@@ -60,11 +60,12 @@ class ComparisonTest extends TestCase
      */
     public function testEqualWithTimezoneTrue($class)
     {
-        $this->assertTrue($class::create(2000, 1, 1, 12, 0, 0, 'America/Toronto')->eq($class::create(
+        $this->assertTrue($class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto')->eq($class::create(
             2000,
             1,
             1,
             9,
+            0,
             0,
             0,
             'America/Vancouver'
@@ -141,8 +142,8 @@ class ComparisonTest extends TestCase
      */
     public function testGreaterThanWithTimezoneTrue($class)
     {
-        $dt1 = $class::create(2000, 1, 1, 12, 0, 0, 'America/Toronto');
-        $dt2 = $class::create(2000, 1, 1, 8, 59, 59, 'America/Vancouver');
+        $dt1 = $class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $dt2 = $class::create(2000, 1, 1, 8, 59, 59, 0, 'America/Vancouver');
         $this->assertTrue($dt1->gt($dt2));
     }
 
@@ -152,8 +153,8 @@ class ComparisonTest extends TestCase
      */
     public function testGreaterThanWithTimezoneFalse($class)
     {
-        $dt1 = $class::create(2000, 1, 1, 12, 0, 0, 'America/Toronto');
-        $dt2 = $class::create(2000, 1, 1, 9, 0, 1, 'America/Vancouver');
+        $dt1 = $class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $dt2 = $class::create(2000, 1, 1, 9, 0, 1, 0, 'America/Vancouver');
         $this->assertFalse($dt1->gt($dt2));
     }
 

--- a/tests/DateTime/ComparisonTest.php
+++ b/tests/DateTime/ComparisonTest.php
@@ -40,15 +40,6 @@ class ComparisonTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testEqualToTrue($class)
-    {
-        $this->assertTrue($class::createFromDate(2000, 1, 1)->eq($class::createFromDate(2000, 1, 1)));
-    }
-
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
     public function testEqualToFalse($class)
     {
         $this->assertFalse($class::createFromDate(2000, 1, 1)->eq($class::createFromDate(2000, 1, 2)));
@@ -93,15 +84,6 @@ class ComparisonTest extends TestCase
     public function testNotEqualToTrue($class)
     {
         $this->assertTrue($class::createFromDate(2000, 1, 1)->ne($class::createFromDate(2000, 1, 2)));
-    }
-
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNotEqualToFalse($class)
-    {
-        $this->assertFalse($class::createFromDate(2000, 1, 1)->ne($class::createFromDate(2000, 1, 1)));
     }
 
     /**
@@ -165,15 +147,6 @@ class ComparisonTest extends TestCase
     public function testGreaterThanOrEqualTrue($class)
     {
         $this->assertTrue($class::createFromDate(2000, 1, 1)->gte($class::createFromDate(1999, 12, 31)));
-    }
-
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGreaterThanOrEqualTrueEqual($class)
-    {
-        $this->assertTrue($class::createFromDate(2000, 1, 1)->gte($class::createFromDate(2000, 1, 1)));
     }
 
     /**

--- a/tests/DateTime/CreateFromDateTest.php
+++ b/tests/DateTime/CreateFromDateTest.php
@@ -26,7 +26,7 @@ class CreateFromDateTest extends TestCase
     public function testCreateFromDateWithDefaults($class)
     {
         $d = $class::createFromDate();
-        $this->assertSame($d->timestamp, $class::create(null, null, null, null, null, null)->timestamp);
+        $this->assertSame($d->timestamp, $class::create(null, null, null, null, null, null, null)->timestamp);
     }
 
     /**

--- a/tests/DateTime/CreateFromTimeTest.php
+++ b/tests/DateTime/CreateFromTimeTest.php
@@ -75,10 +75,21 @@ class CreateFromTimeTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
+    public function testCreateFromTimeWithMicroecond($class)
+    {
+        $d = $class::createFromTime(null, null, null, 123456);
+        $this->assertSame(123456, $d->microsecond);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
     public function testCreateFromTimeWithDateTimeZone($class)
     {
-        $d = $class::createFromTime(12, 0, 0, new \DateTimeZone('Europe/London'));
-        $this->assertDateTime($d, $class::now()->year, $class::now()->month, $class::now()->day, 12, 0, 0);
+        $now = $class::now();
+        $d = $class::createFromTime(12, 0, 0, 0, new \DateTimeZone('Europe/London'));
+        $this->assertDateTime($d, $now->year, $now->month, $now->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
@@ -88,8 +99,9 @@ class CreateFromTimeTest extends TestCase
      */
     public function testCreateFromTimeWithTimeZoneString($class)
     {
-        $d = $class::createFromTime(12, 0, 0, 'Europe/London');
-        $this->assertDateTime($d, $class::now()->year, $class::now()->month, $class::now()->day, 12, 0, 0);
+        $now = $class::now();
+        $d = $class::createFromTime(12, 0, 0, 0, 'Europe/London');
+        $this->assertDateTime($d, $now->year, $now->month, $now->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 }

--- a/tests/DateTime/CreateFromTimeTest.php
+++ b/tests/DateTime/CreateFromTimeTest.php
@@ -75,7 +75,7 @@ class CreateFromTimeTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testCreateFromTimeWithMicroecond($class)
+    public function testCreateFromTimeWithMicrosecond($class)
     {
         $d = $class::createFromTime(null, null, null, 123456);
         $this->assertSame(123456, $d->microsecond);

--- a/tests/DateTime/CreateTest.php
+++ b/tests/DateTime/CreateTest.php
@@ -242,7 +242,7 @@ class CreateTest extends TestCase
      */
     public function testCreateWithDateTimeZone($class)
     {
-        $d = $class::create(2012, 1, 1, 0, 0, 0, new \DateTimeZone('Europe/London'));
+        $d = $class::create(2012, 1, 1, 0, 0, 0, 0, new \DateTimeZone('Europe/London'));
         $this->assertDateTime($d, 2012, 1, 1, 0, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
@@ -253,7 +253,7 @@ class CreateTest extends TestCase
      */
     public function testCreateWithTimeZoneString($class)
     {
-        $d = $class::create(2012, 1, 1, 0, 0, 0, 'Europe/London');
+        $d = $class::create(2012, 1, 1, 0, 0, 0, 0, 'Europe/London');
         $this->assertDateTime($d, 2012, 1, 1, 0, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }

--- a/tests/DateTime/DayOfWeekModifiersTest.php
+++ b/tests/DateTime/DayOfWeekModifiersTest.php
@@ -94,7 +94,7 @@ class DayOfWeekModifiersTest extends TestCase
      */
     public function testStartOrEndOfWeekFromWeekWithUTC($class)
     {
-        $d = $class::create(2016, 7, 27, 17, 13, 7, 'UTC');
+        $d = $class::create(2016, 7, 27, 17, 13, 7, 0, 'UTC');
         $this->assertDateTime($d->copy()->startOfWeek(), 2016, 7, 25, 0, 0, 0);
         $this->assertDateTime($d->copy()->endOfWeek(), 2016, 7, 31, 23, 59, 59);
         $this->assertDateTime($d->startOfWeek()->endOfWeek(), 2016, 7, 31, 23, 59, 59);
@@ -105,7 +105,7 @@ class DayOfWeekModifiersTest extends TestCase
      */
     public function testStartOrEndOfWeekFromWeekWithOtherTimezone($class)
     {
-        $d = $class::create(2016, 7, 27, 17, 13, 7, 'America/New_York');
+        $d = $class::create(2016, 7, 27, 17, 13, 7, 0, 'America/New_York');
         $this->assertDateTime($d->startOfWeek(), 2016, 7, 25, 0, 0, 0);
         $this->assertDateTime($d->endOfWeek(), 2016, 7, 31, 23, 59, 59);
         $this->assertDateTime($d->startOfWeek()->endOfWeek(), 2016, 7, 31, 23, 59, 59);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,7 +61,7 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
-    protected function assertDateTime($d, $year, $month, $day, $hour = null, $minute = null, $second = null)
+    protected function assertDateTime($d, $year, $month, $day, $hour = null, $minute = null, $second = null, $microsecond = null)
     {
         $this->assertSame($year, $d->year, 'Chronos->year');
         $this->assertSame($month, $d->month, 'Chronos->month');
@@ -77,6 +77,10 @@ abstract class TestCase extends BaseTestCase
 
         if ($second !== null) {
             $this->assertSame($second, $d->second, 'Chronos->second');
+        }
+
+        if ($microsecond !== null) {
+            $this->assertSame($microsecond, $d->microsecond, 'Chronos->microsecond');
         }
     }
 


### PR DESCRIPTION
I also changed the format letters used by create() to the standard Y-m-d to match every other place in cakephp. They are aliases of each other.

Fixes https://github.com/cakephp/chronos/issues/220