### PR TITLE
Fix int/timestamp support in Chronos constructor

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -84,11 +84,17 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      * Please see the testing aids section (specifically static::setTestNow())
      * for more on the possibility of this constructor returning a test instance.
      *
-     * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
+     * @param \DateTimeInterface|string|int|null $time Fixed or relative time
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      */
     public function __construct($time = 'now', $tz = null)
     {
+        if (is_int($time)) {
+            parent::__construct('@' . $time);
+
+            return;
+        }
+
         if ($tz !== null) {
             $tz = $tz instanceof DateTimeZone ? $tz : new DateTimeZone($tz);
         }

--- a/src/Date.php
+++ b/src/Date.php
@@ -86,7 +86,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
      * timezone will always be the server local time. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
-     * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
+     * @param \DateTimeInterface|string|int|null $time Fixed or relative time
      * @param \DateTimeZone|string|null $tz The timezone in which the date is taken
      */
     public function __construct($time = 'now', $tz = null)

--- a/src/MutableDate.php
+++ b/src/MutableDate.php
@@ -85,7 +85,7 @@ class MutableDate extends DateTime implements ChronosInterface
      * timezone will always be server local timezone. Normalizing the timezone allows for
      * subtraction/addition to have deterministic results.
      *
-     * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
+     * @param \DateTimeInterface|string|int|null $time Fixed or relative time
      * @param \DateTimeZone|string|null $tz The timezone in which the date is taken
      */
     public function __construct($time = 'now', $tz = null)

--- a/src/MutableDateTime.php
+++ b/src/MutableDateTime.php
@@ -76,11 +76,17 @@ class MutableDateTime extends DateTime implements ChronosInterface
      * Please see the testing aids section (specifically static::setTestNow())
      * for more on the possibility of this constructor returning a test instance.
      *
-     * @param \DateTime|\DateTimeImmutable|string|int|null $time Fixed or relative time
+     * @param \DateTimeInterface|string|int|null $time Fixed or relative time
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      */
     public function __construct($time = 'now', $tz = null)
     {
+        if (is_int($time)) {
+            parent::__construct('@' . $time);
+
+            return;
+        }
+
         if ($tz !== null) {
             $tz = $tz instanceof DateTimeZone ? $tz : new DateTimeZone($tz);
         }

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -324,7 +324,7 @@ trait FactoryTrait
      */
     public static function createFromTimestampUTC(int $timestamp): ChronosInterface
     {
-        return new static('@' . $timestamp);
+        return new static($timestamp);
     }
 
     /**

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -65,8 +65,12 @@ class ConstructTest extends TestCase
     {
         $this->withTimezone('Europe/Berlin', function () use ($class) {
             $ts = 1454284800;
-            $date = $class::createFromTimestamp($ts);
 
+            $date = $class::createFromTimestamp($ts);
+            $this->assertSame('Europe/Berlin', $date->tzName);
+            $this->assertSame('2016-02-01', $date->format('Y-m-d'));
+
+            $date = new $class($ts);
             $this->assertSame('Europe/Berlin', $date->tzName);
             $this->assertSame('2016-02-01', $date->format('Y-m-d'));
         });

--- a/tests/TestCase/DateTime/ConstructTest.php
+++ b/tests/TestCase/DateTime/ConstructTest.php
@@ -23,6 +23,19 @@ class ConstructTest extends TestCase
      * @dataProvider classNameProvider
      * @return void
      */
+    public function testCreateFromTimestamp($class)
+    {
+        $ts = 1454284800;
+
+        $time = new $class($ts);
+        $this->assertSame('+00:00', $time->tzName);
+        $this->assertSame('2016-02-01 00:00:00', $time->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * @dataProvider classNameProvider
+     * @return void
+     */
     public function testCreatesAnInstanceDefaultToNow($class)
     {
         $c = new $class();


### PR DESCRIPTION
Chronos and MutableDateTime did not support the `int` typehint. This required cakephp Time and FrozenTime to wrap all timestamps first.

Changed the constructor typehints to `DateTimeInterface` as that's what users expect. This fixes a typehint mismatch between Chronos and wrapper libraries like cakephp.

@markstory @ADmad 