### PR TITLE
Allow creating Chronos instances using `new` from existing Chronos instances

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -96,8 +96,8 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
         static::$_lastErrors = [];
         $testNow = static::getTestNow();
         if ($testNow === null) {
-            if ($time instanceof ChronosInterface) {
-                $time = $time->__toString();
+            if ($time instanceof \DateTimeInterface) {
+                $time = $time->format(ChronosInterface::DEFAULT_TO_STRING_FORMAT);
             }
             parent::__construct($time ?? 'now', $tz);
 

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -97,7 +97,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
         $testNow = static::getTestNow();
         if ($testNow === null) {
             if ($time instanceof ChronosInterface) {
-              $time = $time->__toString();
+                $time = $time->__toString();
             }
             parent::__construct($time ?? 'now', $tz);
 

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -96,6 +96,9 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
         static::$_lastErrors = [];
         $testNow = static::getTestNow();
         if ($testNow === null) {
+            if ($time instanceof ChronosInterface) {
+              $time = $time->__toString();
+            }
             parent::__construct($time ?? 'now', $tz);
 
             return;

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -87,6 +87,9 @@ class MutableDateTime extends DateTime implements ChronosInterface
 
         $testNow = Chronos::getTestNow();
         if ($testNow === null) {
+            if ($time instanceof \DateTimeInterface) {
+                $time = $time->format(ChronosInterface::DEFAULT_TO_STRING_FORMAT);
+            }
             parent::__construct($time ?? 'now', $tz);
 
             return;

--- a/tests/Date/ConstructTest.php
+++ b/tests/Date/ConstructTest.php
@@ -377,4 +377,35 @@ class ConstructTest extends TestCase
 
         date_default_timezone_set($savedTz);
     }
+
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testCreateFromExistingInstance($class)
+    {
+        $existingClass = new $class();
+        self::assertInstanceOf($class, $existingClass);
+
+        $newClass = new $class($existingClass);
+        self::assertInstanceOf($class, $newClass);
+
+        self::assertEquals((string)$existingClass, (string)$newClass);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testCreateFromDateTimeInterface($class)
+    {
+        $existingClass = new \DateTimeImmutable();
+        $newClass = new $class($existingClass);
+        self::assertInstanceOf($class, $newClass);
+        self::assertEquals($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
+
+        $existingClass = new \DateTime();
+        $newClass = new $class($existingClass);
+        self::assertInstanceOf($class, $newClass);
+        self::assertEquals($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
+    }
 }

--- a/tests/DateTime/ConstructTest.php
+++ b/tests/DateTime/ConstructTest.php
@@ -160,4 +160,35 @@ class ConstructTest extends TestCase
         $this->assertSame($timezone, $c->tzName);
         $this->assertSame(9 + $dayLightSavingTimeOffset, $c->offsetHours);
     }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testCreateFromExistingInstance($class)
+    {
+        $existingClass = new $class();
+        self::assertInstanceOf($class, $existingClass);
+
+        $newClass = new $class($existingClass);
+        self::assertInstanceOf($class, $newClass);
+        self::assertEquals((string)$existingClass, (string)$newClass);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testCreateFromDateTimeInterface($class)
+    {
+        $existingClass = new \DateTimeImmutable();
+        $newClass = new $class($existingClass);
+        self::assertInstanceOf($class, $newClass);
+        self::assertEquals($existingClass->format('Y-m-d H:i:s'), $newClass->format('Y-m-d H:i:s'));
+
+        $existingClass = new \DateTime();
+        $newClass = new $class($existingClass);
+        self::assertInstanceOf($class, $newClass);
+        self::assertEquals($existingClass->format('Y-m-d H:i:s'), $newClass->format('Y-m-d H:i:s'));
+    }
 }


### PR DESCRIPTION
Convert `ChronosInterface` instances to string in `Chronos::_construct`. 

Passing a Chronos instance to `Chronos::parse` or `new Chronos()` was possible in 1.x (where it was typecast to string silently), but not longer in 2.x because we now have `strict_types=1`.

I know I could use `Chronos::instance`, but we have some existing usages in our code where we pass either a string or an existing Chronos instance to `Chronos::parse` (or `new Chronos()`).

This worked in 1.3: 

    use \Cake\Chronos\Chronos;
    new Chronos(new Chronos());

But in 2.x it says `DateTimeImmutable::__construct() expects parameter 1 to be string, object given`.