### PR TITLE
Fix modify method signature in ChronosInterface

### DIFF
--- a/src/ChronosInterface.php
+++ b/src/ChronosInterface.php
@@ -19,7 +19,7 @@ use DateTimeInterface;
 /**
  * An extension to the DateTimeInterface for a friendlier API
  *
- * @method ChronosInterface modify(string $relative)
+ * @method \Cake\Chronos\ChronosInterface modify(string $relative)
  */
 interface ChronosInterface extends DateTimeInterface
 {

--- a/src/ChronosInterface.php
+++ b/src/ChronosInterface.php
@@ -19,7 +19,7 @@ use DateTimeInterface;
 /**
  * An extension to the DateTimeInterface for a friendlier API
  *
- * @method static modify(string $relative)
+ * @method ChronosInterface modify(string $relative)
  */
 interface ChronosInterface extends DateTimeInterface
 {


### PR DESCRIPTION
static is interpreted as a static method in phpdoc, not as a return type.