### PR TITLE
2.x - Added microseconds @method hint to Chronos

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -30,10 +30,11 @@ use DateTimeZone;
  * @property-read int $hour
  * @property-read int $minute
  * @property-read int $second
+ * @property-read int $micro
+ * @property-read int $microsecond
  * @property-read int $timestamp seconds since the Unix Epoch
  * @property-read \DateTimeZone $timezone the current timezone
  * @property-read \DateTimeZone $tz alias of timezone
- * @property-read int $micro
  * @property-read int $dayOfWeek 1 (for Monday) through 7 (for Sunday)
  * @property-read int $dayOfYear 0 through 365
  * @property-read int $weekOfMonth 1 through 5

--- a/src/Date.php
+++ b/src/Date.php
@@ -31,10 +31,11 @@ use DateTimeZone;
  * @property-read int $hour
  * @property-read int $minute
  * @property-read int $second
+ * @property-read int $micro
+ * @property-read int $microsecond
  * @property-read int $timestamp seconds since the Unix Epoch
  * @property-read \DateTimeZone $timezone the current timezone
  * @property-read \DateTimeZone $tz alias of timezone
- * @property-read int $micro
  * @property-read int $dayOfWeek 1 (for Monday) through 7 (for Sunday)
  * @property-read int $dayOfYear 0 through 365
  * @property-read int $weekOfMonth 1 through 5

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -30,10 +30,11 @@ use DateTimeZone;
  * @property-read int $hour
  * @property-read int $minute
  * @property-read int $second
+ * @property-read int $micro
+ * @property-read int $microsecond
  * @property-read int $timestamp seconds since the Unix Epoch
  * @property-read \DateTimeZone $timezone the current timezone
  * @property-read \DateTimeZone $tz alias of timezone
- * @property-read int $micro
  * @property-read int $dayOfWeek 1 (for Monday) through 7 (for Sunday)
  * @property-read int $dayOfYear 0 through 365
  * @property-read int $weekOfMonth 1 through 5

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -31,10 +31,11 @@ use InvalidArgumentException;
  * @property-read int $hour
  * @property-read int $minute
  * @property-read int $second
+ * @property-read int $micro
+ * @property-read int $microsecond
  * @property-read int $timestamp seconds since the Unix Epoch
  * @property-read \DateTimeZone|string $timezone the current timezone
  * @property-read \DateTimeZone|string $tz alias of timezone
- * @property-read int $micro
  * @property-read int $dayOfWeek 1 (for Monday) through 7 (for Sunday)
  * @property-read int $dayOfYear 0 through 365
  * @property-read int $weekOfMonth 1 through 5


### PR DESCRIPTION
These were missing from the class docblocks after adding to the magic trait.