### PR TITLE
Replace ChronosInterface return types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0', '8.1']
+        php-version: ['8.0', '8.1']
         prefer-lowest: ['']
         include:
-          - php-version: '7.2'
+          - php-version: '8.0'
             prefer-lowest: 'prefer-lowest'
 
     steps:
@@ -56,19 +56,19 @@ jobs:
         fi
 
     - name: Setup problem matchers for PHPUnit
-      if: matrix.php-version == '7.4'
+      if: matrix.php-version == '8.0'
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Run PHPUnit
       run: |
-        if [[ ${{ matrix.php-version }} == '7.4' ]]; then
+        if [[ ${{ matrix.php-version }} == '8.0' ]]; then
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
         else
           vendor/bin/phpunit
         fi
 
     - name: Submit code coverage
-      if: matrix.php-version == '7.4'
+      if: matrix.php-version == '8.0'
       uses: codecov/codecov-action@v1
 
   cs-stan:
@@ -81,7 +81,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.2'
+        php-version: '8.0'
         extensions: mbstring, intl
         tools: cs2pr
         coverage: none

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -67,7 +67,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      * There is a single test now for all date/time classes provided by Chronos.
      * This aims to emulate stubbing out 'now' which is a single global fact.
      *
-     * @var \Cake\Chronos\ChronosInterface|null
+     * @var static|null
      */
     protected static $testNow;
 
@@ -145,9 +145,9 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
     /**
      * Get a copy of the instance
      *
-     * @return static
+     * @return self
      */
-    public function copy(): ChronosInterface
+    public function copy(): self
     {
         return clone $this;
     }
@@ -167,7 +167,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      * To clear the test instance call this method using the default
      * parameter of null.
      *
-     * @param \Cake\Chronos\ChronosInterface|string|null $testNow The instance to use for all future instances.
+     * @param static|string|null $testNow The instance to use for all future instances.
      * @return void
      */
     public static function setTestNow($testNow = null): void
@@ -179,9 +179,9 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      * Get the ChronosInterface instance (real or mock) to be returned when a "now"
      * instance is created.
      *
-     * @return \Cake\Chronos\ChronosInterface|null The current instance used for testing
+     * @return static|null The current instance used for testing
      */
-    public static function getTestNow(): ?ChronosInterface
+    public static function getTestNow(): ?static
     {
         return static::$testNow;
     }

--- a/src/ChronosInterface.php
+++ b/src/ChronosInterface.php
@@ -102,12 +102,12 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function now($tz): self;
+    public static function now($tz): static;
 
     /**
      * Get a copy of the instance
      *
-     * @return static
+     * @return self
      */
     public function copy(): self;
 
@@ -115,7 +115,7 @@ interface ChronosInterface extends DateTimeInterface
      * Set the instance's year
      *
      * @param int $value The year value.
-     * @return static
+     * @return self
      */
     public function year(int $value): self;
 
@@ -123,7 +123,7 @@ interface ChronosInterface extends DateTimeInterface
      * Set the instance's month
      *
      * @param int $value The month value.
-     * @return static
+     * @return self
      */
     public function month(int $value): self;
 
@@ -131,7 +131,7 @@ interface ChronosInterface extends DateTimeInterface
      * Set the instance's day
      *
      * @param int $value The day value.
-     * @return static
+     * @return self
      */
     public function day(int $value): self;
 
@@ -139,7 +139,7 @@ interface ChronosInterface extends DateTimeInterface
      * Set the instance's hour
      *
      * @param int $value The hour value.
-     * @return static
+     * @return self
      */
     public function hour(int $value): self;
 
@@ -147,7 +147,7 @@ interface ChronosInterface extends DateTimeInterface
      * Set the instance's minute
      *
      * @param int $value The minute value.
-     * @return static
+     * @return self
      */
     public function minute(int $value): self;
 
@@ -155,7 +155,7 @@ interface ChronosInterface extends DateTimeInterface
      * Set the instance's second
      *
      * @param int $value The seconds value.
-     * @return static
+     * @return self
      */
     public function second(int $value): self;
 
@@ -168,7 +168,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $hour The hour to set.
      * @param int $minute The minute to set.
      * @param int $second The second to set.
-     * @return static
+     * @return self
      */
     public function setDateTime(int $year, int $month, int $day, int $hour, int $minute, int $second = 0): self;
 
@@ -176,7 +176,7 @@ interface ChronosInterface extends DateTimeInterface
      * Set the time by time string
      *
      * @param string $time Time as string.
-     * @return static
+     * @return self
      */
     public function setTimeFromTimeString(string $time): self;
 
@@ -192,25 +192,25 @@ interface ChronosInterface extends DateTimeInterface
      * Alias for setTimezone()
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return self
      */
-    public function timezone($value);
+    public function timezone($value): self;
 
     /**
      * Alias for setTimezone()
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return self
      */
-    public function tz($value);
+    public function tz($value): self;
 
     /**
      * Set the instance's timezone from a string or object
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return self
      */
-    public function setTimezone($value);
+    public function setTimezone($value): self;
 
     /**
      * Format the instance as date
@@ -441,7 +441,7 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
      * @param \Cake\Chronos\ChronosInterface $dt2 The instance to compare with.
-     * @return static
+     * @return self
      */
     public function closest(ChronosInterface $dt1, ChronosInterface $dt2): self;
 
@@ -450,7 +450,7 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
      * @param \Cake\Chronos\ChronosInterface $dt2 The instance to compare with.
-     * @return static
+     * @return self
      */
     public function farthest(ChronosInterface $dt1, ChronosInterface $dt2): self;
 
@@ -458,7 +458,7 @@ interface ChronosInterface extends DateTimeInterface
      * Get the minimum instance between a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return static
+     * @return self
      */
     public function min(?ChronosInterface $dt = null): self;
 
@@ -466,7 +466,7 @@ interface ChronosInterface extends DateTimeInterface
      * Get the maximum instance between a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return static
+     * @return self
      */
     public function max(?ChronosInterface $dt = null): self;
 
@@ -620,7 +620,7 @@ interface ChronosInterface extends DateTimeInterface
      * ```
      *
      * @param int $value The number of years to add.
-     * @return static
+     * @return self
      */
     public function addYears(int $value): self;
 
@@ -630,7 +630,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addYears()`.
      *
      * @param int $value The number of years to add.
-     * @return static
+     * @return self
      */
     public function addYear(int $value = 1): self;
 
