### PR TITLE
Fix PHPStan setting issue

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,4 @@ parameters:
     level: 5
     ignoreErrors:
         - '#Access to an undefined property Cake\\Chronos\\ChronosInterface::\$tz#'
-        - '#Access to private property \$days of parent class DateInterval#'
-        - '#Access to private property \$f of parent class DateInterval#'
-        - '#Access to private property \$invert of parent class DateInterval#'
-        - '#Unsafe usage of new static().#'
+        - '#Unsafe usage of new static\(\).#'


### PR DESCRIPTION
When running the PHPStan with `composer phpstan-setup` and `composer phpstan`, it will get following error message:

```
> phpstan analyze -c phpstan.neon src/
 -- --------------------------------------------------------------------------- 
     Error                                                                      
 -- --------------------------------------------------------------------------- 
     Ignored error #Unsafe usage of new static().# has an unescaped '()' which  
     leads to ignoring all errors. Use '\(\)' instead.                          
 -- --------------------------------------------------------------------------- 
 [ERROR] Found 1 error
```

- The above problem is about setting on `phpstan.neon` and it should be fixed.

After fixing above setting, it gets following message during `phpstan analyze -c phpstan.neon src/` running:

```
> phpstan analyze -c phpstan.neon src/
 21/21 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 -- -------------------------------------------------------------------------- 
     Error                                                                     
 -- -------------------------------------------------------------------------- 
     Ignored error pattern #Access to private property \$days of parent class  
     DateInterval# was not matched in reported errors.                         
     Ignored error pattern #Access to private property \$f of parent class     
     DateInterval# was not matched in reported errors.                         
     Ignored error pattern #Access to private property \$invert of parent      
     class DateInterval# was not matched in reported errors.                   
 -- -------------------------------------------------------------------------- 

 [ERROR] Found 3 errors   
```

- It should remove above settings because they're not presented on reported errors.