### PR TITLE
Remove HHVM references since it dropped support for php

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ A minor but still noticeable difference is that `Chronos` has no external depend
 Finally, Chronos is faster than Carbon as it has been optimized for the creation of hundreds of instances with minimal
 overhead.
 
-Chronos also strives for HHVM compatibility, this library can be used safely with HHVM 3.11.
-
 # Migrating from Carbon
 
 

--- a/src/Traits/DifferenceTrait.php
+++ b/src/Traits/DifferenceTrait.php
@@ -19,7 +19,6 @@ use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\DifferenceFormatter;
 use Cake\Chronos\DifferenceFormatterInterface;
 use DatePeriod;
-use DateTimeImmutable;
 use DateTimeInterface;
 
 /**
@@ -139,11 +138,6 @@ trait DifferenceTrait
         $start = $this;
         $end = $dt ?? static::now($this->tz);
         $inverse = false;
-
-        if (defined('HHVM_VERSION')) {
-            $start = new DateTimeImmutable($this->toIso8601String());
-            $end = new DateTimeImmutable($end->toIso8601String());
-        }
 
         if ($end < $start) {
             $start = $end;


### PR DESCRIPTION
They dropped support before 2.0 release.