### PR TITLE
Date should use the system timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,11 @@ $fixed = $date->toImmutable();
 
 # Calendar Dates
 
-PHP only offers datetime objects as part of the native extensions. Chronos
-adds a number of conveniences to the traditional DateTime object and introduces
-a `Date` object. `Date` instances offer compatibility with the `ChronosInterface`, but
-have their time & timezone frozen to `00:00:00 UTC`. This makes them ideal when working with
+PHP only offers datetime objects as part of the native extensions. Chronos adds
+a number of conveniences to the traditional DateTime object and introduces
+a `Date` object. `Date` instances offer compatibility with the
+`ChronosInterface`, but have their time frozen to `00:00:00` and the timezone
+set to the server default timezone. This makes them ideal when working with
 calendar dates as the time components will always match.
 
 ```php
@@ -135,12 +136,12 @@ echo $today->modify('+3 hours');
 // Outputs '2015-10-21'
 ```
 
-Like instances of `Chronos`, `Date` objects are also *immutable*. The `MutableDate` class provides
-a mutable variant of `Date`.
+Like instances of `Chronos`, `Date` objects are also *immutable*. The
+`MutableDate` class provides a mutable variant of `Date`.
 
 # Documentation
 
-A more descriptive documentation can be found at [book.cakephp.org/chronos/1.x/en/](https://book.cakephp.org/chronos/1.x/en/).
+A more descriptive documentation can be found at [book.cakephp.org/chronos/2/en/](https://book.cakephp.org/chronos/2/en/).
 
 # API Documentation
 

--- a/src/Date.php
+++ b/src/Date.php
@@ -82,7 +82,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
      *
      * Date instances lack time components, however due to limitations in PHP's
      * internal Datetime object the time will always be set to 00:00:00, and the
-     * timezone will always be UTC. Normalizing the timezone allows for
+     * timezone will always be the server local time. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
      * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
@@ -97,7 +97,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
         $testNow = Chronos::getTestNow();
         if ($testNow === null || !static::isRelativeOnly($time)) {
             $time = $this->stripTime($time, $tz);
-            parent::__construct($time, new DateTimeZone('UTC'));
+            parent::__construct($time, new DateTimeZone(date_default_timezone_get()));
 
             return;
         }
@@ -111,7 +111,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
         }
 
         $time = $testNow->format('Y-m-d 00:00:00');
-        parent::__construct($time, new DateTimeZone('UTC'));
+        parent::__construct($time, new DateTimeZone(date_default_timezone_get()));
     }
 
     /**

--- a/src/Date.php
+++ b/src/Date.php
@@ -97,7 +97,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
         $testNow = Chronos::getTestNow();
         if ($testNow === null || !static::isRelativeOnly($time)) {
             $time = $this->stripTime($time, $tz);
-            parent::__construct($time, new DateTimeZone(date_default_timezone_get()));
+            parent::__construct($time);
 
             return;
         }
@@ -111,7 +111,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
         }
 
         $time = $testNow->format('Y-m-d 00:00:00');
-        parent::__construct($time, new DateTimeZone(date_default_timezone_get()));
+        parent::__construct($time);
     }
 
     /**

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -81,7 +81,7 @@ class MutableDate extends DateTime implements ChronosInterface
      *
      * Date instances lack time components, however due to limitations in PHP's
      * internal Datetime object the time will always be set to 00:00:00, and the
-     * timezone will always be UTC. Normalizing the timezone allows for
+     * timezone will always be server local timezone. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
      * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
@@ -96,7 +96,7 @@ class MutableDate extends DateTime implements ChronosInterface
         $testNow = Chronos::getTestNow();
         if ($testNow === null || !static::isRelativeOnly($time)) {
             $time = $this->stripTime($time, $tz);
-            parent::__construct($time, new DateTimezone(date_default_timezone_get()));
+            parent::__construct($time);
 
             return;
         }
@@ -110,7 +110,7 @@ class MutableDate extends DateTime implements ChronosInterface
         }
 
         $time = $testNow->format('Y-m-d 00:00:00');
-        parent::__construct($time, new DateTimeZone(date_default_timezone_get()));
+        parent::__construct($time);
     }
 
     /**

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -96,7 +96,7 @@ class MutableDate extends DateTime implements ChronosInterface
         $testNow = Chronos::getTestNow();
         if ($testNow === null || !static::isRelativeOnly($time)) {
             $time = $this->stripTime($time, $tz);
-            parent::__construct($time, new DateTimeZone('UTC'));
+            parent::__construct($time, new DateTimezone(date_default_timezone_get()));
 
             return;
         }
@@ -110,7 +110,7 @@ class MutableDate extends DateTime implements ChronosInterface
         }
 
         $time = $testNow->format('Y-m-d 00:00:00');
-        parent::__construct($time, new DateTimeZone('UTC'));
+        parent::__construct($time, new DateTimeZone(date_default_timezone_get()));
     }
 
     /**

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -63,14 +63,13 @@ class ConstructTest extends TestCase
      */
     public function testCreateFromTimestamp($class)
     {
-        $tz = date_default_timezone_get();
-        date_default_timezone_set('Europe/London');
-        $ts = 1454284800;
-        $date = $class::createFromTimestamp($ts);
-        date_default_timezone_set($tz);
+        $this->withTimezone('Europe/Berlin', function () use ($class) {
+            $ts = 1454284800;
+            $date = $class::createFromTimestamp($ts);
 
-        $this->assertEquals('Europe/London', $date->tzName);
-        $this->assertEquals('2016-02-01', $date->format('Y-m-d'));
+            $this->assertEquals('Europe/Berlin', $date->tzName);
+            $this->assertEquals('2016-02-01', $date->format('Y-m-d'));
+        });
     }
 
     /**

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -33,11 +33,11 @@ class ConstructTest extends TestCase
     {
         $c = $class::parse(null);
         $this->assertEquals('00:00:00', $c->format('H:i:s'));
-        $this->assertEquals('UTC', $c->tzName);
+        $this->assertEquals(date_default_timezone_get(), $c->tzName);
 
         $c = $class::parse('');
         $this->assertEquals('00:00:00', $c->format('H:i:s'));
-        $this->assertEquals('UTC', $c->tzName);
+        $this->assertEquals(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -50,11 +50,11 @@ class ConstructTest extends TestCase
 
         $c = $class::parse(null);
         $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertEquals('UTC', $c->tzName);
+        $this->assertEquals(date_default_timezone_get(), $c->tzName);
 
         $c = $class::parse('');
         $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertEquals('UTC', $c->tzName);
+        $this->assertEquals(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -63,9 +63,13 @@ class ConstructTest extends TestCase
      */
     public function testCreateFromTimestamp($class)
     {
+        $tz = date_default_timezone_get();
+        date_default_timezone_set('Europe/London');
         $ts = 1454284800;
         $date = $class::createFromTimestamp($ts);
-        $this->assertEquals('UTC', $date->tzName);
+        date_default_timezone_set($tz);
+
+        $this->assertEquals('Europe/London', $date->tzName);
         $this->assertEquals('2016-02-01', $date->format('Y-m-d'));
     }
 
