### PR TITLE
2.x - Added createFromArray()

### DIFF
--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -252,6 +252,11 @@ trait FactoryTrait
     /**
      * Creates a ChronosInterface instance from an array of date and time values.
      *
+     * The 'year', 'month' and 'day' values must all be set for a date. The time
+     * values all default to 0.
+     *
+     * The 'timezone' value can be any format supported by `\DateTimeZone`.
+     *
      * Allowed values:
      *  - year
      *  - month
@@ -260,7 +265,7 @@ trait FactoryTrait
      *  - minute
      *  - second
      *  - microsecond
-     *  - meridian ('am or 'pm')
+     *  - meridian ('am' or 'pm')
      *  - timezone
      *
      * @param (int|string)[] $values Array of date and time values.
@@ -279,7 +284,7 @@ trait FactoryTrait
                 is_numeric($values['day'])
             )
         ) {
-            $formatted .= sprintf('%d-%02d-%02d', $values['year'], $values['month'], $values['day']);
+            $formatted .= sprintf('%04d-%02d-%02d', $values['year'], $values['month'], $values['day']);
         }
 
         if (isset($values['meridian']) && (int)$values['hour'] === 12) {

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -284,7 +284,7 @@ trait FactoryTrait
                 is_numeric($values['day'])
             )
         ) {
-            $formatted .= sprintf('%04d-%02d-%02d', $values['year'], $values['month'], $values['day']);
+            $formatted .= sprintf('%04d-%02d-%02d ', $values['year'], $values['month'], $values['day']);
         }
 
         if (isset($values['meridian']) && (int)$values['hour'] === 12) {
@@ -294,8 +294,7 @@ trait FactoryTrait
             $values['hour'] = strtolower($values['meridian']) === 'am' ? $values['hour'] : $values['hour'] + 12;
         }
         $formatted .= sprintf(
-            '%s%02d:%02d:%02d.%06d',
-            empty($formatted) ? '' : ' ',
+            '%02d:%02d:%02d.%06d',
             $values['hour'],
             $values['minute'],
             $values['second'],

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -250,6 +250,58 @@ trait FactoryTrait
     }
 
     /**
+     * Creates a ChronosInterface instance from an array of date and time values.
+     *
+     * Allowed values:
+     *  - year
+     *  - month
+     *  - day
+     *  - hour
+     *  - minute
+     *  - second
+     *  - microsecond
+     *  - meridian ('am or 'pm')
+     *  - timezone
+     *
+     * @param (int|string)[] $values Array of date and time values.
+     * @return static
+     */
+    public static function createFromArray($values): ChronosInterface
+    {
+        $values += ['hour' => 0, 'minute' => 0, 'second' => 0, 'microsecond' => 0];
+
+        $formatted = '';
+        if (
+            isset($values['year'], $values['month'], $values['day']) &&
+            (
+                is_numeric($values['year']) &&
+                is_numeric($values['month']) &&
+                is_numeric($values['day'])
+            )
+        ) {
+            $formatted .= sprintf('%d-%02d-%02d', $values['year'], $values['month'], $values['day']);
+        }
+
+        if (isset($values['meridian']) && (int)$values['hour'] === 12) {
+            $values['hour'] = 0;
+        }
+        if (isset($values['meridian'])) {
+            $values['hour'] = strtolower($values['meridian']) === 'am' ? $values['hour'] : $values['hour'] + 12;
+        }
+        $formatted .= sprintf(
+            '%s%02d:%02d:%02d.%06d',
+            empty($formatted) ? '' : ' ',
+            $values['hour'],
+            $values['minute'],
+            $values['second'],
+            $values['microsecond']
+        );
+        $tz = $values['timezone'] ?? null;
+
+        return static::parse($formatted, $tz);
+    }
+
+    /**
      * Create a ChronosInterface instance from a timestamp
      *
      * @param int $timestamp The timestamp to create an instance from.

--- a/tests/DateTime/CreateTest.php
+++ b/tests/DateTime/CreateTest.php
@@ -257,4 +257,59 @@ class CreateTest extends TestCase
         $this->assertDateTime($d, 2012, 1, 1, 0, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testCreateFromArray($class)
+    {
+        $values = [
+            'year' => 2012,
+            'month' => '1',
+            'day' => '1',
+            'hour' => 12,
+            'minute' => 13,
+            'second' => '14',
+            'microsecond' => 123456,
+            'meridian' => 'am',
+        ];
+        $d = $class::createFromArray($values);
+        $this->assertDateTime($d, 2012, 1, 1, 0, 13, 14, 123456);
+        $this->assertSame('America/Toronto', $d->tzName);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testCreateFromArrayDateOnly($class)
+    {
+        $values = [
+            'year' => 2012,
+            'month' => '1',
+            'day' => '1',
+        ];
+        $d = $class::createFromArray($values);
+        $this->assertDateTime($d, 2012, 1, 1);
+        $this->assertSame('America/Toronto', $d->tzName);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testCreateFromArrayTimeOnly($class)
+    {
+        $values = [
+            'hour' => 12,
+            'minute' => 13,
+            'second' => '14',
+            'microsecond' => 123456,
+            'meridian' => 'am',
+        ];
+        $d = $class::createFromArray($values);
+        $this->assertTime($d, 0, 13, 14, 123456);
+        $this->assertSame('America/Toronto', $d->tzName);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,6 +61,20 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
+    protected function assertTime($d, $hour, $minute, $second = null, $microsecond = null)
+    {
+        $this->assertSame($hour, $d->hour, 'Chronos->hour');
+        $this->assertSame($minute, $d->minute, 'Chronos->minute');
+
+        if ($second !== null) {
+            $this->assertSame($second, $d->second, 'Chronos->second');
+        }
+
+        if ($microsecond !== null) {
+            $this->assertSame($microsecond, $d->microsecond, 'Chronos->microsecond');
+        }
+    }
+
     protected function assertDateTime($d, $year, $month, $day, $hour = null, $minute = null, $second = null, $microsecond = null)
     {
         $this->assertSame($year, $d->year, 'Chronos->year');


### PR DESCRIPTION
This is a copy of the array to string conversion in `DateTimeType::marshal()` and `Validation::_getDateString()` from cakephp.  We can just construct the instance using this helper in `marshal()` and maintain the format here.

Can back-port to 1.3 without the microseconds support.

Closes https://github.com/cakephp/chronos/issues/176