### PR TITLE
Respect microseconds when constructing from DateTimeInterface

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -97,7 +97,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
         $testNow = static::getTestNow();
         if ($testNow === null) {
             if ($time instanceof \DateTimeInterface) {
-                $time = $time->format(ChronosInterface::DEFAULT_TO_STRING_FORMAT);
+                $time = $time->format('Y-m-d H:i:s.u');
             }
             parent::__construct($time ?? 'now', $tz);
 

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -88,7 +88,7 @@ class MutableDateTime extends DateTime implements ChronosInterface
         $testNow = Chronos::getTestNow();
         if ($testNow === null) {
             if ($time instanceof \DateTimeInterface) {
-                $time = $time->format(ChronosInterface::DEFAULT_TO_STRING_FORMAT);
+                $time = $time->format('Y-m-d H:i:s.u');
             }
             parent::__construct($time ?? 'now', $tz);
 

--- a/tests/DateTime/ConstructTest.php
+++ b/tests/DateTime/ConstructTest.php
@@ -183,12 +183,15 @@ class ConstructTest extends TestCase
     {
         $existingClass = new \DateTimeImmutable();
         $newClass = new $class($existingClass);
-        self::assertInstanceOf($class, $newClass);
-        self::assertEquals($existingClass->format('Y-m-d H:i:s'), $newClass->format('Y-m-d H:i:s'));
+        self::assertEquals($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
         $existingClass = new \DateTime();
         $newClass = new $class($existingClass);
-        self::assertInstanceOf($class, $newClass);
-        self::assertEquals($existingClass->format('Y-m-d H:i:s'), $newClass->format('Y-m-d H:i:s'));
+        self::assertEquals($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
+
+        $existingClass = new \DateTime('2019-01-15 00:15:22.139302');
+        $newClass = new $class($existingClass);
+        $this->assertDateTime($newClass, 2019, 01, 15, 0, 15, 22);
+        $this->assertSame(139302, $newClass->micro);
     }
 }


### PR DESCRIPTION
As rightly pointed out by @othercorey in #245, we should also consider the microseconds when constructing Chronos or MutableDateTime from an existing DateTimeInterface.

This PR fixes that.