### PR TITLE
Fixed creating Chronos/MutableDateTime from existing instance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "benchmark": "phpbench run --report=chronos",
-        "phpstan": "phpstan analyze -c phpstan.neon -l 3 src/",
+        "phpstan": "phpstan analyze -c phpstan.neon src/",
         "phpstan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^0.12 && mv composer.backup composer.json"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 4
+    level: 5
     ignoreErrors:
         - '#Access to an undefined property Cake\\Chronos\\ChronosInterface::\$tz#'
         - '#Unsafe usage of new static().#'

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -84,7 +84,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      * Please see the testing aids section (specifically static::setTestNow())
      * for more on the possibility of this constructor returning a test instance.
      *
-     * @param string|int|null $time Fixed or relative time
+     * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      */
     public function __construct($time = 'now', $tz = null)
@@ -93,12 +93,13 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
             $tz = $tz instanceof DateTimeZone ? $tz : new DateTimeZone($tz);
         }
 
+        if ($time instanceof \DateTimeInterface) {
+            $time = $time->format('Y-m-d H:i:s.u');
+        }
+
         static::$_lastErrors = [];
         $testNow = static::getTestNow();
         if ($testNow === null) {
-            if ($time instanceof \DateTimeInterface) {
-                $time = $time->format('Y-m-d H:i:s.u');
-            }
             parent::__construct($time ?? 'now', $tz);
 
             return;

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -76,7 +76,7 @@ class MutableDateTime extends DateTime implements ChronosInterface
      * Please see the testing aids section (specifically static::setTestNow())
      * for more on the possibility of this constructor returning a test instance.
      *
-     * @param string|int|null $time Fixed or relative time
+     * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      */
     public function __construct($time = 'now', $tz = null)
@@ -85,11 +85,12 @@ class MutableDateTime extends DateTime implements ChronosInterface
             $tz = $tz instanceof DateTimeZone ? $tz : new DateTimeZone($tz);
         }
 
+        if ($time instanceof \DateTimeInterface) {
+            $time = $time->format('Y-m-d H:i:s.u');
+        }
+
         $testNow = Chronos::getTestNow();
         if ($testNow === null) {
-            if ($time instanceof \DateTimeInterface) {
-                $time = $time->format('Y-m-d H:i:s.u');
-            }
             parent::__construct($time ?? 'now', $tz);
 
             return;

--- a/src/Traits/TimezoneTrait.php
+++ b/src/Traits/TimezoneTrait.php
@@ -52,13 +52,6 @@ trait TimezoneTrait
      */
     public function setTimezone($value): ChronosInterface
     {
-        $date = parent::setTimezone(static::safeCreateDateTimeZone($value));
-
-        // https://bugs.php.net/bug.php?id=72338
-        // this is workaround for this bug
-        // Needed for PHP below 7.0 version
-        $date->getTimestamp();
-
-        return $date;
+        return parent::setTimezone(static::safeCreateDateTimeZone($value));
     }
 }


### PR DESCRIPTION
This makes sure it works when test now is set. 

Set phptan to level 5. There were no new errors after fixing level 4.