### PR TITLE
Remove now superfluous constant

### DIFF
--- a/src/carbon_compat.php
+++ b/src/carbon_compat.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
  * @link          http://cakephp.org CakePHP(tm) Project
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
-define('CHRONOS_SUPPORTS_MICROSECONDS', version_compare(PHP_VERSION, '7.1.0', '>='));
 
 if (!class_exists('Carbon\Carbon')) {
     // Create class aliases for Carbon so applications


### PR DESCRIPTION
Chronos requires PHP 7.2 now.

https://github.com/cakephp/chronos/commit/3f580610ab7a010015bbbc49f4fd2d65376418c8#r36790304