### PR TITLE
Add dayOfWeekName support

### DIFF
--- a/src/Traits/MagicPropertyTrait.php
+++ b/src/Traits/MagicPropertyTrait.php
@@ -70,6 +70,7 @@ trait MagicPropertyTrait
             'micro' => 'u',
             'microsecond' => 'u',
             'dayOfWeek' => 'N',
+            'dayOfWeekName' => 'l',
             'dayOfYear' => 'z',
             'weekOfYear' => 'W',
             'daysInMonth' => 't',


### PR DESCRIPTION
This lets us use the magic property dayOfWeekName to get the weekday name using `date('l');`.

I will be adding some tests asap.