### PR TITLE
Add diffInMonthsIgnoreTimezone()

### DIFF
--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -30,25 +30,6 @@ class DiffTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
-    public function testDiffIgnoreTimezone($class)
-    {
-        $source = $class::createFromDate(2019, 06, 01, 'Asia/Tokyo');
-        $target = $class::createFromDate(2019, 10, 01, 'Asia/Tokyo');
-        $this->assertSame(4, $source->diffIgnoreTimezone($target)->m);
-
-        $source = $class::createFromDate(2019, 06, 01, 'UTC');
-        $target = $class::createFromDate(2019, 10, 01, 'UTC');
-        $this->assertSame(4, $source->diffIgnoreTimezone($target)->m);
-
-        $source = $class::createFromDate(2019, 06, 01, 'UTC');
-        $target = $class::createFromDate(2019, 10, 01, 'Asia/Tokyo');
-        $this->assertSame(4, $source->diffIgnoreTimezone($target)->m);
-    }
-
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
     public function testDiffInYearsPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
@@ -145,6 +126,29 @@ class DiffTest extends TestCase
     {
         $dt = $class::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInMonths($dt->copy()->addMonth()->addDays(16)));
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
+    public function testDiffInMonthsIgnoreTimezone($class)
+    {
+        $source = $class::createFromDate(2019, 06, 01, 'Asia/Tokyo');
+        $target = $class::createFromDate(2019, 10, 01, 'Asia/Tokyo');
+        $this->assertSame(4, $source->diffInMonthsIgnoreTimezone($target));
+
+        $source = $class::createFromDate(2019, 06, 01, 'UTC');
+        $target = $class::createFromDate(2019, 10, 01, 'UTC');
+        $this->assertSame(4, $source->diffInMonthsIgnoreTimezone($target));
+
+        $source = $class::createFromDate(2019, 06, 01, 'UTC');
+        $target = $class::createFromDate(2019, 10, 01, 'Asia/Tokyo');
+        $this->assertSame(4, $source->diffInMonthsIgnoreTimezone($target));
+
+        $this->wrapWithTestNow(function () use ($class) {
+            $this->assertSame(1, $class::now()->subMonth()->startOfMonth()->diffInMonthsIgnoreTimezone());
+        });
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/cakephp/chronos/issues/253

This merges the original `diffIgnoreTimezone()` into just `diffInMonthsIgnoreTimezone()` because that's the only place this is really used. Adding `IgnoreTimezone` wrappers to all the other diffs doesn't make much sense as we can't really describe a difference.

@chinpei215 