@@ -132,20 +136,20 @@ class ConstructTest extends TestCase
      * @dataProvider dateClassProvider
      * @return void
      */
-    public function testUsesUTC($class)
+    public function testUsesDefaultTimezone($class)
     {
         $c = new $class('now');
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
      * @dataProvider dateClassProvider
      * @return void
      */
-    public function testParseUsesUTC($class)
+    public function testParseUsesDefaultTimezone($class)
     {
         $c = $class::parse('now');
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -157,7 +161,7 @@ class ConstructTest extends TestCase
         $timezone = 'Europe/London';
         $dtz = new \DateTimeZone($timezone);
         $c = new $class('now', $dtz);
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -166,11 +170,8 @@ class ConstructTest extends TestCase
      */
     public function testParseSettingTimezoneIgnored($class)
     {
-        $timezone = 'Europe/London';
-        $dtz = new \DateTimeZone($timezone);
-        $c = $class::parse('now', $dtz);
-
-        $this->assertSame('UTC', $c->tzName);
+        $c = $class::parse('now', new DateTimeZone('Europe/London'));
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -179,11 +180,8 @@ class ConstructTest extends TestCase
      */
     public function testSettingTimezoneWithStringIgnored($class)
     {
-        $timezone = 'Asia/Tokyo';
-        $dtz = new \DateTimeZone($timezone);
-
-        $c = new $class('now', $timezone);
-        $this->assertSame('UTC', $c->tzName);
+        $c = new $class('now', 'Asia/Tokyo');
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -192,10 +190,8 @@ class ConstructTest extends TestCase
      */
     public function testParseSettingTimezoneWithStringIgnored($class)
     {
-        $timezone = 'Asia/Tokyo';
-        $dtz = new \DateTimeZone($timezone);
-        $c = $class::parse('now', $timezone);
-        $this->assertSame('UTC', $c->tzName);
+        $c = $class::parse('now', 'Asia/Tokyo');
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -301,7 +297,7 @@ class ConstructTest extends TestCase
         $c = new $class('now', $londonTimezone);
         $london = new DateTimeImmutable('now', $londonTimezone);
         $this->assertEquals($london->format('Y-m-d'), $c->format('Y-m-d'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // now adjusted to London time
         $c = $class::today($londonTimezone);
@@ -310,17 +306,17 @@ class ConstructTest extends TestCase
         // London timezone is used instead of local timezone
         $c = new $class('2001-01-02 01:00:00', $londonTimezone);
         $this->assertEquals('2001-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // London timezone is ignored when timezone is provided in time string
         $c = new $class('2001-01-01 23:00:00-400', $londonTimezone);
         $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // London timezone is ignored when DateTimeInterface instance is provided
         $c = new $class(new DateTimeImmutable('2001-01-01 23:00:00-400'), $londonTimezone);
         $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -335,29 +331,29 @@ class ConstructTest extends TestCase
         // TestNow is adjusted to London time
         $c = new $class('now', $londonTimezone);
         $this->assertEquals('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
         $c = new $class('+2 days', $londonTimezone);
         $this->assertEquals('2010-01-04 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
         $c = $class::today($londonTimezone);
         $this->assertEquals('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertEquals(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
         $c = $class::tomorrow($londonTimezone);
         $this->assertEquals('2010-01-03 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertEquals(Chronos::tomorrow($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is ignored when specific date is provided
         $c = new $class('2001-01-05 01:00:00', $londonTimezone);
         $this->assertEquals('2001-01-05 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -367,7 +363,7 @@ class ConstructTest extends TestCase
      *
      * @dataProvider dateClassProvider
      */
-    public function testConstructWithLargeTimzoneChange($class)
+    public function testConstructWithLargeTimezoneChange($class)
     {
         $savedTz = date_default_timezone_get();
         date_default_timezone_set('Pacific/Kiritimati');
@@ -378,7 +374,7 @@ class ConstructTest extends TestCase
         $c = $class::today($samoaTimezone);
         $Samoa = new DateTimeImmutable('now', $samoaTimezone);
         $this->assertEquals($Samoa->format('Y-m-d'), $c->format('Y-m-d'));
-        $this->assertSame('UTC', $c->tzName);
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         date_default_timezone_set($savedTz);
     }

--- a/tests/Date/IsTest.php
+++ b/tests/Date/IsTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Chronos\Test\Date;
+
+use Cake\Chronos\Test\TestCase;
+
+class IsTest extends TestCase
+{
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testIsTodayTrue($class)
+    {
+        $this->assertTrue($class::now()->isToday());
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testIsTodayOtherTimezone($class)
+    {
+        $this->withTimezone('Asia/Tokyo', function () use ($class) {
+            $today = $class::today();
+            $this->assertSame('Asia/Tokyo', $today->tzName);
+            $this->assertTrue($today->isToday());
+        });
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testIsTodayFalseWithYesterday($class)
+    {
+        $this->assertFalse($class::now()->subDay()->endOfDay()->isToday());
+    }
+}

--- a/tests/Date/StringsTest.php
+++ b/tests/Date/StringsTest.php
@@ -19,12 +19,37 @@ use Cake\Chronos\Test\TestCase;
 class StringsTest extends TestCase
 {
     /**
+     * Setup
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('UTC');
+    }
+
+    /**
+     * Teardown
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        date_default_timezone_set($this->tz);
+
+        unset($this->tz);
+    }
+
+    /**
      * @dataProvider dateClassProvider
      * @return void
      */
     public function testToString($class)
     {
-        $d = Date::now();
+        $d = $class::now();
         $this->assertSame(Date::now()->toDateString(), '' . $d);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -115,4 +115,15 @@ abstract class TestCase extends BaseTestCase
         $func();
         Chronos::setTestNow();
     }
+
+    protected function withTimezone(string $tz, Closure $cb)
+    {
+        $restore = date_default_timezone_get();
+        date_default_timezone_set($tz);
+        try {
+            $cb();
+        } finally {
+            date_default_timezone_set($restore);
+        }
+    }
 }


### PR DESCRIPTION
While pinning calendar dates to UTC is helpful in many situations it makes Date objects hard to use when the server local timezone is far away from UTC (like Asia/Tokyo) as Date::today() and other factory methods will create the wrong date for half the day. By using the server's default timezone we can have more correct date generation in these timezones. The behavior will be unchanged for applications that have their default timezone set to UTC.