### PR TITLE
Add diff() that ignores timezone

### DIFF
--- a/src/Traits/DifferenceTrait.php
+++ b/src/Traits/DifferenceTrait.php
@@ -19,7 +19,9 @@ use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\DifferenceFormatter;
 use Cake\Chronos\DifferenceFormatterInterface;
 use DatePeriod;
+use DateTime;
 use DateTimeInterface;
+use DateTimeZone;
 
 /**
  * Provides methods for getting differences between datetime objects.
@@ -38,6 +40,31 @@ trait DifferenceTrait
      * @var \Cake\Chronos\DifferenceFormatterInterface
      */
     protected static $diffFormatter;
+
+    /**
+     * Peforms a `diff()` without adjusting for timezone.
+     *
+     * The normal `diff()` will convert all times to UTC before comparing which can
+     * result in day and month calculations to be different than in the original timezone.
+     *
+     * @param \Cake\Chronos\ChronosInterface $dt The target instance
+     * @param bool $abs Get the absolute difference
+     * @return false|\DateInterval
+     */
+    public function diffIgnoreTimezone(ChronosInterface $dt, bool $abs = true)
+    {
+        $utcTz = new DateTimeZone('UTC');
+
+        $source = $this;
+        if ($this->getTimezone()->getName() !== 'UTC') {
+            $source = new DateTime($this->format('Y-m-d H:i:s.u'), $utcTz);
+        }
+        if ($dt->getTimezone()->getName() !== 'UTC') {
+            $dt = new DateTime($dt->format('Y-m-d H:i:s.u'), $utcTz);
+        }
+
+        return $source->diff($dt, $abs);
+    }
 
     /**
      * Get the difference in years

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -30,6 +30,25 @@ class DiffTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
+    public function testDiffIgnoreTimezone($class)
+    {
+        $source = $class::createFromDate(2019, 06, 01, 'Asia/Tokyo');
+        $target = $class::createFromDate(2019, 10, 01, 'Asia/Tokyo');
+        $this->assertSame(4, $source->diffIgnoreTimezone($target)->m);
+
+        $source = $class::createFromDate(2019, 06, 01, 'UTC');
+        $target = $class::createFromDate(2019, 10, 01, 'UTC');
+        $this->assertSame(4, $source->diffIgnoreTimezone($target)->m);
+
+        $source = $class::createFromDate(2019, 06, 01, 'UTC');
+        $target = $class::createFromDate(2019, 10, 01, 'Asia/Tokyo');
+        $this->assertSame(4, $source->diffIgnoreTimezone($target)->m);
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
     public function testDiffInYearsPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);


### PR DESCRIPTION
Closes https://github.com/cakephp/chronos/issues/253

`DateTime::diff()` converts all dates to UTC before performing the diff. That means any timezone changes that change the date will change the diff calculation.

This allows the user to perform a diff in the timezone of the DateTime instance. To avoid complicated scenarios, both instances are assumed to be in the correct timezone. They will not be converted first.

@chinpei215 