### PR TITLE
Add link annotations to RFCs

### DIFF
--- a/src/Traits/FormattingTrait.php
+++ b/src/Traits/FormattingTrait.php
@@ -139,6 +139,7 @@ trait FormattingTrait
      * Format the instance as RFC822
      *
      * @return string
+     * @link https://tools.ietf.org/html/rfc822
      */
     public function toRfc822String(): string
     {
@@ -149,6 +150,7 @@ trait FormattingTrait
      * Format the instance as RFC850
      *
      * @return string
+     * @link https://tools.ietf.org/html/rfc850
      */
     public function toRfc850String(): string
     {
@@ -159,6 +161,7 @@ trait FormattingTrait
      * Format the instance as RFC1036
      *
      * @return string
+     * @link https://tools.ietf.org/html/rfc1036
      */
     public function toRfc1036String(): string
     {
@@ -169,6 +172,7 @@ trait FormattingTrait
      * Format the instance as RFC1123
      *
      * @return string
+     * @link https://tools.ietf.org/html/rfc1123
      */
     public function toRfc1123String(): string
     {
@@ -179,6 +183,7 @@ trait FormattingTrait
      * Format the instance as RFC2822
      *
      * @return string
+     * @link https://tools.ietf.org/html/rfc2822
      */
     public function toRfc2822String(): string
     {
@@ -189,6 +194,7 @@ trait FormattingTrait
      * Format the instance as RFC3339
      *
      * @return string
+     * @link https://tools.ietf.org/html/rfc3339
      */
     public function toRfc3339String(): string
     {


### PR DESCRIPTION
RFCs are important sources of formats and protocols.
Let's include them in the docs this way.