### PR TITLE
Consistency for assertion methods call

### DIFF
--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -385,12 +385,12 @@ class ConstructTest extends TestCase
     public function testCreateFromExistingInstance($class)
     {
         $existingClass = new $class();
-        self::assertInstanceOf($class, $existingClass);
+        $this->assertInstanceOf($class, $existingClass);
 
         $newClass = new $class($existingClass);
-        self::assertInstanceOf($class, $newClass);
+        $this->assertInstanceOf($class, $newClass);
 
-        self::assertEquals((string)$existingClass, (string)$newClass);
+        $this->assertEquals((string)$existingClass, (string)$newClass);
     }
 
     /**
@@ -401,12 +401,12 @@ class ConstructTest extends TestCase
     {
         $existingClass = new \DateTimeImmutable();
         $newClass = new $class($existingClass);
-        self::assertInstanceOf($class, $newClass);
-        self::assertEquals($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
+        $this->assertInstanceOf($class, $newClass);
+        $this->assertEquals($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
 
         $existingClass = new \DateTime();
         $newClass = new $class($existingClass);
-        self::assertInstanceOf($class, $newClass);
-        self::assertEquals($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
+        $this->assertInstanceOf($class, $newClass);
+        $this->assertEquals($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
     }
 }

--- a/tests/TestCase/DateTime/ConstructTest.php
+++ b/tests/TestCase/DateTime/ConstructTest.php
@@ -168,11 +168,11 @@ class ConstructTest extends TestCase
     public function testCreateFromExistingInstance($class)
     {
         $existingClass = new $class();
-        self::assertInstanceOf($class, $existingClass);
+        $this->assertInstanceOf($class, $existingClass);
 
         $newClass = new $class($existingClass);
-        self::assertInstanceOf($class, $newClass);
-        self::assertEquals((string)$existingClass, (string)$newClass);
+        $this->assertInstanceOf($class, $newClass);
+        $this->assertEquals((string)$existingClass, (string)$newClass);
     }
 
     /**
@@ -183,11 +183,11 @@ class ConstructTest extends TestCase
     {
         $existingClass = new \DateTimeImmutable();
         $newClass = new $class($existingClass);
-        self::assertEquals($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
+        $this->assertEquals($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
         $existingClass = new \DateTime();
         $newClass = new $class($existingClass);
-        self::assertEquals($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
+        $this->assertEquals($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
         $existingClass = new \DateTime('2019-01-15 00:15:22.139302');
         $newClass = new $class($existingClass);


### PR DESCRIPTION
# Changed log

- The PHPUnit accepts two approaches about calling assertions. And there're two approaches used on this repository.
- It seems that using the `$this` to call assertion times is greater than using `self::` to call assertions.

To be consistency, it should let all PHPUnit assertion methods call to be the `$this`.