### PR TITLE
Replace assertEquals with assertSame

### DIFF
--- a/src/Traits/FormattingTrait.php
+++ b/src/Traits/FormattingTrait.php
@@ -233,7 +233,7 @@ trait FormattingTrait
      */
     public function toQuarter(bool $range = false)
     {
-        $quarter = ceil($this->format('m') / 3);
+        $quarter = (int)ceil($this->format('m') / 3);
         if ($range === false) {
             return $quarter;
         }

--- a/tests/TestCase/Date/AddTest.php
+++ b/tests/TestCase/Date/AddTest.php
@@ -28,12 +28,12 @@ class AddTest extends TestCase
         $date = $class::create(2001, 1, 1);
         $new = $date->add($interval);
 
-        $this->assertEquals(0, $new->hour);
-        $this->assertEquals(0, $new->minute);
-        $this->assertEquals(0, $new->second);
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
+        $this->assertSame(0, $new->hour);
+        $this->assertSame(0, $new->minute);
+        $this->assertSame(0, $new->second);
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
     }
 
     /**
@@ -45,12 +45,12 @@ class AddTest extends TestCase
         $date = $class::create(2001, 1, 1);
         $new = $date->add($interval);
 
-        $this->assertEquals(0, $new->hour);
-        $this->assertEquals(0, $new->minute);
-        $this->assertEquals(0, $new->second);
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
+        $this->assertSame(0, $new->hour);
+        $this->assertSame(0, $new->minute);
+        $this->assertSame(0, $new->second);
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
     }
 
     /**
@@ -62,12 +62,12 @@ class AddTest extends TestCase
         $date = $class::create(2001, 1, 1);
         $new = $date->sub($interval);
 
-        $this->assertEquals(0, $new->hour);
-        $this->assertEquals(0, $new->minute);
-        $this->assertEquals(0, $new->second);
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
+        $this->assertSame(0, $new->hour);
+        $this->assertSame(0, $new->minute);
+        $this->assertSame(0, $new->second);
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
     }
 
     /**
@@ -79,12 +79,12 @@ class AddTest extends TestCase
         $date = $class::create(2001, 1, 1);
         $new = $date->sub($interval);
 
-        $this->assertEquals(0, $new->hour);
-        $this->assertEquals(0, $new->minute);
-        $this->assertEquals(0, $new->second);
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
+        $this->assertSame(0, $new->hour);
+        $this->assertSame(0, $new->minute);
+        $this->assertSame(0, $new->second);
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
     }
 
     /**
@@ -92,8 +92,8 @@ class AddTest extends TestCase
      */
     public function testAddDay($class)
     {
-        $this->assertEquals(1, $class::create(1975, 5, 31)->addDays(1)->day);
-        $this->assertEquals(30, $class::create(1975, 5, 31)->addDays(-1)->day);
+        $this->assertSame(1, $class::create(1975, 5, 31)->addDays(1)->day);
+        $this->assertSame(30, $class::create(1975, 5, 31)->addDays(-1)->day);
     }
 
     /**
@@ -101,8 +101,8 @@ class AddTest extends TestCase
      */
     public function testAddMonth($class)
     {
-        $this->assertEquals(6, $class::create(1975, 5, 31)->addMonths(1)->month);
-        $this->assertEquals(4, $class::create(1975, 5, 31)->addMonths(-1)->month);
+        $this->assertSame(6, $class::create(1975, 5, 31)->addMonths(1)->month);
+        $this->assertSame(4, $class::create(1975, 5, 31)->addMonths(-1)->month);
     }
 
     /**
@@ -110,8 +110,8 @@ class AddTest extends TestCase
      */
     public function testAddYear($class)
     {
-        $this->assertEquals(1976, $class::create(1975, 5, 31)->addYears(1)->year);
-        $this->assertEquals(1974, $class::create(1975, 5, 31)->addYears(-1)->year);
+        $this->assertSame(1976, $class::create(1975, 5, 31)->addYears(1)->year);
+        $this->assertSame(1974, $class::create(1975, 5, 31)->addYears(-1)->year);
     }
 
     /**
@@ -119,7 +119,7 @@ class AddTest extends TestCase
      */
     public function testAddWeekdays($class)
     {
-        $this->assertEquals(2, $class::create(1975, 5, 31)->addWeekdays(1)->day);
-        $this->assertEquals(30, $class::create(1975, 5, 31)->addWeekdays(-1)->day);
+        $this->assertSame(2, $class::create(1975, 5, 31)->addWeekdays(1)->day);
+        $this->assertSame(30, $class::create(1975, 5, 31)->addWeekdays(-1)->day);
     }
 }

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -32,12 +32,12 @@ class ConstructTest extends TestCase
     public function testCreateFromEmpty($class)
     {
         $c = $class::parse(null);
-        $this->assertEquals('00:00:00', $c->format('H:i:s'));
-        $this->assertEquals(date_default_timezone_get(), $c->tzName);
+        $this->assertSame('00:00:00', $c->format('H:i:s'));
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         $c = $class::parse('');
-        $this->assertEquals('00:00:00', $c->format('H:i:s'));
-        $this->assertEquals(date_default_timezone_get(), $c->tzName);
+        $this->assertSame('00:00:00', $c->format('H:i:s'));
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -49,12 +49,12 @@ class ConstructTest extends TestCase
         $class::setTestNow($class::create(2001, 1, 1));
 
         $c = $class::parse(null);
-        $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertEquals(date_default_timezone_get(), $c->tzName);
+        $this->assertSame('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         $c = $class::parse('');
-        $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertEquals(date_default_timezone_get(), $c->tzName);
+        $this->assertSame('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
     /**
@@ -67,8 +67,8 @@ class ConstructTest extends TestCase
             $ts = 1454284800;
             $date = $class::createFromTimestamp($ts);
 
-            $this->assertEquals('Europe/Berlin', $date->tzName);
-            $this->assertEquals('2016-02-01', $date->format('Y-m-d'));
+            $this->assertSame('Europe/Berlin', $date->tzName);
+            $this->assertSame('2016-02-01', $date->format('Y-m-d'));
         });
     }
 
@@ -125,10 +125,10 @@ class ConstructTest extends TestCase
     public function testParseWithMicroSeconds($class)
     {
         $date = $class::parse('2016-12-08 18:06:46.510954');
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->second);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->micro);
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->second);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->micro);
     }
 
     /**
@@ -224,10 +224,10 @@ class ConstructTest extends TestCase
     public function testConstructWithTimeParts($time)
     {
         $dt = new Date($time);
-        $this->assertEquals(8, $dt->month);
-        $this->assertEquals(0, $dt->hour);
-        $this->assertEquals(0, $dt->minute);
-        $this->assertEquals(0, $dt->second);
+        $this->assertSame(8, $dt->month);
+        $this->assertSame(0, $dt->hour);
+        $this->assertSame(0, $dt->minute);
+        $this->assertSame(0, $dt->second);
     }
 
     /**
@@ -237,10 +237,10 @@ class ConstructTest extends TestCase
     public function testConstructMutableWithTimeParts($time)
     {
         $dt = new MutableDate($time);
-        $this->assertEquals(8, $dt->month);
-        $this->assertEquals(0, $dt->hour);
-        $this->assertEquals(0, $dt->minute);
-        $this->assertEquals(0, $dt->second);
+        $this->assertSame(8, $dt->month);
+        $this->assertSame(0, $dt->hour);
+        $this->assertSame(0, $dt->minute);
+        $this->assertSame(0, $dt->second);
     }
 
     /**
@@ -276,13 +276,13 @@ class ConstructTest extends TestCase
     public function testConstructWithRelative($class)
     {
         $c = new $class('+7 days');
-        $this->assertEquals('00:00:00', $c->format('H:i:s'));
+        $this->assertSame('00:00:00', $c->format('H:i:s'));
 
         $c = new $class('+10 minutes');
-        $this->assertEquals('00:00:00', $c->format('H:i:s'));
+        $this->assertSame('00:00:00', $c->format('H:i:s'));
 
         $c = new $class('2001-01-01 +7 days');
-        $this->assertEquals('2001-01-08', $c->format('Y-m-d'));
+        $this->assertSame('2001-01-08', $c->format('Y-m-d'));
     }
 
     /**
@@ -296,26 +296,26 @@ class ConstructTest extends TestCase
         // This test could have different results depending on when now is
         $c = new $class('now', $londonTimezone);
         $london = new DateTimeImmutable('now', $londonTimezone);
-        $this->assertEquals($london->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame($london->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // now adjusted to London time
         $c = $class::today($londonTimezone);
-        $this->assertEquals(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
 
         // London timezone is used instead of local timezone
         $c = new $class('2001-01-02 01:00:00', $londonTimezone);
-        $this->assertEquals('2001-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('2001-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // London timezone is ignored when timezone is provided in time string
         $c = new $class('2001-01-01 23:00:00-400', $londonTimezone);
-        $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // London timezone is ignored when DateTimeInterface instance is provided
         $c = new $class(new DateTimeImmutable('2001-01-01 23:00:00-400'), $londonTimezone);
-        $this->assertEquals('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
@@ -330,29 +330,29 @@ class ConstructTest extends TestCase
 
         // TestNow is adjusted to London time
         $c = new $class('now', $londonTimezone);
-        $this->assertEquals('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
         $c = new $class('+2 days', $londonTimezone);
-        $this->assertEquals('2010-01-04 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('2010-01-04 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
         $c = $class::today($londonTimezone);
-        $this->assertEquals('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertEquals(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
         $c = $class::tomorrow($londonTimezone);
-        $this->assertEquals('2010-01-03 00:00:00', $c->format('Y-m-d H:i:s'));
-        $this->assertEquals(Chronos::tomorrow($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame('2010-01-03 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame(Chronos::tomorrow($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is ignored when specific date is provided
         $c = new $class('2001-01-05 01:00:00', $londonTimezone);
-        $this->assertEquals('2001-01-05 00:00:00', $c->format('Y-m-d H:i:s'));
+        $this->assertSame('2001-01-05 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
@@ -373,7 +373,7 @@ class ConstructTest extends TestCase
         // Pacific/Samoa -11:00 is used intead of local timezone +14:00
         $c = $class::today($samoaTimezone);
         $Samoa = new DateTimeImmutable('now', $samoaTimezone);
-        $this->assertEquals($Samoa->format('Y-m-d'), $c->format('Y-m-d'));
+        $this->assertSame($Samoa->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         date_default_timezone_set($savedTz);
@@ -390,7 +390,7 @@ class ConstructTest extends TestCase
         $newClass = new $class($existingClass);
         $this->assertInstanceOf($class, $newClass);
 
-        $this->assertEquals((string)$existingClass, (string)$newClass);
+        $this->assertSame((string)$existingClass, (string)$newClass);
     }
 
     /**
@@ -402,11 +402,11 @@ class ConstructTest extends TestCase
         $existingClass = new \DateTimeImmutable();
         $newClass = new $class($existingClass);
         $this->assertInstanceOf($class, $newClass);
-        $this->assertEquals($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
+        $this->assertSame($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
 
         $existingClass = new \DateTime();
         $newClass = new $class($existingClass);
         $this->assertInstanceOf($class, $newClass);
-        $this->assertEquals($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
+        $this->assertSame($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
     }
 }

--- a/tests/TestCase/Date/TimeMutateTest.php
+++ b/tests/TestCase/Date/TimeMutateTest.php
@@ -42,12 +42,12 @@ class TimeMutateTest extends TestCase
         $date = new Date();
         $new = $date->modify($value);
 
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
-        $this->assertEquals(0, $new->hour);
-        $this->assertEquals(0, $new->minute);
-        $this->assertEquals(0, $new->second);
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
+        $this->assertSame(0, $new->hour);
+        $this->assertSame(0, $new->minute);
+        $this->assertSame(0, $new->second);
     }
 
     /**
@@ -77,14 +77,14 @@ class TimeMutateTest extends TestCase
     {
         $date = new Date();
         $new = $date->{$method}($value);
-        $this->assertEquals(0, $new->hour);
-        $this->assertEquals(0, $new->minute);
-        $this->assertEquals(0, $new->second);
-        $this->assertEquals(0, $new->format('u'));
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
-        $this->assertEquals(0, $date->format('u'));
+        $this->assertSame(0, $new->hour);
+        $this->assertSame(0, $new->minute);
+        $this->assertSame(0, $new->second);
+        $this->assertSame('000000', $new->format('u'));
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
+        $this->assertSame('000000', $date->format('u'));
     }
 
     /**
@@ -94,14 +94,14 @@ class TimeMutateTest extends TestCase
     {
         $date = new Date();
         $new = $date->setTime(1, 2, 3, 4);
-        $this->assertEquals(0, $new->hour);
-        $this->assertEquals(0, $new->minute);
-        $this->assertEquals(0, $new->second);
-        $this->assertEquals(0, $new->format('u'));
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
-        $this->assertEquals(0, $date->format('u'));
+        $this->assertSame(0, $new->hour);
+        $this->assertSame(0, $new->minute);
+        $this->assertSame(0, $new->second);
+        $this->assertSame('000000', $new->format('u'));
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
+        $this->assertSame('000000', $date->format('u'));
     }
 
     /**
@@ -113,72 +113,72 @@ class TimeMutateTest extends TestCase
     {
         $date = new Date();
         $date->setTimestamp(strtotime('+2 hours +2 minutes'));
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
 
         $date = new Date();
         $date->timestamp(strtotime('+2 hours +2 minutes'));
-        $this->assertEquals(0, $date->hour);
-        $this->assertEquals(0, $date->minute);
-        $this->assertEquals(0, $date->second);
+        $this->assertSame(0, $date->hour);
+        $this->assertSame(0, $date->minute);
+        $this->assertSame(0, $date->second);
     }
 
     public function testStartOfDay()
     {
         $date = new Date();
-        $this->assertEquals('00:00:00', $date->startOfDay()->format('H:i:s'));
+        $this->assertSame('00:00:00', $date->startOfDay()->format('H:i:s'));
     }
 
     public function testEndOfDay()
     {
         $date = Date::create(2001, 1, 1);
         $new = $date->endOfDay();
-        $this->assertEquals('00:00:00', $new->format('H:i:s'));
-        $this->assertEquals('2001-01-01', $new->format('Y-m-d'));
+        $this->assertSame('00:00:00', $new->format('H:i:s'));
+        $this->assertSame('2001-01-01', $new->format('Y-m-d'));
     }
 
     public function testEndOfMonth()
     {
         $date = Date::create(2001, 1, 1);
         $new = $date->endOfMonth();
-        $this->assertEquals('00:00:00', $new->format('H:i:s'));
-        $this->assertEquals('2001-01-31', $new->format('Y-m-d'));
+        $this->assertSame('00:00:00', $new->format('H:i:s'));
+        $this->assertSame('2001-01-31', $new->format('Y-m-d'));
     }
 
     public function testEndOfYear()
     {
         $date = Date::create(2001, 1, 1);
         $new = $date->endOfYear();
-        $this->assertEquals('00:00:00', $new->format('H:i:s'));
-        $this->assertEquals('2001-12-31', $new->format('Y-m-d'));
+        $this->assertSame('00:00:00', $new->format('H:i:s'));
+        $this->assertSame('2001-12-31', $new->format('Y-m-d'));
     }
 
     public function testEndOfDecade()
     {
         $date = Date::create(2001, 1, 1);
         $new = $date->endOfDecade();
-        $this->assertEquals('00:00:00', $new->format('H:i:s'));
-        $this->assertEquals('2009-12-31', $new->format('Y-m-d'));
+        $this->assertSame('00:00:00', $new->format('H:i:s'));
+        $this->assertSame('2009-12-31', $new->format('Y-m-d'));
     }
 
     public function testEndOfCentury()
     {
         $date = Date::create(2001, 1, 1);
         $new = $date->endOfCentury();
-        $this->assertEquals('00:00:00', $new->format('H:i:s'));
-        $this->assertEquals('2100-12-31', $new->format('Y-m-d'));
+        $this->assertSame('00:00:00', $new->format('H:i:s'));
+        $this->assertSame('2100-12-31', $new->format('Y-m-d'));
     }
 
     public function testNextAndPrev()
     {
         $date = Date::create(2001, 1, 1);
         $new = $date->next(3);
-        $this->assertEquals('00:00:00', $new->format('H:i:s'));
-        $this->assertEquals('2001-01-03', $new->format('Y-m-d'));
+        $this->assertSame('00:00:00', $new->format('H:i:s'));
+        $this->assertSame('2001-01-03', $new->format('Y-m-d'));
 
         $new = $date->previous(1);
-        $this->assertEquals('00:00:00', $new->format('H:i:s'));
-        $this->assertEquals('2000-12-25', $new->format('Y-m-d'));
+        $this->assertSame('00:00:00', $new->format('H:i:s'));
+        $this->assertSame('2000-12-25', $new->format('Y-m-d'));
     }
 }

--- a/tests/TestCase/DateTime/ComparisonTest.php
+++ b/tests/TestCase/DateTime/ComparisonTest.php
@@ -27,11 +27,11 @@ class ComparisonTest extends TestCase
     public function testGetSetWeekendDays($class)
     {
         $expected = [ChronosInterface::SATURDAY, ChronosInterface::SUNDAY];
-        $this->assertEquals($expected, $class::getWeekendDays());
+        $this->assertSame($expected, $class::getWeekendDays());
 
         $replace = [ChronosInterface::SUNDAY];
         $class::setWeekendDays($replace);
-        $this->assertEquals($replace, $class::getWeekendDays());
+        $this->assertSame($replace, $class::getWeekendDays());
 
         $class::setWeekendDays($expected);
     }
@@ -466,7 +466,7 @@ class ComparisonTest extends TestCase
         $dt1 = $class::create(2015, 5, 28, 11, 0, 0);
         $dt2 = $class::create(2015, 5, 28, 14, 0, 0);
         $closest = $instance->closest($dt1, $dt2);
-        $this->assertEquals($dt1, $closest);
+        $this->assertSame($dt1, $closest);
     }
 
     /**
@@ -479,7 +479,7 @@ class ComparisonTest extends TestCase
         $dt1 = $class::create(2015, 5, 28, 12, 0, 0);
         $dt2 = $class::create(2015, 5, 28, 14, 0, 0);
         $closest = $instance->closest($dt1, $dt2);
-        $this->assertEquals($dt1, $closest);
+        $this->assertSame($dt1, $closest);
     }
 
     /**
@@ -492,7 +492,7 @@ class ComparisonTest extends TestCase
         $dt1 = $class::create(2015, 5, 28, 11, 0, 0);
         $dt2 = $class::create(2015, 5, 28, 14, 0, 0);
         $Farthest = $instance->farthest($dt1, $dt2);
-        $this->assertEquals($dt2, $Farthest);
+        $this->assertSame($dt2, $Farthest);
     }
 
     /**
@@ -505,6 +505,6 @@ class ComparisonTest extends TestCase
         $dt1 = $class::create(2015, 5, 28, 12, 0, 0);
         $dt2 = $class::create(2015, 5, 28, 14, 0, 0);
         $Farthest = $instance->farthest($dt1, $dt2);
-        $this->assertEquals($dt2, $Farthest);
+        $this->assertSame($dt2, $Farthest);
     }
 }

--- a/tests/TestCase/DateTime/ConstructTest.php
+++ b/tests/TestCase/DateTime/ConstructTest.php
@@ -172,7 +172,7 @@ class ConstructTest extends TestCase
 
         $newClass = new $class($existingClass);
         $this->assertInstanceOf($class, $newClass);
-        $this->assertEquals((string)$existingClass, (string)$newClass);
+        $this->assertSame((string)$existingClass, (string)$newClass);
     }
 
     /**
@@ -183,11 +183,11 @@ class ConstructTest extends TestCase
     {
         $existingClass = new \DateTimeImmutable();
         $newClass = new $class($existingClass);
-        $this->assertEquals($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
+        $this->assertSame($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
         $existingClass = new \DateTime();
         $newClass = new $class($existingClass);
-        $this->assertEquals($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
+        $this->assertSame($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
         $existingClass = new \DateTime('2019-01-15 00:15:22.139302');
         $newClass = new $class($existingClass);

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -745,7 +745,7 @@ class DiffTest extends TestCase
             ->modify('-51 seconds');
         $interval = $class::fromNow($date);
         $result = $interval->format('%y %m %d %H %i %s');
-        $this->assertEquals($result, '1 0 6 00 0 51');
+        $this->assertSame($result, '1 0 6 00 0 51');
     }
 
     public function diffForHumansProvider()

--- a/tests/TestCase/DateTime/MutabilityTest.php
+++ b/tests/TestCase/DateTime/MutabilityTest.php
@@ -24,13 +24,13 @@ class MutabilityTest extends TestCase
     {
         $dt1 = MutableDateTime::createFromDate(2000, 1, 1);
         $dt2 = $dt1->addDay();
-        $this->assertEquals($dt1, $dt2);
+        $this->assertSame($dt1, $dt2);
     }
 
     public function testSet()
     {
         $dt1 = MutableDateTime::createFromDate(2000, 1, 1);
         $dt2 = $dt1->setDateTime(2001, 2, 2, 10, 20, 30);
-        $this->assertEquals($dt1, $dt2);
+        $this->assertSame($dt1, $dt2);
     }
 }

--- a/tests/TestCase/DateTime/SettersTest.php
+++ b/tests/TestCase/DateTime/SettersTest.php
@@ -121,13 +121,13 @@ class SettersTest extends TestCase
     public function testSetDateAfterStringCreation()
     {
         $d = new MutableDateTime('first day of this month');
-        $this->assertEquals(1, $d->day);
+        $this->assertSame(1, $d->day);
         $d->setDate($d->year, $d->month, 12);
-        $this->assertEquals(12, $d->day);
+        $this->assertSame(12, $d->day);
 
         $d = new Chronos('first day of this month');
-        $this->assertEquals(1, $d->day);
-        $this->assertEquals(12, $d->setDate($d->year, $d->month, 12)->day);
+        $this->assertSame(1, $d->day);
+        $this->assertSame(12, $d->setDate($d->year, $d->month, 12)->day);
     }
 
     public function testDateTimeSetter()

--- a/tests/TestCase/DateTime/StringsTest.php
+++ b/tests/TestCase/DateTime/StringsTest.php
@@ -236,10 +236,10 @@ class StringsTest extends TestCase
     public function testToUnixString($class)
     {
         $time = $class::parse('2014-04-20 08:00:00');
-        $this->assertEquals('1397995200', $time->toUnixString());
+        $this->assertSame('1397995200', $time->toUnixString());
 
         $time = $class::parse('2021-12-11 07:00:01');
-        $this->assertEquals('1639224001', $time->toUnixString());
+        $this->assertSame('1639224001', $time->toUnixString());
     }
 
     /**
@@ -268,7 +268,7 @@ class StringsTest extends TestCase
      */
     public function testToQuarter($date, $expected, $range = false)
     {
-        $this->assertEquals($expected, (new Chronos($date))->toQuarter($range));
+        $this->assertSame($expected, (new Chronos($date))->toQuarter($range));
     }
 
     /**
@@ -294,6 +294,6 @@ class StringsTest extends TestCase
      */
     public function testToWeek($date, $expected)
     {
-        $this->assertEquals($expected, (new Chronos($date))->toWeek());
+        $this->assertSame($expected, (new Chronos($date))->toWeek());
     }
 }

--- a/tests/TestCase/DateTime/TestingAidsTest.php
+++ b/tests/TestCase/DateTime/TestingAidsTest.php
@@ -46,7 +46,7 @@ class TestingAidsTest extends TestCase
         $class::setTestNow($notNow);
 
         $this->assertTrue($class::hasTestNow());
-        $this->assertEquals($notNow, $class::getTestNow());
+        $this->assertSame($notNow, $class::getTestNow());
     }
 
     /**
@@ -57,7 +57,7 @@ class TestingAidsTest extends TestCase
     {
         $class::setTestNow('2016-11-23');
         $this->assertTrue($class::hasTestNow());
-        $this->assertEquals($class::getTestNow(), $class::parse('2016-11-23'));
+        $this->assertSame((string)$class::getTestNow(), (string)$class::parse('2016-11-23'));
     }
 
     /**
@@ -69,10 +69,10 @@ class TestingAidsTest extends TestCase
         $notNow = $class::yesterday();
         $class::setTestNow($notNow);
 
-        $this->assertEquals($notNow, new $class());
-        $this->assertEquals($notNow, new $class(null));
-        $this->assertEquals($notNow, new $class(''));
-        $this->assertEquals($notNow, new $class('now'));
+        $this->assertSame((string)$notNow, (string)new $class());
+        $this->assertSame((string)$notNow, (string)new $class(null));
+        $this->assertSame((string)$notNow, (string)new $class(''));
+        $this->assertSame((string)$notNow, (string)new $class('now'));
     }
 
     /**
@@ -84,7 +84,7 @@ class TestingAidsTest extends TestCase
         $notNow = $class::yesterday();
         $class::setTestNow($notNow);
 
-        $this->assertEquals($notNow, $class::now());
+        $this->assertSame((string)$notNow, (string)$class::now());
     }
 
     /**
@@ -137,10 +137,10 @@ class TestingAidsTest extends TestCase
         $notNow = $class::yesterday();
         $class::setTestNow($notNow);
 
-        $this->assertEquals($notNow, $class::parse());
-        $this->assertEquals($notNow, $class::parse(null));
-        $this->assertEquals($notNow, $class::parse(''));
-        $this->assertEquals($notNow, $class::parse('now'));
+        $this->assertSame((string)$notNow, (string)$class::parse());
+        $this->assertSame((string)$notNow, (string)$class::parse(null));
+        $this->assertSame((string)$notNow, (string)$class::parse(''));
+        $this->assertSame((string)$notNow, (string)$class::parse('now'));
     }
 
     /**
@@ -271,9 +271,9 @@ class TestingAidsTest extends TestCase
         $class::setTestNow($c);
 
         $result = new $class('now', null);
-        $this->assertEquals(new DateTimeZone('America/Toronto'), $result->tz);
-        $this->assertEquals('2015-12-31 18:00:00', $result->format('Y-m-d H:i:s'));
-        $this->assertEquals(new DateTimeZone('Europe/Copenhagen'), $class::getTestNow()->tz);
+        $this->assertSame((new DateTimeZone('America/Toronto'))->getName(), $result->tz->getName());
+        $this->assertSame('2015-12-31 18:00:00', $result->format('Y-m-d H:i:s'));
+        $this->assertSame((new DateTimeZone('Europe/Copenhagen'))->getName(), $class::getTestNow()->tz->getName());
     }
 
     /**
@@ -287,9 +287,9 @@ class TestingAidsTest extends TestCase
         $c = new $class('2016-01-03 00:00:00', 'Europe/Copenhagen');
         $class::setTestNow($c);
 
-        $this->assertEquals($c, MutableDate::getTestNow());
-        $this->assertEquals($c, Date::getTestNow());
-        $this->assertEquals($c, Chronos::getTestNow());
-        $this->assertEquals($c, MutableDateTime::getTestNow());
+        $this->assertSame($c, MutableDate::getTestNow());
+        $this->assertSame($c, Date::getTestNow());
+        $this->assertSame($c, Chronos::getTestNow());
+        $this->assertSame($c, MutableDateTime::getTestNow());
     }
 }

--- a/tests/TestCase/DebugInfoTest.php
+++ b/tests/TestCase/DebugInfoTest.php
@@ -24,62 +24,62 @@ class DebugInfoTest extends TestCase
     public function testDateTime()
     {
         $expected = [
+            'hasFixedNow' => false,
             'time' => '2001-02-03 10:20:30.000000',
             'timezone' => 'America/Toronto',
-            'hasFixedNow' => false,
         ];
 
         $chronos = Chronos::create(2001, 2, 3, 10, 20, 30);
-        $this->assertEquals($expected, $chronos->__debugInfo());
+        $this->assertSame($expected, $chronos->__debugInfo());
 
         $mutable = MutableDateTime::create(2001, 2, 3, 10, 20, 30);
-        $this->assertEquals($expected, $mutable->__debugInfo());
+        $this->assertSame($expected, $mutable->__debugInfo());
     }
 
     public function testDate()
     {
         $expected = [
-            'date' => '2001-02-03',
             'hasFixedNow' => false,
+            'date' => '2001-02-03',
         ];
 
         $date = Date::create(2001, 2, 3, 10, 20, 30);
-        $this->assertEquals($expected, $date->__debugInfo());
+        $this->assertSame($expected, $date->__debugInfo());
 
         $mutable = MutableDate::create(2001, 2, 3, 10, 20, 30);
-        $this->assertEquals($expected, $mutable->__debugInfo());
+        $this->assertSame($expected, $mutable->__debugInfo());
     }
 
     public function testDateTimeWithNow()
     {
         $expected = [
+            'hasFixedNow' => true,
             'time' => '2001-02-03 10:20:30.000000',
             'timezone' => 'America/Toronto',
-            'hasFixedNow' => true,
         ];
 
         Chronos::setTestNow(Chronos::now());
         $chronos = Chronos::create(2001, 2, 3, 10, 20, 30);
-        $this->assertEquals($expected, $chronos->__debugInfo());
+        $this->assertSame($expected, $chronos->__debugInfo());
 
         MutableDateTime::setTestNow(Chronos::now());
         $mutable = MutableDateTime::create(2001, 2, 3, 10, 20, 30);
-        $this->assertEquals($expected, $mutable->__debugInfo());
+        $this->assertSame($expected, $mutable->__debugInfo());
     }
 
     public function testDateWithNow()
     {
         $expected = [
-            'date' => '2001-02-03',
             'hasFixedNow' => true,
+            'date' => '2001-02-03',
         ];
 
         Date::setTestNow(Chronos::now());
         $date = Date::create(2001, 2, 3, 10, 20, 30);
-        $this->assertEquals($expected, $date->__debugInfo());
+        $this->assertSame($expected, $date->__debugInfo());
 
         MutableDate::setTestNow(Chronos::now());
         $mutable = MutableDate::create(2001, 2, 3, 10, 20, 30);
-        $this->assertEquals($expected, $mutable->__debugInfo());
+        $this->assertSame($expected, $mutable->__debugInfo());
     }
 }

--- a/tests/TestCase/Interval/IntervalToStringTest.php
+++ b/tests/TestCase/Interval/IntervalToStringTest.php
@@ -24,13 +24,13 @@ class IntervalToStringTest extends TestCase
     public function testZeroInterval()
     {
         $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0);
-        $this->assertEquals('PT0S', (string)$ci);
+        $this->assertSame('PT0S', (string)$ci);
     }
 
     public function testNegativeArguments()
     {
         $ci = new ChronosInterval(1, -2, 0, 15);
-        $this->assertEquals('P1Y15D', (string)$ci, 'Negative arguments are not considered');
+        $this->assertSame('P1Y15D', (string)$ci, 'Negative arguments are not considered');
     }
 
     /**
@@ -44,11 +44,11 @@ class IntervalToStringTest extends TestCase
         $ci3 = new ChronosInterval(0, 0, 0, 365);
         $ci4 = new ChronosInterval(0, 0, 52, 1);
 
-        $this->assertEquals('P1Y', (string)$ci);
-        $this->assertEquals('P1Y', (string)$ci1);
-        $this->assertEquals('P1Y', (string)$ci2);
-        $this->assertEquals('P1Y', (string)$ci3);
-        $this->assertEquals('P1Y', (string)$ci4);
+        $this->assertSame('P1Y', (string)$ci);
+        $this->assertSame('P1Y', (string)$ci1);
+        $this->assertSame('P1Y', (string)$ci2);
+        $this->assertSame('P1Y', (string)$ci3);
+        $this->assertSame('P1Y', (string)$ci4);
     }
 
     public function testMonthInterval()
@@ -57,9 +57,9 @@ class IntervalToStringTest extends TestCase
         $ci2 = new ChronosInterval(0, 0, 0, 30, 10);
         $ci3 = new ChronosInterval(0, 0, 4, 2, 10);
 
-        $this->assertEquals('P1M', (string)$ci1);
-        $this->assertEquals('P1M', (string)$ci2);
-        $this->assertEquals('P1M', (string)$ci3);
+        $this->assertSame('P1M', (string)$ci1);
+        $this->assertSame('P1M', (string)$ci2);
+        $this->assertSame('P1M', (string)$ci3);
     }
 
     public function testWeekInterval()
@@ -69,10 +69,10 @@ class IntervalToStringTest extends TestCase
         $ci3 = new ChronosInterval(0, 0, 0, 0, 7 * 24);
         $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 7 * 24 * 60);
 
-        $this->assertEquals('P7D', (string)$ci1);
-        $this->assertEquals('P7D', (string)$ci2);
-        $this->assertEquals('P7D', (string)$ci3);
-        $this->assertEquals('P7D', (string)$ci4);
+        $this->assertSame('P7D', (string)$ci1);
+        $this->assertSame('P7D', (string)$ci2);
+        $this->assertSame('P7D', (string)$ci3);
+        $this->assertSame('P7D', (string)$ci4);
     }
 
     public function testDayInterval()
@@ -82,18 +82,18 @@ class IntervalToStringTest extends TestCase
         $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 24 * 60);
         $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 0, 24 * 60 * 60);
 
-        $this->assertEquals('P1D', (string)$ci1);
-        $this->assertEquals('P1D', (string)$ci2);
-        $this->assertEquals('P1D', (string)$ci3);
-        $this->assertEquals('P1D', (string)$ci4);
+        $this->assertSame('P1D', (string)$ci1);
+        $this->assertSame('P1D', (string)$ci2);
+        $this->assertSame('P1D', (string)$ci3);
+        $this->assertSame('P1D', (string)$ci4);
     }
 
     public function testMixedDateInterval()
     {
         $ci1 = new ChronosInterval(1, 2, 0, 3);
         $ci2 = new ChronosInterval(0, 14, 0, 3);
-        $this->assertEquals('P1Y2M3D', (string)$ci1);
-        $this->assertEquals('P1Y2M3D', (string)$ci2);
+        $this->assertSame('P1Y2M3D', (string)$ci1);
+        $this->assertSame('P1Y2M3D', (string)$ci2);
     }
 
     /**
@@ -105,9 +105,9 @@ class IntervalToStringTest extends TestCase
         $ci2 = new ChronosInterval(0, 0, 0, 0, 0, 60);
         $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 0, 3600);
 
-        $this->assertEquals('PT1H', (string)$ci1);
-        $this->assertEquals('PT1H', (string)$ci2);
-        $this->assertEquals('PT1H', (string)$ci3);
+        $this->assertSame('PT1H', (string)$ci1);
+        $this->assertSame('PT1H', (string)$ci2);
+        $this->assertSame('PT1H', (string)$ci3);
     }
 
     public function testMinuteInterval()
@@ -115,21 +115,21 @@ class IntervalToStringTest extends TestCase
         $ci1 = new ChronosInterval(0, 0, 0, 0, 0, 1);
         $ci2 = new ChronosInterval(0, 0, 0, 0, 0, 0, 60);
 
-        $this->assertEquals('PT1M', (string)$ci1);
-        $this->assertEquals('PT1M', (string)$ci2);
+        $this->assertSame('PT1M', (string)$ci1);
+        $this->assertSame('PT1M', (string)$ci2);
     }
 
     public function testSecondInterval()
     {
         $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 1);
 
-        $this->assertEquals('PT1S', (string)$ci);
+        $this->assertSame('PT1S', (string)$ci);
     }
 
     public function testMixedTimeInterval()
     {
         $ci = new ChronosInterval(0, 0, 0, 0, 1, 2, 3);
-        $this->assertEquals('PT1H2M3S', (string)$ci);
+        $this->assertSame('PT1H2M3S', (string)$ci);
     }
 
     /**
@@ -140,16 +140,16 @@ class IntervalToStringTest extends TestCase
         $ci1 = new ChronosInterval(0, 0, 0, 0, 48, 120);
         $ci2 = new ChronosInterval(0, 24, 0, 0, 48, 120);
 
-        $this->assertEquals('P2DT2H', (string)$ci1);
-        $this->assertEquals('P2Y2DT2H', (string)$ci2);
+        $this->assertSame('P2DT2H', (string)$ci1);
+        $this->assertSame('P2Y2DT2H', (string)$ci2);
     }
 
     public function testCreatingInstanceEquals()
     {
         $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
-        $this->assertEquals(
-            $ci,
-            ChronosInterval::instance(new DateInterval((string)$ci))
+        $this->assertSame(
+            (string)$ci,
+            (string)ChronosInterval::instance(new DateInterval((string)$ci))
         );
     }
 
@@ -157,6 +157,6 @@ class IntervalToStringTest extends TestCase
     {
         $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
         $ci->invert = 1;
-        $this->assertEquals('-P1Y2M3DT4H5M6S', (string)$ci);
+        $this->assertSame('-P1Y2M3DT4H5M6S', (string)$ci);
     }
 }


### PR DESCRIPTION
# Changed log

- It's related to this [comment](https://github.com/cakephp/chronos/pull/267#issuecomment-673383878).
- Using the `assertSame` assertion to replace `assertEquals` and it makes all value equal checking strictly.
  - When using the `assertSame`, it cannot assert the different objects are same strictly.
  - To resolve above this issue, it should cast object to string and assert their strings are same.