@@ -640,7 +640,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addYears()`.
      *
      * @param int $value The number of years to remove.
-     * @return static
+     * @return self
      */
     public function subYears(int $value): self;
 
@@ -650,7 +650,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addYears()`.
      *
      * @param int $value The number of years to remove.
-     * @return static
+     * @return self
      */
     public function subYear(int $value = 1): self;
 
@@ -667,7 +667,7 @@ interface ChronosInterface extends DateTimeInterface
      * ```
      *
      * @param int $value The number of years to add.
-     * @return static
+     * @return self
      */
     public function addYearsWithOverflow(int $value): self;
 
@@ -677,7 +677,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addYearsWithOverflow()`.
      *
      * @param int $value The number of years to add.
-     * @return static
+     * @return self
      */
     public function addYearWithOverflow(int $value = 1): self;
 
@@ -687,7 +687,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addYearsWithOverflow()`.
      *
      * @param int $value The number of years to remove.
-     * @return static
+     * @return self
      */
     public function subYearsWithOverflow(int $value): self;
 
@@ -697,7 +697,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addYearsWithOverflow()`.
      *
      * @param int $value The number of years to remove.
-     * @return static
+     * @return self
      */
     public function subYearWithOverflow(int $value = 1): self;
 
@@ -717,7 +717,7 @@ interface ChronosInterface extends DateTimeInterface
      * ```
      *
      * @param int $value The number of months to add.
-     * @return static
+     * @return self
      */
     public function addMonths(int $value): self;
 
@@ -727,7 +727,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addMonths()`.
      *
      * @param int $value The number of months to add.
-     * @return static
+     * @return self
      */
     public function addMonth(int $value = 1): self;
 
@@ -737,7 +737,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addMonths()`.
      *
      * @param int $value The number of months to remove.
-     * @return static
+     * @return self
      */
     public function subMonth(int $value = 1): self;
 
@@ -747,7 +747,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addMonths()`.
      *
      * @param int $value The number of months to remove.
-     * @return static
+     * @return self
      */
     public function subMonths(int $value): self;
 
@@ -764,7 +764,7 @@ interface ChronosInterface extends DateTimeInterface
      * ```
      *
      * @param int $value The number of months to add.
-     * @return static
+     * @return self
      */
     public function addMonthsWithOverflow(int $value): self;
 
@@ -774,7 +774,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addMonthsWithOverflow()`.
      *
      * @param int $value The number of months to add.
-     * @return static
+     * @return self
      */
     public function addMonthWithOverflow(int $value = 1): self;
 
