### PR TITLE
Check if carbon interface alias has been already declared

### DIFF
--- a/src/carbon_compat.php
+++ b/src/carbon_compat.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
-if (!class_exists('Carbon\Carbon')) {
+if (!\class_exists('Carbon\Carbon') && !\interface_exists('Carbon\CarbonInterface', false)) {
     // Create class aliases for Carbon so applications
     // can upgrade more easily.
     class_alias('Cake\Chronos\Chronos', 'Carbon\MutableDateTime');


### PR DESCRIPTION
This is a simple workaround for #249 

If the file has been preloaded `Carbon\CarbonInterface` has been already declared.
Passing `false` as second parameter of `interface_exists` ensures that we do not hit the autoloader, making the call zero-cost.