@@ -784,7 +784,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addMonthsWithOverflow()`.
      *
      * @param int $value The number of months to remove.
-     * @return static
+     * @return self
      */
     public function subMonthsWithOverflow(int $value): self;
 
@@ -794,7 +794,7 @@ interface ChronosInterface extends DateTimeInterface
      * Has the same behavior as `addMonthsWithOverflow()`.
      *
      * @param int $value The number of months to remove.
-     * @return static
+     * @return self
      */
     public function subMonthWithOverflow(int $value = 1): self;
 
@@ -803,7 +803,7 @@ interface ChronosInterface extends DateTimeInterface
      * negative $value travels into the past.
      *
      * @param int $value The number of days to add.
-     * @return static
+     * @return self
      */
     public function addDays(int $value): self;
 
@@ -811,7 +811,7 @@ interface ChronosInterface extends DateTimeInterface
      * Add a day to the instance
      *
      * @param int $value The number of days to add.
-     * @return static
+     * @return self
      */
     public function addDay(int $value = 1): self;
 
@@ -819,7 +819,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove days from the instance
      *
      * @param int $value The number of days to remove.
-     * @return static
+     * @return self
      */
     public function subDays(int $value): self;
 
@@ -827,7 +827,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove a day from the instance
      *
      * @param int $value The number of days to remove.
-     * @return static
+     * @return self
      */
     public function subDay(int $value = 1): self;
 
@@ -836,7 +836,7 @@ interface ChronosInterface extends DateTimeInterface
      * negative $value travels into the past.
      *
      * @param int $value The number of weekdays to add.
-     * @return static
+     * @return self
      */
     public function addWeekdays(int $value): self;
 
@@ -844,7 +844,7 @@ interface ChronosInterface extends DateTimeInterface
      * Add a weekday to the instance
      *
      * @param int $value The number of weekdays to add.
-     * @return static
+     * @return self
      */
     public function addWeekday(int $value = 1): self;
 
@@ -852,7 +852,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove a weekday from the instance
      *
      * @param int $value The number of weekdays to remove.
-     * @return static
+     * @return self
      */
     public function subWeekday(int $value = 1): self;
 
@@ -860,7 +860,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove weekdays from the instance
      *
      * @param int $value The number of weekdays to remove.
-     * @return static
+     * @return self
      */
     public function subWeekdays(int $value): self;
 
@@ -869,7 +869,7 @@ interface ChronosInterface extends DateTimeInterface
      * negative $value travels into the past.
      *
      * @param int $value The number of weeks to add.
-     * @return static
+     * @return self
      */
     public function addWeeks(int $value): self;
 
@@ -877,7 +877,7 @@ interface ChronosInterface extends DateTimeInterface
      * Add a week to the instance
      *
      * @param int $value The number of weeks to add.
-     * @return static
+     * @return self
      */
     public function addWeek(int $value = 1): self;
 
@@ -885,7 +885,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove a week from the instance
      *
      * @param int $value The number of weeks to remove.
-     * @return static
+     * @return self
      */
     public function subWeek(int $value = 1): self;
 
@@ -893,7 +893,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove weeks to the instance
      *
      * @param int $value The number of weeks to remove.
-     * @return static
+     * @return self
      */
     public function subWeeks(int $value): self;
 
@@ -902,7 +902,7 @@ interface ChronosInterface extends DateTimeInterface
      * negative $value travels into the past.
      *
      * @param int $value The number of hours to add.
-     * @return static
+     * @return self
      */
     public function addHours(int $value): self;
 
@@ -910,7 +910,7 @@ interface ChronosInterface extends DateTimeInterface
      * Add an hour to the instance
      *
      * @param int $value The number of hours to add.
-     * @return static
+     * @return self
      */
     public function addHour(int $value = 1): self;
 
@@ -918,7 +918,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove an hour from the instance
      *
      * @param int $value The number of hours to remove.
-     * @return static
+     * @return self
      */
     public function subHour(int $value = 1): self;
 
@@ -926,7 +926,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove hours from the instance
      *
      * @param int $value The number of hours to remove.
-     * @return static
+     * @return self
      */
     public function subHours(int $value): self;
 
@@ -935,7 +935,7 @@ interface ChronosInterface extends DateTimeInterface
      * negative $value travels into the past.
      *
      * @param int $value The number of minutes to add.
-     * @return static
+     * @return self
      */
     public function addMinutes(int $value): self;
 
@@ -943,7 +943,7 @@ interface ChronosInterface extends DateTimeInterface
      * Add a minute to the instance
      *
      * @param int $value The number of minutes to add.
-     * @return static
+     * @return self
      */
     public function addMinute(int $value = 1): self;
 
@@ -951,7 +951,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove a minute from the instance
      *
      * @param int $value The number of minutes to remove.
-     * @return static
+     * @return self
      */
     public function subMinute(int $value = 1): self;
 
@@ -959,7 +959,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove minutes from the instance
      *
      * @param int $value The number of minutes to remove.
-     * @return static
+     * @return self
      */
     public function subMinutes(int $value): self;
 
@@ -968,7 +968,7 @@ interface ChronosInterface extends DateTimeInterface
      * negative $value travels into the past.
      *
      * @param int $value The number of seconds to add.
-     * @return static
+     * @return self
      */
     public function addSeconds(int $value): self;
 
@@ -976,7 +976,7 @@ interface ChronosInterface extends DateTimeInterface
      * Add a second to the instance
      *
      * @param int $value The number of seconds to add.
-     * @return static
+     * @return self
      */
     public function addSecond(int $value = 1): self;
 
@@ -984,7 +984,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove a second from the instance
      *
      * @param int $value The number of seconds to remove.
-     * @return static
+     * @return self
      */
     public function subSecond(int $value = 1): self;
 
@@ -992,7 +992,7 @@ interface ChronosInterface extends DateTimeInterface
      * Remove seconds from the instance
      *
      * @param int $value The number of seconds to remove.
-     * @return static
+     * @return self
      */
     public function subSeconds(int $value): self;
 
@@ -1243,9 +1243,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function next(?int $dayOfWeek = null);
+    public function next(?int $dayOfWeek = null): self;
 
     /**
      * Modify to the previous occurrence of a given day of the week.
@@ -1254,9 +1254,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function previous(?int $dayOfWeek = null);
+    public function previous(?int $dayOfWeek = null): self;
 
     /**
      * Modify to the first occurrence of a given day of the week
@@ -1265,9 +1265,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function firstOfMonth(?int $dayOfWeek = null);
+    public function firstOfMonth(?int $dayOfWeek = null): self;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1276,9 +1276,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function lastOfMonth(?int $dayOfWeek = null);
+    public function lastOfMonth(?int $dayOfWeek = null): self;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1288,7 +1288,7 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self|false
      */
     public function nthOfMonth(int $nth, int $dayOfWeek);
 
@@ -1299,9 +1299,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function firstOfQuarter(?int $dayOfWeek = null);
+    public function firstOfQuarter(?int $dayOfWeek = null): self;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1310,9 +1310,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function lastOfQuarter(?int $dayOfWeek = null);
+    public function lastOfQuarter(?int $dayOfWeek = null): self;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1322,7 +1322,7 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self|false
      */
     public function nthOfQuarter(int $nth, int $dayOfWeek);
 
@@ -1333,9 +1333,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function firstOfYear(?int $dayOfWeek = null);
+    public function firstOfYear(?int $dayOfWeek = null): self;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1344,9 +1344,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function lastOfYear(?int $dayOfWeek = null);
+    public function lastOfYear(?int $dayOfWeek = null): self;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1356,7 +1356,7 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self|false
      */
     public function nthOfYear(int $nth, int $dayOfWeek);
 
@@ -1364,7 +1364,7 @@ interface ChronosInterface extends DateTimeInterface
      * Modify the current instance to the average of a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
-     * @return static
+     * @return self
      */
     public function average(?ChronosInterface $dt = null): self;
 

--- a/src/Traits/ComparisonTrait.php
+++ b/src/Traits/ComparisonTrait.php
@@ -212,9 +212,9 @@ trait ComparisonTrait
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
      * @param \Cake\Chronos\ChronosInterface $dt2 The instance to compare with.
-     * @return \Cake\Chronos\ChronosInterface
+     * @return self
      */
-    public function closest(ChronosInterface $dt1, ChronosInterface $dt2): ChronosInterface
+    public function closest(ChronosInterface $dt1, ChronosInterface $dt2): self
     {
         return $this->diffInSeconds($dt1) < $this->diffInSeconds($dt2) ? $dt1 : $dt2;
     }
@@ -224,9 +224,9 @@ trait ComparisonTrait
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
      * @param \Cake\Chronos\ChronosInterface $dt2 The instance to compare with.
-     * @return \Cake\Chronos\ChronosInterface
+     * @return self
      */
-    public function farthest(ChronosInterface $dt1, ChronosInterface $dt2): ChronosInterface
+    public function farthest(ChronosInterface $dt1, ChronosInterface $dt2): self
     {
         return $this->diffInSeconds($dt1) > $this->diffInSeconds($dt2) ? $dt1 : $dt2;
     }
@@ -235,9 +235,9 @@ trait ComparisonTrait
      * Get the minimum instance between a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return \Cake\Chronos\ChronosInterface
+     * @return self
      */
-    public function min(?ChronosInterface $dt = null): ChronosInterface
+    public function min(?ChronosInterface $dt = null): self
     {
         $dt = $dt ?? static::now($this->tz);
 
@@ -248,9 +248,9 @@ trait ComparisonTrait
      * Get the maximum instance between a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return \Cake\Chronos\ChronosInterface
+     * @return self
      */
-    public function max(?ChronosInterface $dt = null): ChronosInterface
+    public function max(?ChronosInterface $dt = null): self
     {
         $dt = $dt ?? static::now($this->tz);
 

--- a/src/Traits/CopyTrait.php
+++ b/src/Traits/CopyTrait.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
-
 /**
  * Provides methods for copying datetime objects.
  *
@@ -28,7 +26,7 @@ trait CopyTrait
      *
      * @return static
      */
-    public function copy(): ChronosInterface
+    public function copy(): self
     {
         return static::instance($this);
     }

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
@@ -37,7 +36,7 @@ trait FactoryTrait
      * @param \DateTimeInterface $dt The datetime instance to convert.
      * @return static
      */
-    public static function instance(DateTimeInterface $dt): ChronosInterface
+    public static function instance(DateTimeInterface $dt): static
     {
         if ($dt instanceof static) {
             return clone $dt;
@@ -56,7 +55,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function parse($time = 'now', $tz = null): ChronosInterface
+    public static function parse($time = 'now', $tz = null): static
     {
         return new static($time, $tz);
     }
@@ -67,7 +66,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function now($tz = null): ChronosInterface
+    public static function now($tz = null): static
     {
         return new static('now', $tz);
     }
@@ -78,7 +77,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The timezone to use.
      * @return static
      */
-    public static function today($tz = null): ChronosInterface
+    public static function today($tz = null): static
     {
         return new static('midnight', $tz);
     }
@@ -89,7 +88,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function tomorrow($tz = null): ChronosInterface
+    public static function tomorrow($tz = null): static
     {
         return new static('tomorrow, midnight', $tz);
     }
@@ -100,7 +99,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function yesterday($tz = null): ChronosInterface
+    public static function yesterday($tz = null): static
     {
         return new static('yesterday, midnight', $tz);
     }
@@ -108,9 +107,9 @@ trait FactoryTrait
     /**
      * Create a ChronosInterface instance for the greatest supported date.
      *
-     * @return \Cake\Chronos\ChronosInterface
+     * @return static
      */
-    public static function maxValue(): ChronosInterface
+    public static function maxValue(): static
     {
         return static::createFromTimestampUTC(PHP_INT_MAX);
     }
@@ -118,9 +117,9 @@ trait FactoryTrait
     /**
      * Create a ChronosInterface instance for the lowest supported date.
      *
-     * @return \Cake\Chronos\ChronosInterface
+     * @return static
      */
-    public static function minValue(): ChronosInterface
+    public static function minValue(): static
     {
         $max = PHP_INT_SIZE === 4 ? PHP_INT_MAX : PHP_INT_MAX / 10;
 
@@ -157,7 +156,7 @@ trait FactoryTrait
         ?int $second = null,
         ?int $microsecond = null,
         $tz = null
-    ): ChronosInterface {
+    ): static {
         $now = static::now();
         $year = $year ?? (int)$now->format('Y');
         $month = $month ?? $now->format('m');
@@ -197,7 +196,7 @@ trait FactoryTrait
         ?int $month = null,
         ?int $day = null,
         $tz = null
-    ): ChronosInterface {
+    ): static {
         return static::create($year, $month, $day, null, null, null, null, $tz);
     }
 
@@ -217,7 +216,7 @@ trait FactoryTrait
         ?int $second = null,
         ?int $microsecond = null,
         $tz = null
-    ): ChronosInterface {
+    ): static {
         return static::create(null, null, null, $hour, $minute, $second, $microsecond, $tz);
     }
 
@@ -230,7 +229,7 @@ trait FactoryTrait
      * @return static
      * @throws \InvalidArgumentException
      */
-    public static function createFromFormat($format, $time, $tz = null): ChronosInterface
+    public static function createFromFormat($format, $time, $tz = null): static
     {
         if ($tz !== null) {
             $dt = parent::createFromFormat($format, $time, static::safeCreateDateTimeZone($tz));
@@ -271,7 +270,7 @@ trait FactoryTrait
      * @param (int|string)[] $values Array of date and time values.
      * @return static
      */
-    public static function createFromArray(array $values): ChronosInterface
+    public static function createFromArray(array $values): static
     {
         $values += ['hour' => 0, 'minute' => 0, 'second' => 0, 'microsecond' => 0, 'timezone' => null];
 
@@ -311,7 +310,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function createFromTimestamp(int $timestamp, $tz = null): ChronosInterface
+    public static function createFromTimestamp(int $timestamp, $tz = null): static
     {
         return static::now($tz)->setTimestamp($timestamp);
     }
@@ -322,7 +321,7 @@ trait FactoryTrait
      * @param int $timestamp The UTC timestamp to create an instance from.
      * @return static
      */
-    public static function createFromTimestampUTC(int $timestamp): ChronosInterface
+    public static function createFromTimestampUTC(int $timestamp): static
     {
         return new static($timestamp);
     }

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
 use DateTimeImmutable;
 use DateTimeInterface;
 
@@ -73,9 +72,9 @@ trait FrozenTimeTrait
      * @param int $minutes The minutes to set (ignored)
      * @param int $seconds The seconds to set (ignored)
      * @param int $microseconds The microseconds to set (ignored)
-     * @return static A modified Date instance.
+     * @return self A modified Date instance.
      */
-    public function setTime($hours, $minutes, $seconds = null, $microseconds = null): ChronosInterface
+    public function setTime($hours, $minutes, $seconds = null, $microseconds = null): self
     {
         return parent::setTime(0, 0, 0, 0);
     }
@@ -86,9 +85,9 @@ trait FrozenTimeTrait
      * Any changes to the time will be ignored and reset to 00:00:00
      *
      * @param \DateInterval $interval The interval to modify this date by.
-     * @return static A modified Date instance
+     * @return self A modified Date instance
      */
-    public function add($interval): ChronosInterface
+    public function add($interval): self
     {
         return parent::add($interval)->setTime(0, 0, 0);
     }
@@ -99,9 +98,9 @@ trait FrozenTimeTrait
      * Any changes to the time will be ignored and reset to 00:00:00
      *
      * @param \DateInterval $interval The interval to modify this date by.
-     * @return static A modified Date instance
+     * @return self A modified Date instance
      */
-    public function sub($interval): ChronosInterface
+    public function sub($interval): self
     {
         return parent::sub($interval)->setTime(0, 0, 0);
     }
@@ -112,9 +111,9 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return self
      */
-    public function timezone($value)
+    public function timezone($value): self
     {
         return $this;
     }
@@ -125,9 +124,9 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return self
      */
-    public function tz($value)
+    public function tz($value): self
     {
         return $this;
     }
@@ -138,9 +137,9 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return self
      */
-    public function setTimezone($value)
+    public function setTimezone($value): self
     {
         return $this;
     }
@@ -152,9 +151,9 @@ trait FrozenTimeTrait
      * and only apply the date portions
      *
      * @param int $value The timestamp value to set.
-     * @return static
+     * @return self
      */
-    public function setTimestamp($value): ChronosInterface
+    public function setTimestamp($value): self
     {
         return parent::setTimestamp($value)->setTime(0, 0, 0);
     }
@@ -166,9 +165,9 @@ trait FrozenTimeTrait
      * will have its time frozen to 00:00:00.
      *
      * @param string $relative The relative change to make.
-     * @return static A new date with the applied date changes.
+     * @return self A new date with the applied date changes.
      */
-    public function modify($relative): ChronosInterface
+    public function modify($relative): self
     {
         if (preg_match('/hour|minute|second/', $relative)) {
             return $this;

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -107,9 +107,9 @@ trait ModifierTrait
      * @param int $year The year to set.
      * @param int $month The month to set.
      * @param int $day The day to set.
-     * @return static
+     * @return self
      */
-    public function setDate($year, $month, $day): ChronosInterface
+    public function setDate($year, $month, $day): self
     {
         return $this->modify('+0 day')->setDateParent($year, $month, $day);
     }
@@ -121,9 +121,9 @@ trait ModifierTrait
      * @param int $year The year to set.
      * @param int $month The month to set.
      * @param int $day The day to set.
-     * @return static
+     * @return self
      */
-    private function setDateParent(int $year, int $month, int $day): ChronosInterface
+    private function setDateParent(int $year, int $month, int $day): self
     {
         return parent::setDate($year, $month, $day);
     }
@@ -137,7 +137,7 @@ trait ModifierTrait
      * @param int $hour The hour to set.
      * @param int $minute The minute to set.
      * @param int $second The second to set.
-     * @return static
+     * @return self
      */
     public function setDateTime(
         int $year,
@@ -146,7 +146,7 @@ trait ModifierTrait
         int $hour,
         int $minute,
         int $second = 0
-    ): ChronosInterface {
+    ): self {
         return $this->setDate($year, $month, $day)->setTime($hour, $minute, $second);
     }
 
@@ -154,9 +154,9 @@ trait ModifierTrait
      * Set the time by time string
      *
      * @param string $time Time as string.
-     * @return static
+     * @return self
      */
-    public function setTimeFromTimeString(string $time): ChronosInterface
+    public function setTimeFromTimeString(string $time): self
     {
         $time = explode(':', $time);
         $hour = $time[0];
@@ -170,9 +170,9 @@ trait ModifierTrait
      * Set the instance's timestamp
      *
      * @param int $value The timestamp value to set.
-     * @return static
+     * @return self
      */
-    public function timestamp(int $value): ChronosInterface
+    public function timestamp(int $value): self
     {
         return $this->setTimestamp($value);
     }
@@ -181,9 +181,9 @@ trait ModifierTrait
      * Set the instance's year
      *
      * @param int $value The year value.
-     * @return static
+     * @return self
      */
-    public function year(int $value): ChronosInterface
+    public function year(int $value): self
     {
         return $this->setDate($value, $this->month, $this->day);
     }
@@ -192,9 +192,9 @@ trait ModifierTrait
      * Set the instance's month
      *
      * @param int $value The month value.
-     * @return static
+     * @return self
      */
-    public function month(int $value): ChronosInterface
+    public function month(int $value): self
     {
         return $this->setDate($this->year, $value, $this->day);
     }
@@ -203,9 +203,9 @@ trait ModifierTrait
      * Set the instance's day
      *
      * @param int $value The day value.
-     * @return static
+     * @return self
      */
-    public function day(int $value): ChronosInterface
+    public function day(int $value): self
     {
         return $this->setDate($this->year, $this->month, $value);
     }
@@ -214,9 +214,9 @@ trait ModifierTrait
      * Set the instance's hour
      *
      * @param int $value The hour value.
-     * @return static
+     * @return self
      */
-    public function hour(int $value): ChronosInterface
+    public function hour(int $value): self
     {
         return $this->setTime($value, $this->minute, $this->second);
     }
@@ -225,9 +225,9 @@ trait ModifierTrait
      * Set the instance's minute
      *
      * @param int $value The minute value.
-     * @return static
+     * @return self
      */
-    public function minute(int $value): ChronosInterface
+    public function minute(int $value): self
     {
         return $this->setTime($this->hour, $value, $this->second);
     }
@@ -236,9 +236,9 @@ trait ModifierTrait
      * Set the instance's second
      *
      * @param int $value The seconds value.
-     * @return static
+     * @return self
      */
-    public function second(int $value): ChronosInterface
+    public function second(int $value): self
     {
         return $this->setTime($this->hour, $this->minute, $value);
     }
@@ -259,9 +259,9 @@ trait ModifierTrait
      * ```
      *
      * @param int $value The number of years to add.
-     * @return static
+     * @return self
      */
-    public function addYears(int $value): ChronosInterface
+    public function addYears(int $value): self
     {
         $month = $this->month;
         $date = $this->modify($value . ' year');
@@ -279,9 +279,9 @@ trait ModifierTrait
      * Has the same behavior as `addYears()`.
      *
      * @param int $value The number of years to add.
-     * @return static
+     * @return self
      */
-    public function addYear(int $value = 1): ChronosInterface
+    public function addYear(int $value = 1): self
     {
         return $this->addYears($value);
     }
@@ -292,9 +292,9 @@ trait ModifierTrait
      * Has the same behavior as `addYears()`.
      *
      * @param int $value The number of years to remove.
-     * @return static
+     * @return self
      */
-    public function subYears(int $value): ChronosInterface
+    public function subYears(int $value): self
     {
         return $this->addYears(-1 * $value);
     }
@@ -305,9 +305,9 @@ trait ModifierTrait
      * Has the same behavior as `addYears()`.
      *
      * @param int $value The number of years to remove.
-     * @return static
+     * @return self
      */
-    public function subYear(int $value = 1): ChronosInterface
+    public function subYear(int $value = 1): self
     {
         return $this->subYears($value);
     }
@@ -325,9 +325,9 @@ trait ModifierTrait
      * ```
      *
      * @param int $value The number of years to add.
-     * @return static
+     * @return self
      */
-    public function addYearsWithOverflow(int $value): ChronosInterface
+    public function addYearsWithOverflow(int $value): self
     {
         return $this->modify($value . ' year');
     }
@@ -338,9 +338,9 @@ trait ModifierTrait
      * Has the same behavior as `addYearsWithOverflow()`.
      *
      * @param int $value The number of years to add.
-     * @return static
+     * @return self
      */
-    public function addYearWithOverflow(int $value = 1): ChronosInterface
+    public function addYearWithOverflow(int $value = 1): self
     {
         return $this->addYearsWithOverflow($value);
     }
@@ -351,9 +351,9 @@ trait ModifierTrait
      * Has the same behavior as `addYeasrWithOverflow()`.
      *
      * @param int $value The number of years to remove.
-     * @return static
+     * @return self
      */
-    public function subYearsWithOverflow(int $value): ChronosInterface
+    public function subYearsWithOverflow(int $value): self
     {
         return $this->addYearsWithOverflow(-1 * $value);
     }
@@ -364,9 +364,9 @@ trait ModifierTrait
      * Has the same behavior as `addYearsWithOverflow()`.
      *
      * @param int $value The number of years to remove.
-     * @return static
+     * @return self
      */
-    public function subYearWithOverflow(int $value = 1): ChronosInterface
+    public function subYearWithOverflow(int $value = 1): self
     {
         return $this->subYearsWithOverflow($value);
     }
@@ -388,9 +388,9 @@ trait ModifierTrait
      * ```
      *
      * @param int $value The number of months to add.
-     * @return static
+     * @return self
      */
-    public function addMonths(int $value): ChronosInterface
+    public function addMonths(int $value): self
     {
         $day = $this->day;
         $date = $this->modify($value . ' month');
@@ -408,9 +408,9 @@ trait ModifierTrait
      * Has the same behavior as `addMonths()`.
      *
      * @param int $value The number of months to add.
-     * @return static
+     * @return self
      */
-    public function addMonth(int $value = 1): ChronosInterface
+    public function addMonth(int $value = 1): self
     {
         return $this->addMonths($value);
     }
@@ -421,9 +421,9 @@ trait ModifierTrait
      * Has the same behavior as `addMonths()`.
      *
      * @param int $value The number of months to remove.
-     * @return static
+     * @return self
      */
-    public function subMonth(int $value = 1): ChronosInterface
+    public function subMonth(int $value = 1): self
     {
         return $this->subMonths($value);
     }
@@ -434,9 +434,9 @@ trait ModifierTrait
      * Has the same behavior as `addMonths()`.
      *
      * @param int $value The number of months to remove.
-     * @return static
+     * @return self
      */
-    public function subMonths(int $value): ChronosInterface
+    public function subMonths(int $value): self
     {
         return $this->addMonths(-1 * $value);
     }
@@ -454,9 +454,9 @@ trait ModifierTrait
      * ```
      *
      * @param int $value The number of months to add.
-     * @return static
+     * @return self
      */
-    public function addMonthsWithOverflow(int $value): ChronosInterface
+    public function addMonthsWithOverflow(int $value): self
     {
         return $this->modify($value . ' month');
     }
@@ -467,9 +467,9 @@ trait ModifierTrait
      * Has the same behavior as `addMonthsWithOverflow()`.
      *
      * @param int $value The number of months to add.
-     * @return static
+     * @return self
      */
-    public function addMonthWithOverflow(int $value = 1): ChronosInterface
+    public function addMonthWithOverflow(int $value = 1): self
     {
         return $this->modify($value . ' month');
     }
@@ -480,9 +480,9 @@ trait ModifierTrait
      * Has the same behavior as `addMonthsWithOverflow()`.
      *
      * @param int $value The number of months to remove.
-     * @return static
+     * @return self
      */
-    public function subMonthsWithOverflow(int $value): ChronosInterface
+    public function subMonthsWithOverflow(int $value): self
     {
         return $this->addMonthsWithOverflow(-1 * $value);
     }
@@ -493,9 +493,9 @@ trait ModifierTrait
      * Has the same behavior as `addMonthsWithOverflow()`.
      *
      * @param int $value The number of months to remove.
-     * @return static
+     * @return self
      */
-    public function subMonthWithOverflow(int $value = 1): ChronosInterface
+    public function subMonthWithOverflow(int $value = 1): self
     {
         return $this->subMonthsWithOverflow($value);
     }
@@ -505,9 +505,9 @@ trait ModifierTrait
      * negative $value travels into the past.
      *
      * @param int $value The number of days to add.
-     * @return static
+     * @return self
      */
-    public function addDays(int $value): ChronosInterface
+    public function addDays(int $value): self
     {
         return $this->modify("$value day");
     }
@@ -516,9 +516,9 @@ trait ModifierTrait
      * Add a day to the instance
      *
      * @param int $value The number of days to add.
-     * @return static
+     * @return self
      */
-    public function addDay(int $value = 1): ChronosInterface
+    public function addDay(int $value = 1): self
     {
         return $this->modify("$value day");
     }
@@ -527,9 +527,9 @@ trait ModifierTrait
      * Remove a day from the instance
      *
      * @param int $value The number of days to remove.
-     * @return static
+     * @return self
      */
-    public function subDay(int $value = 1): ChronosInterface
+    public function subDay(int $value = 1): self
     {
         return $this->modify("-$value day");
     }
@@ -538,9 +538,9 @@ trait ModifierTrait
      * Remove days from the instance
      *
      * @param int $value The number of days to remove.
-     * @return static
+     * @return self
      */
-    public function subDays(int $value): ChronosInterface
+    public function subDays(int $value): self
     {
         return $this->modify("-$value day");
     }
@@ -550,9 +550,9 @@ trait ModifierTrait
      * negative $value travels into the past.
      *
      * @param int $value The number of weekdays to add.
-     * @return static
+     * @return self
      */
-    public function addWeekdays(int $value): ChronosInterface
+    public function addWeekdays(int $value): self
     {
         return $this->modify((int)$value . ' weekdays ' . $this->format('H:i:s'));
     }
@@ -561,9 +561,9 @@ trait ModifierTrait
      * Add a weekday to the instance
      *
      * @param int $value The number of weekdays to add.
-     * @return static
+     * @return self
      */
-    public function addWeekday(int $value = 1): ChronosInterface
+    public function addWeekday(int $value = 1): self
     {
         return $this->addWeekdays($value);
     }
@@ -572,9 +572,9 @@ trait ModifierTrait
      * Remove weekdays from the instance
      *
      * @param int $value The number of weekdays to remove.
-     * @return static
+     * @return self
      */
-    public function subWeekdays(int $value): ChronosInterface
+    public function subWeekdays(int $value): self
     {
         return $this->modify("$value weekdays ago, " . $this->format('H:i:s'));
     }
@@ -583,9 +583,9 @@ trait ModifierTrait
      * Remove a weekday from the instance
      *
      * @param int $value The number of weekdays to remove.
-     * @return static
+     * @return self
      */
-    public function subWeekday(int $value = 1): ChronosInterface
+    public function subWeekday(int $value = 1): self
     {
         return $this->subWeekdays($value);
     }
@@ -595,9 +595,9 @@ trait ModifierTrait
      * negative $value travels into the past.
      *
      * @param int $value The number of weeks to add.
-     * @return static
+     * @return self
      */
-    public function addWeeks(int $value): ChronosInterface
+    public function addWeeks(int $value): self
     {
         return $this->modify("$value week");
     }
@@ -606,9 +606,9 @@ trait ModifierTrait
      * Add a week to the instance
      *
      * @param int $value The number of weeks to add.
-     * @return static
+     * @return self
      */
-    public function addWeek(int $value = 1): ChronosInterface
+    public function addWeek(int $value = 1): self
     {
         return $this->modify("$value week");
     }
@@ -617,9 +617,9 @@ trait ModifierTrait
      * Remove a week from the instance
      *
      * @param int $value The number of weeks to remove.
-     * @return static
+     * @return self
      */
-    public function subWeek(int $value = 1): ChronosInterface
+    public function subWeek(int $value = 1): self
     {
         return $this->modify("-$value week");
     }
@@ -628,9 +628,9 @@ trait ModifierTrait
      * Remove weeks to the instance
      *
      * @param int $value The number of weeks to remove.
-     * @return static
+     * @return self
      */
-    public function subWeeks(int $value): ChronosInterface
+    public function subWeeks(int $value): self
     {
         return $this->modify("-$value week");
     }
@@ -640,9 +640,9 @@ trait ModifierTrait
      * negative $value travels into the past.
      *
      * @param int $value The number of hours to add.
-     * @return static
+     * @return self
      */
-    public function addHours(int $value): ChronosInterface
+    public function addHours(int $value): self
     {
         return $this->modify("$value hour");
     }
@@ -651,9 +651,9 @@ trait ModifierTrait
      * Add an hour to the instance
      *
      * @param int $value The number of hours to add.
-     * @return static
+     * @return self
      */
-    public function addHour(int $value = 1): ChronosInterface
+    public function addHour(int $value = 1): self
     {
         return $this->modify("$value hour");
     }
@@ -662,9 +662,9 @@ trait ModifierTrait
      * Remove an hour from the instance
      *
      * @param int $value The number of hours to remove.
-     * @return static
+     * @return self
      */
-    public function subHour(int $value = 1): ChronosInterface
+    public function subHour(int $value = 1): self
     {
         return $this->modify("-$value hour");
     }
@@ -673,9 +673,9 @@ trait ModifierTrait
      * Remove hours from the instance
      *
      * @param int $value The number of hours to remove.
-     * @return static
+     * @return self
      */
-    public function subHours(int $value): ChronosInterface
+    public function subHours(int $value): self
     {
         return $this->modify("-$value hour");
     }
@@ -685,9 +685,9 @@ trait ModifierTrait
      * negative $value travels into the past.
      *
      * @param int $value The number of minutes to add.
-     * @return static
+     * @return self
      */
-    public function addMinutes(int $value): ChronosInterface
+    public function addMinutes(int $value): self
     {
         return $this->modify("$value minute");
     }
@@ -696,9 +696,9 @@ trait ModifierTrait
      * Add a minute to the instance
      *
      * @param int $value The number of minutes to add.
-     * @return static
+     * @return self
      */
-    public function addMinute(int $value = 1): ChronosInterface
+    public function addMinute(int $value = 1): self
     {
         return $this->modify("$value minute");
     }
@@ -707,9 +707,9 @@ trait ModifierTrait
      * Remove a minute from the instance
      *
      * @param int $value The number of minutes to remove.
-     * @return static
+     * @return self
      */
-    public function subMinute(int $value = 1): ChronosInterface
+    public function subMinute(int $value = 1): self
     {
         return $this->modify("-$value minute");
     }
@@ -718,9 +718,9 @@ trait ModifierTrait
      * Remove minutes from the instance
      *
      * @param int $value The number of minutes to remove.
-     * @return static
+     * @return self
      */
-    public function subMinutes(int $value): ChronosInterface
+    public function subMinutes(int $value): self
     {
         return $this->modify("-$value minute");
     }
@@ -730,9 +730,9 @@ trait ModifierTrait
      * negative $value travels into the past.
      *
      * @param int $value The number of seconds to add.
-     * @return static
+     * @return self
      */
-    public function addSeconds(int $value): ChronosInterface
+    public function addSeconds(int $value): self
     {
         return $this->modify("$value second");
     }
@@ -741,9 +741,9 @@ trait ModifierTrait
      * Add a second to the instance
      *
      * @param int $value The number of seconds to add.
-     * @return static
+     * @return self
      */
-    public function addSecond(int $value = 1): ChronosInterface
+    public function addSecond(int $value = 1): self
     {
         return $this->modify("$value second");
     }
@@ -752,9 +752,9 @@ trait ModifierTrait
      * Remove a second from the instance
      *
      * @param int $value The number of seconds to remove.
-     * @return static
+     * @return self
      */
-    public function subSecond(int $value = 1): ChronosInterface
+    public function subSecond(int $value = 1): self
     {
         return $this->modify("-$value second");
     }
@@ -763,9 +763,9 @@ trait ModifierTrait
      * Remove seconds from the instance
      *
      * @param int $value The number of seconds to remove.
-     * @return static
+     * @return self
      */
-    public function subSeconds(int $value): ChronosInterface
+    public function subSeconds(int $value): self
     {
         return $this->modify("-$value second");
     }
@@ -773,9 +773,9 @@ trait ModifierTrait
     /**
      * Resets the time to 00:00:00
      *
-     * @return static
+     * @return self
      */
-    public function startOfDay(): ChronosInterface
+    public function startOfDay(): self
     {
         return $this->modify('midnight');
     }
@@ -783,9 +783,9 @@ trait ModifierTrait
     /**
      * Resets the time to 23:59:59
      *
-     * @return static
+     * @return self
      */
-    public function endOfDay(): ChronosInterface
+    public function endOfDay(): self
     {
         return $this->modify('23:59:59');
     }
@@ -793,9 +793,9 @@ trait ModifierTrait
     /**
      * Resets the date to the first day of the month and the time to 00:00:00
      *
-     * @return static
+     * @return self
      */
-    public function startOfMonth(): ChronosInterface
+    public function startOfMonth(): self
     {
         return $this->modify('first day of this month midnight');
     }
@@ -803,9 +803,9 @@ trait ModifierTrait
     /**
      * Resets the date to end of the month and time to 23:59:59
      *
-     * @return static
+     * @return self
      */
-    public function endOfMonth(): ChronosInterface
+    public function endOfMonth(): self
     {
         return $this->modify('last day of this month, 23:59:59');
     }
@@ -813,9 +813,9 @@ trait ModifierTrait
     /**
      * Resets the date to the first day of the year and the time to 00:00:00
      *
-     * @return static
+     * @return self
      */
-    public function startOfYear(): ChronosInterface
+    public function startOfYear(): self
     {
         return $this->modify('first day of january midnight');
     }
@@ -823,9 +823,9 @@ trait ModifierTrait
     /**
      * Resets the date to end of the year and time to 23:59:59
      *
-     * @return static
+     * @return self
      */
-    public function endOfYear(): ChronosInterface
+    public function endOfYear(): self
     {
         return $this->modify('last day of december, 23:59:59');
     }
@@ -833,9 +833,9 @@ trait ModifierTrait
     /**
      * Resets the date to the first day of the decade and the time to 00:00:00
      *
-     * @return static
+     * @return self
      */
-    public function startOfDecade(): ChronosInterface
+    public function startOfDecade(): self
     {
         $year = $this->year - $this->year % ChronosInterface::YEARS_PER_DECADE;
 
@@ -845,9 +845,9 @@ trait ModifierTrait
     /**
      * Resets the date to end of the decade and time to 23:59:59
      *
-     * @return static
+     * @return self
      */
-    public function endOfDecade(): ChronosInterface
+    public function endOfDecade(): self
     {
         $year = $this->year - $this->year % ChronosInterface::YEARS_PER_DECADE + ChronosInterface::YEARS_PER_DECADE - 1;
 
@@ -857,9 +857,9 @@ trait ModifierTrait
     /**
      * Resets the date to the first day of the century and the time to 00:00:00
      *
-     * @return static
+     * @return self
      */
-    public function startOfCentury(): ChronosInterface
+    public function startOfCentury(): self
     {
         $year = $this->startOfYear()
             ->year($this->year - 1 - ($this->year - 1) % ChronosInterface::YEARS_PER_CENTURY + 1)
@@ -871,9 +871,9 @@ trait ModifierTrait
     /**
      * Resets the date to end of the century and time to 23:59:59
      *
-     * @return static
+     * @return self
      */
-    public function endOfCentury(): ChronosInterface
+    public function endOfCentury(): self
     {
         $y = $this->year - 1
             - ($this->year - 1)
@@ -890,9 +890,9 @@ trait ModifierTrait
     /**
      * Resets the date to the first day of week (defined in $weekStartsAt) and the time to 00:00:00
      *
-     * @return static
+     * @return self
      */
-    public function startOfWeek(): ChronosInterface
+    public function startOfWeek(): self
     {
         $dt = $this;
         if ($dt->dayOfWeek !== static::$weekStartsAt) {
@@ -905,9 +905,9 @@ trait ModifierTrait
     /**
      * Resets the date to end of week (defined in $weekEndsAt) and time to 23:59:59
      *
-     * @return static
+     * @return self
      */
-    public function endOfWeek(): ChronosInterface
+    public function endOfWeek(): self
     {
         $dt = $this;
         if ($dt->dayOfWeek !== static::$weekEndsAt) {
@@ -924,9 +924,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function next(?int $dayOfWeek = null)
+    public function next(?int $dayOfWeek = null): self
     {
         if ($dayOfWeek === null) {
             $dayOfWeek = $this->dayOfWeek;
@@ -944,9 +944,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function previous(?int $dayOfWeek = null)
+    public function previous(?int $dayOfWeek = null): self
     {
         if ($dayOfWeek === null) {
             $dayOfWeek = $this->dayOfWeek;
@@ -964,9 +964,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function firstOfMonth(?int $dayOfWeek = null)
+    public function firstOfMonth(?int $dayOfWeek = null): self
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -980,9 +980,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function lastOfMonth(?int $dayOfWeek = null)
+    public function lastOfMonth(?int $dayOfWeek = null): self
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -997,7 +997,7 @@ trait ModifierTrait
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self|false
      */
     public function nthOfMonth(int $nth, int $dayOfWeek)
     {
@@ -1015,9 +1015,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function firstOfQuarter(?int $dayOfWeek = null)
+    public function firstOfQuarter(?int $dayOfWeek = null): self
     {
         return $this
             ->day(1)
@@ -1032,9 +1032,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function lastOfQuarter(?int $dayOfWeek = null)
+    public function lastOfQuarter(?int $dayOfWeek = null): self
     {
         return $this
             ->day(1)
@@ -1050,7 +1050,7 @@ trait ModifierTrait
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self|false
      */
     public function nthOfQuarter(int $nth, int $dayOfWeek)
     {
@@ -1069,9 +1069,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function firstOfYear(?int $dayOfWeek = null)
+    public function firstOfYear(?int $dayOfWeek = null): self
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -1085,9 +1085,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self
      */
-    public function lastOfYear(?int $dayOfWeek = null)
+    public function lastOfYear(?int $dayOfWeek = null): self
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -1102,7 +1102,7 @@ trait ModifierTrait
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return self|false
      */
     public function nthOfYear(int $nth, int $dayOfWeek)
     {
@@ -1115,9 +1115,9 @@ trait ModifierTrait
      * Modify the current instance to the average of a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return static
+     * @return self
      */
-    public function average(?ChronosInterface $dt = null): ChronosInterface
+    public function average(?ChronosInterface $dt = null): self
     {
         $dt = $dt ?? static::now($this->tz);
 

--- a/src/Traits/TimezoneTrait.php
+++ b/src/Traits/TimezoneTrait.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
-
 /**
  * Methods for modifying/reading timezone data.
  */
@@ -26,9 +24,9 @@ trait TimezoneTrait
      * Alias for setTimezone()
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return self
      */
-    public function timezone($value): ChronosInterface
+    public function timezone($value): self
     {
         return $this->setTimezone($value);
     }
@@ -37,9 +35,9 @@ trait TimezoneTrait
      * Alias for setTimezone()
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return self
      */
-    public function tz($value): ChronosInterface
+    public function tz($value): self
     {
         return $this->setTimezone($value);
     }
@@ -48,9 +46,9 @@ trait TimezoneTrait
      * Set the instance's timezone from a string or object
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return static
+     * @return self
      */
-    public function setTimezone($value): ChronosInterface
+    public function setTimezone($value): self
     {
         return parent::setTimezone(static::safeCreateDateTimeZone($value));
     }


### PR DESCRIPTION
Refs https://github.com/cakephp/chronos/issues/293

* Replace `ChronosInterface` return type on non-static methods with `self`
* Replace missing return type on static methods with `static`
* Replace `mixed` return types on non-static methods with `self`

Previously, a lot of `@return` types were `static` instead of `self`. Only static methods need static binding type.