### PR TITLE
Replace ChronosInterface return types with static

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -147,7 +147,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      *
      * @return static
      */
-    public function copy(): ChronosInterface
+    public function copy(): static
     {
         return clone $this;
     }

--- a/src/ChronosInterface.php
+++ b/src/ChronosInterface.php
@@ -19,7 +19,7 @@ use DateTimeInterface;
 /**
  * An extension to the DateTimeInterface for a friendlier API
  *
- * @method \Cake\Chronos\ChronosInterface modify(string $relative)
+ * @method static modify(string $relative)
  */
 interface ChronosInterface extends DateTimeInterface
 {
@@ -102,14 +102,14 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function now($tz): self;
+    public static function now($tz): static;
 
     /**
      * Get a copy of the instance
      *
      * @return static
      */
-    public function copy(): self;
+    public function copy(): static;
 
     /**
      * Set the instance's year
@@ -125,7 +125,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The month value.
      * @return static
      */
-    public function month(int $value): self;
+    public function month(int $value): static;
 
     /**
      * Set the instance's day
@@ -133,7 +133,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The day value.
      * @return static
      */
-    public function day(int $value): self;
+    public function day(int $value): static;
 
     /**
      * Set the instance's hour
@@ -141,7 +141,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The hour value.
      * @return static
      */
-    public function hour(int $value): self;
+    public function hour(int $value): static;
 
     /**
      * Set the instance's minute
@@ -149,7 +149,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The minute value.
      * @return static
      */
-    public function minute(int $value): self;
+    public function minute(int $value): static;
 
     /**
      * Set the instance's second
@@ -157,7 +157,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The seconds value.
      * @return static
      */
-    public function second(int $value): self;
+    public function second(int $value): static;
 
     /**
      * Set the date and time all together
@@ -170,7 +170,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $second The second to set.
      * @return static
      */
-    public function setDateTime(int $year, int $month, int $day, int $hour, int $minute, int $second = 0): self;
+    public function setDateTime(int $year, int $month, int $day, int $hour, int $minute, int $second = 0): static;
 
     /**
      * Set the time by time string
@@ -178,7 +178,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param string $time Time as string.
      * @return static
      */
-    public function setTimeFromTimeString(string $time): self;
+    public function setTimeFromTimeString(string $time): static;
 
     /**
      * Set the instance's timestamp
@@ -186,7 +186,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The timestamp value to set.
      * @return static
      */
-    public function timestamp(int $value): self;
+    public function timestamp(int $value): static;
 
     /**
      * Alias for setTimezone()
@@ -194,7 +194,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function timezone($value);
+    public function timezone($value): static;
 
     /**
      * Alias for setTimezone()
@@ -202,7 +202,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function tz($value);
+    public function tz($value): static;
 
     /**
      * Set the instance's timezone from a string or object
@@ -210,7 +210,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function setTimezone($value);
+    public function setTimezone($value): static;
 
     /**
      * Format the instance as date
@@ -441,34 +441,34 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
      * @param \Cake\Chronos\ChronosInterface $dt2 The instance to compare with.
-     * @return static
+     * @return \Cake\Chronos\ChronosInterface
      */
-    public function closest(ChronosInterface $dt1, ChronosInterface $dt2): self;
+    public function closest(ChronosInterface $dt1, ChronosInterface $dt2): ChronosInterface;
 
     /**
      * Get the farthest date from the instance.
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
      * @param \Cake\Chronos\ChronosInterface $dt2 The instance to compare with.
-     * @return static
+     * @return \Cake\Chronos\ChronosInterface
      */
-    public function farthest(ChronosInterface $dt1, ChronosInterface $dt2): self;
+    public function farthest(ChronosInterface $dt1, ChronosInterface $dt2): ChronosInterface;
 
     /**
      * Get the minimum instance between a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return static
+     * @return \Cake\Chronos\ChronosInterface
      */
-    public function min(?ChronosInterface $dt = null): self;
+    public function min(?ChronosInterface $dt = null): ChronosInterface;
 
     /**
      * Get the maximum instance between a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return static
+     * @return \Cake\Chronos\ChronosInterface
      */
-    public function max(?ChronosInterface $dt = null): self;
+    public function max(?ChronosInterface $dt = null): ChronosInterface;
 
     /**
      * Determines if the instance is a weekday
@@ -622,7 +622,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYears(int $value): self;
+    public function addYears(int $value): static;
 
     /**
      * Add a year to the instance
@@ -632,7 +632,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYear(int $value = 1): self;
+    public function addYear(int $value = 1): static;
 
     /**
      * Remove years from the instance.
@@ -642,7 +642,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYears(int $value): self;
+    public function subYears(int $value): static;
 
     /**
      * Remove a year from the instance.
@@ -652,7 +652,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYear(int $value = 1): self;
+    public function subYear(int $value = 1): static;
 
     /**
      * Add years with overflowing to the instance. Positive $value
@@ -669,7 +669,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYearsWithOverflow(int $value): self;
+    public function addYearsWithOverflow(int $value): static;
 
     /**
      * Add a year with overflow to the instance
@@ -679,7 +679,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYearWithOverflow(int $value = 1): self;
+    public function addYearWithOverflow(int $value = 1): static;
 
     /**
      * Remove years with overflow from the instance
@@ -689,7 +689,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYearsWithOverflow(int $value): self;
+    public function subYearsWithOverflow(int $value): static;
 
     /**
      * Remove a year with overflow from the instance
@@ -699,7 +699,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYearWithOverflow(int $value = 1): self;
+    public function subYearWithOverflow(int $value = 1): static;
 
     /**
      * Add months to the instance. Positive $value travels forward while
@@ -719,7 +719,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonths(int $value): self;
+    public function addMonths(int $value): static;
 
     /**
      * Add a month to the instance.
@@ -729,7 +729,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonth(int $value = 1): self;
+    public function addMonth(int $value = 1): static;
 
     /**
      * Remove a month from the instance
@@ -739,7 +739,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonth(int $value = 1): self;
+    public function subMonth(int $value = 1): static;
 
     /**
      * Remove months from the instance.
@@ -749,7 +749,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonths(int $value): self;
+    public function subMonths(int $value): static;
 
     /**
      * Add months with overflowing to the instance. Positive $value
@@ -766,7 +766,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonthsWithOverflow(int $value): self;
+    public function addMonthsWithOverflow(int $value): static;
 
     /**
      * Add a month with overflow to the instance.
@@ -776,7 +776,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonthWithOverflow(int $value = 1): self;
+    public function addMonthWithOverflow(int $value = 1): static;
 
     /**
      * Remove months with overflow from the instance.
@@ -786,7 +786,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonthsWithOverflow(int $value): self;
+    public function subMonthsWithOverflow(int $value): static;
 
     /**
      * Remove a month with overflow from the instance.
@@ -796,7 +796,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonthWithOverflow(int $value = 1): self;
+    public function subMonthWithOverflow(int $value = 1): static;
 
     /**
      * Add days to the instance. Positive $value travels forward while
@@ -805,7 +805,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of days to add.
      * @return static
      */
-    public function addDays(int $value): self;
+    public function addDays(int $value): static;
 
     /**
      * Add a day to the instance
@@ -813,7 +813,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of days to add.
      * @return static
      */
-    public function addDay(int $value = 1): self;
+    public function addDay(int $value = 1): static;
 
     /**
      * Remove days from the instance
@@ -821,7 +821,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of days to remove.
      * @return static
      */
-    public function subDays(int $value): self;
+    public function subDays(int $value): static;
 
     /**
      * Remove a day from the instance
@@ -829,7 +829,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of days to remove.
      * @return static
      */
-    public function subDay(int $value = 1): self;
+    public function subDay(int $value = 1): static;
 
     /**
      * Add weekdays to the instance. Positive $value travels forward while
@@ -838,7 +838,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of weekdays to add.
      * @return static
      */
-    public function addWeekdays(int $value): self;
+    public function addWeekdays(int $value): static;
 
     /**
      * Add a weekday to the instance
@@ -846,7 +846,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of weekdays to add.
      * @return static
      */
-    public function addWeekday(int $value = 1): self;
+    public function addWeekday(int $value = 1): static;
 
     /**
      * Remove a weekday from the instance
@@ -854,7 +854,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of weekdays to remove.
      * @return static
      */
-    public function subWeekday(int $value = 1): self;
+    public function subWeekday(int $value = 1): static;
 
     /**
      * Remove weekdays from the instance
@@ -862,7 +862,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of weekdays to remove.
      * @return static
      */
-    public function subWeekdays(int $value): self;
+    public function subWeekdays(int $value): static;
 
     /**
      * Add weeks to the instance. Positive $value travels forward while
@@ -871,7 +871,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of weeks to add.
      * @return static
      */
-    public function addWeeks(int $value): self;
+    public function addWeeks(int $value): static;
 
     /**
      * Add a week to the instance
@@ -879,7 +879,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of weeks to add.
      * @return static
      */
-    public function addWeek(int $value = 1): self;
+    public function addWeek(int $value = 1): static;
 
     /**
      * Remove a week from the instance
@@ -887,7 +887,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of weeks to remove.
      * @return static
      */
-    public function subWeek(int $value = 1): self;
+    public function subWeek(int $value = 1): static;
 
     /**
      * Remove weeks to the instance
@@ -895,7 +895,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of weeks to remove.
      * @return static
      */
-    public function subWeeks(int $value): self;
+    public function subWeeks(int $value): static;
 
     /**
      * Add hours to the instance. Positive $value travels forward while
@@ -904,7 +904,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of hours to add.
      * @return static
      */
-    public function addHours(int $value): self;
+    public function addHours(int $value): static;
 
     /**
      * Add an hour to the instance
@@ -912,7 +912,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of hours to add.
      * @return static
      */
-    public function addHour(int $value = 1): self;
+    public function addHour(int $value = 1): static;
 
     /**
      * Remove an hour from the instance
@@ -920,7 +920,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of hours to remove.
      * @return static
      */
-    public function subHour(int $value = 1): self;
+    public function subHour(int $value = 1): static;
 
     /**
      * Remove hours from the instance
@@ -928,7 +928,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of hours to remove.
      * @return static
      */
-    public function subHours(int $value): self;
+    public function subHours(int $value): static;
 
     /**
      * Add minutes to the instance. Positive $value travels forward while
@@ -937,7 +937,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of minutes to add.
      * @return static
      */
-    public function addMinutes(int $value): self;
+    public function addMinutes(int $value): static;
 
     /**
      * Add a minute to the instance
@@ -945,7 +945,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of minutes to add.
      * @return static
      */
-    public function addMinute(int $value = 1): self;
+    public function addMinute(int $value = 1): static;
 
     /**
      * Remove a minute from the instance
@@ -953,7 +953,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of minutes to remove.
      * @return static
      */
-    public function subMinute(int $value = 1): self;
+    public function subMinute(int $value = 1): static;
 
     /**
      * Remove minutes from the instance
@@ -961,7 +961,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of minutes to remove.
      * @return static
      */
-    public function subMinutes(int $value): self;
+    public function subMinutes(int $value): static;
 
     /**
      * Add seconds to the instance. Positive $value travels forward while
@@ -970,7 +970,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of seconds to add.
      * @return static
      */
-    public function addSeconds(int $value): self;
+    public function addSeconds(int $value): static;
 
     /**
      * Add a second to the instance
@@ -978,7 +978,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of seconds to add.
      * @return static
      */
-    public function addSecond(int $value = 1): self;
+    public function addSecond(int $value = 1): static;
 
     /**
      * Remove a second from the instance
@@ -986,7 +986,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of seconds to remove.
      * @return static
      */
-    public function subSecond(int $value = 1): self;
+    public function subSecond(int $value = 1): static;
 
     /**
      * Remove seconds from the instance
@@ -994,7 +994,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The number of seconds to remove.
      * @return static
      */
-    public function subSeconds(int $value): self;
+    public function subSeconds(int $value): static;
 
     /**
      * Get the difference in a human readable format in the current locale.
@@ -1157,84 +1157,84 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @return static
      */
-    public function startOfDay(): self;
+    public function startOfDay(): static;
 
     /**
      * Resets the time to 23:59:59
      *
      * @return static
      */
-    public function endOfDay(): self;
+    public function endOfDay(): static;
 
     /**
      * Resets the date to the first day of the month and the time to 00:00:00
      *
      * @return static
      */
-    public function startOfMonth(): self;
+    public function startOfMonth(): static;
 
     /**
      * Resets the date to end of the month and time to 23:59:59
      *
      * @return static
      */
-    public function endOfMonth(): self;
+    public function endOfMonth(): static;
 
     /**
      * Resets the date to the first day of the year and the time to 00:00:00
      *
      * @return static
      */
-    public function startOfYear(): self;
+    public function startOfYear(): static;
 
     /**
      * Resets the date to end of the year and time to 23:59:59
      *
      * @return static
      */
-    public function endOfYear(): self;
+    public function endOfYear(): static;
 
     /**
      * Resets the date to the first day of the decade and the time to 00:00:00
      *
      * @return static
      */
-    public function startOfDecade(): self;
+    public function startOfDecade(): static;
 
     /**
      * Resets the date to end of the decade and time to 23:59:59
      *
      * @return static
      */
-    public function endOfDecade(): self;
+    public function endOfDecade(): static;
 
     /**
      * Resets the date to the first day of the century and the time to 00:00:00
      *
      * @return static
      */
-    public function startOfCentury(): self;
+    public function startOfCentury(): static;
 
     /**
      * Resets the date to end of the century and time to 23:59:59
      *
      * @return static
      */
-    public function endOfCentury(): self;
+    public function endOfCentury(): static;
 
     /**
      * Resets the date to the first day of week (defined in $weekStartsAt) and the time to 00:00:00
      *
      * @return static
      */
-    public function startOfWeek(): self;
+    public function startOfWeek(): static;
 
     /**
      * Resets the date to end of week (defined in $weekEndsAt) and time to 23:59:59
      *
      * @return static
      */
-    public function endOfWeek(): self;
+    public function endOfWeek(): static;
 
     /**
      * Modify to the next occurrence of a given day of the week.
@@ -1243,9 +1243,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function next(?int $dayOfWeek = null);
+    public function next(?int $dayOfWeek = null): static;
 
     /**
      * Modify to the previous occurrence of a given day of the week.
@@ -1254,9 +1254,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function previous(?int $dayOfWeek = null);
+    public function previous(?int $dayOfWeek = null): static;
 
     /**
      * Modify to the first occurrence of a given day of the week
@@ -1265,9 +1265,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfMonth(?int $dayOfWeek = null);
+    public function firstOfMonth(?int $dayOfWeek = null): static;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1276,9 +1276,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfMonth(?int $dayOfWeek = null);
+    public function lastOfMonth(?int $dayOfWeek = null): static;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1288,9 +1288,9 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfMonth(int $nth, int $dayOfWeek);
+    public function nthOfMonth(int $nth, int $dayOfWeek): static|false;
 
     /**
      * Modify to the first occurrence of a given day of the week
@@ -1299,9 +1299,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfQuarter(?int $dayOfWeek = null);
+    public function firstOfQuarter(?int $dayOfWeek = null): static;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1310,9 +1310,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfQuarter(?int $dayOfWeek = null);
+    public function lastOfQuarter(?int $dayOfWeek = null): static;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1322,9 +1322,9 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfQuarter(int $nth, int $dayOfWeek);
+    public function nthOfQuarter(int $nth, int $dayOfWeek): static|false;
 
     /**
      * Modify to the first occurrence of a given day of the week
@@ -1333,9 +1333,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfYear(?int $dayOfWeek = null);
+    public function firstOfYear(?int $dayOfWeek = null): static;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1344,9 +1344,9 @@ interface ChronosInterface extends DateTimeInterface
      * to indicate the desired dayOfWeek, ex. static::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfYear(?int $dayOfWeek = null);
+    public function lastOfYear(?int $dayOfWeek = null): static;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1356,9 +1356,9 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfYear(int $nth, int $dayOfWeek);
+    public function nthOfYear(int $nth, int $dayOfWeek): static|false;
 
     /**
      * Modify the current instance to the average of a given instance (default now) and the current instance.
@@ -1366,7 +1366,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return static
      */
-    public function average(?ChronosInterface $dt = null): self;
+    public function average(?ChronosInterface $dt = null): static;
 
     /**
      * Check if its the birthday. Compares the date/month values of the two dates.

--- a/src/Traits/CopyTrait.php
+++ b/src/Traits/CopyTrait.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
-
 /**
  * Provides methods for copying datetime objects.
  *
@@ -28,7 +26,7 @@ trait CopyTrait
      *
      * @return static
      */
-    public function copy(): ChronosInterface
+    public function copy(): static
     {
         return static::instance($this);
     }

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
@@ -37,7 +36,7 @@ trait FactoryTrait
      * @param \DateTimeInterface $dt The datetime instance to convert.
      * @return static
      */
-    public static function instance(DateTimeInterface $dt): ChronosInterface
+    public static function instance(DateTimeInterface $dt): static
     {
         if ($dt instanceof static) {
             return clone $dt;
@@ -56,7 +55,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function parse($time = 'now', $tz = null): ChronosInterface
+    public static function parse($time = 'now', $tz = null): static
     {
         return new static($time, $tz);
     }
@@ -67,7 +66,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function now($tz = null): ChronosInterface
+    public static function now($tz = null): static
     {
         return new static('now', $tz);
     }
@@ -78,7 +77,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The timezone to use.
      * @return static
      */
-    public static function today($tz = null): ChronosInterface
+    public static function today($tz = null): static
     {
         return new static('midnight', $tz);
     }
@@ -89,7 +88,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function tomorrow($tz = null): ChronosInterface
+    public static function tomorrow($tz = null): static
     {
         return new static('tomorrow, midnight', $tz);
     }
@@ -100,7 +99,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function yesterday($tz = null): ChronosInterface
+    public static function yesterday($tz = null): static
     {
         return new static('yesterday, midnight', $tz);
     }
@@ -108,9 +107,9 @@ trait FactoryTrait
     /**
      * Create a ChronosInterface instance for the greatest supported date.
      *
-     * @return \Cake\Chronos\ChronosInterface
+     * @return static
      */
-    public static function maxValue(): ChronosInterface
+    public static function maxValue(): static
     {
         return static::createFromTimestampUTC(PHP_INT_MAX);
     }
@@ -118,9 +117,9 @@ trait FactoryTrait
     /**
      * Create a ChronosInterface instance for the lowest supported date.
      *
-     * @return \Cake\Chronos\ChronosInterface
+     * @return static
      */
-    public static function minValue(): ChronosInterface
+    public static function minValue(): static
     {
         $max = PHP_INT_SIZE === 4 ? PHP_INT_MAX : PHP_INT_MAX / 10;
 
@@ -157,7 +156,7 @@ trait FactoryTrait
         ?int $second = null,
         ?int $microsecond = null,
         $tz = null
-    ): ChronosInterface {
+    ): static {
         $now = static::now();
         $year = $year ?? (int)$now->format('Y');
         $month = $month ?? $now->format('m');
@@ -197,7 +196,7 @@ trait FactoryTrait
         ?int $month = null,
         ?int $day = null,
         $tz = null
-    ): ChronosInterface {
+    ): static {
         return static::create($year, $month, $day, null, null, null, null, $tz);
     }
 
@@ -217,7 +216,7 @@ trait FactoryTrait
         ?int $second = null,
         ?int $microsecond = null,
         $tz = null
-    ): ChronosInterface {
+    ): static {
         return static::create(null, null, null, $hour, $minute, $second, $microsecond, $tz);
     }
 
@@ -230,7 +229,7 @@ trait FactoryTrait
      * @return static
      * @throws \InvalidArgumentException
      */
-    public static function createFromFormat($format, $time, $tz = null): ChronosInterface
+    public static function createFromFormat($format, $time, $tz = null): static
     {
         if ($tz !== null) {
             $dt = parent::createFromFormat($format, $time, static::safeCreateDateTimeZone($tz));
@@ -271,7 +270,7 @@ trait FactoryTrait
      * @param (int|string)[] $values Array of date and time values.
      * @return static
      */
-    public static function createFromArray(array $values): ChronosInterface
+    public static function createFromArray(array $values): static
     {
         $values += ['hour' => 0, 'minute' => 0, 'second' => 0, 'microsecond' => 0, 'timezone' => null];
 
@@ -311,7 +310,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function createFromTimestamp(int $timestamp, $tz = null): ChronosInterface
+    public static function createFromTimestamp(int $timestamp, $tz = null): static
     {
         return static::now($tz)->setTimestamp($timestamp);
     }
@@ -322,7 +321,7 @@ trait FactoryTrait
      * @param int $timestamp The UTC timestamp to create an instance from.
      * @return static
      */
-    public static function createFromTimestampUTC(int $timestamp): ChronosInterface
+    public static function createFromTimestampUTC(int $timestamp): static
     {
         return new static($timestamp);
     }

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
 use DateTimeImmutable;
 use DateTimeInterface;
 
@@ -75,7 +74,7 @@ trait FrozenTimeTrait
      * @param int $microseconds The microseconds to set (ignored)
      * @return static A modified Date instance.
      */
-    public function setTime($hours, $minutes, $seconds = null, $microseconds = null): ChronosInterface
+    public function setTime($hours, $minutes, $seconds = null, $microseconds = null): static
     {
         return parent::setTime(0, 0, 0, 0);
     }
@@ -88,7 +87,7 @@ trait FrozenTimeTrait
      * @param \DateInterval $interval The interval to modify this date by.
      * @return static A modified Date instance
      */
-    public function add($interval): ChronosInterface
+    public function add($interval): static
     {
         return parent::add($interval)->setTime(0, 0, 0);
     }
@@ -101,7 +100,7 @@ trait FrozenTimeTrait
      * @param \DateInterval $interval The interval to modify this date by.
      * @return static A modified Date instance
      */
-    public function sub($interval): ChronosInterface
+    public function sub($interval): static
     {
         return parent::sub($interval)->setTime(0, 0, 0);
     }
@@ -112,9 +111,9 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return static
      */
-    public function timezone($value)
+    public function timezone($value): static
     {
         return $this;
     }
@@ -125,9 +124,9 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return static
      */
-    public function tz($value)
+    public function tz($value): static
     {
         return $this;
     }
@@ -138,9 +137,9 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return static
      */
-    public function setTimezone($value)
+    public function setTimezone($value): static
     {
         return $this;
     }
@@ -154,7 +153,7 @@ trait FrozenTimeTrait
      * @param int $value The timestamp value to set.
      * @return static
      */
-    public function setTimestamp($value): ChronosInterface
+    public function setTimestamp($value): static
     {
         return parent::setTimestamp($value)->setTime(0, 0, 0);
     }
@@ -168,7 +167,7 @@ trait FrozenTimeTrait
      * @param string $relative The relative change to make.
      * @return static A new date with the applied date changes.
      */
-    public function modify($relative): ChronosInterface
+    public function modify($relative): static
     {
         if (preg_match('/hour|minute|second/', $relative)) {
             return $this;

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -109,7 +109,7 @@ trait ModifierTrait
      * @param int $day The day to set.
      * @return static
      */
-    public function setDate($year, $month, $day): ChronosInterface
+    public function setDate($year, $month, $day): static
     {
         return $this->modify('+0 day')->setDateParent($year, $month, $day);
     }
@@ -123,7 +123,7 @@ trait ModifierTrait
      * @param int $day The day to set.
      * @return static
      */
-    private function setDateParent(int $year, int $month, int $day): ChronosInterface
+    private function setDateParent(int $year, int $month, int $day): static
     {
         return parent::setDate($year, $month, $day);
     }
@@ -146,7 +146,7 @@ trait ModifierTrait
         int $hour,
         int $minute,
         int $second = 0
-    ): ChronosInterface {
+    ): static {
         return $this->setDate($year, $month, $day)->setTime($hour, $minute, $second);
     }
 
@@ -156,7 +156,7 @@ trait ModifierTrait
      * @param string $time Time as string.
      * @return static
      */
-    public function setTimeFromTimeString(string $time): ChronosInterface
+    public function setTimeFromTimeString(string $time): static
     {
         $time = explode(':', $time);
         $hour = $time[0];
@@ -172,7 +172,7 @@ trait ModifierTrait
      * @param int $value The timestamp value to set.
      * @return static
      */
-    public function timestamp(int $value): ChronosInterface
+    public function timestamp(int $value): static
     {
         return $this->setTimestamp($value);
     }
@@ -183,7 +183,7 @@ trait ModifierTrait
      * @param int $value The year value.
      * @return static
      */
-    public function year(int $value): ChronosInterface
+    public function year(int $value): static
     {
         return $this->setDate($value, $this->month, $this->day);
     }
@@ -194,7 +194,7 @@ trait ModifierTrait
      * @param int $value The month value.
      * @return static
      */
-    public function month(int $value): ChronosInterface
+    public function month(int $value): static
     {
         return $this->setDate($this->year, $value, $this->day);
     }
@@ -205,7 +205,7 @@ trait ModifierTrait
      * @param int $value The day value.
      * @return static
      */
-    public function day(int $value): ChronosInterface
+    public function day(int $value): static
     {
         return $this->setDate($this->year, $this->month, $value);
     }
@@ -216,7 +216,7 @@ trait ModifierTrait
      * @param int $value The hour value.
      * @return static
      */
-    public function hour(int $value): ChronosInterface
+    public function hour(int $value): static
     {
         return $this->setTime($value, $this->minute, $this->second);
     }
@@ -227,7 +227,7 @@ trait ModifierTrait
      * @param int $value The minute value.
      * @return static
      */
-    public function minute(int $value): ChronosInterface
+    public function minute(int $value): static
     {
         return $this->setTime($this->hour, $value, $this->second);
     }
@@ -238,7 +238,7 @@ trait ModifierTrait
      * @param int $value The seconds value.
      * @return static
      */
-    public function second(int $value): ChronosInterface
+    public function second(int $value): static
     {
         return $this->setTime($this->hour, $this->minute, $value);
     }
@@ -261,7 +261,7 @@ trait ModifierTrait
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYears(int $value): ChronosInterface
+    public function addYears(int $value): static
     {
         $month = $this->month;
         $date = $this->modify($value . ' year');
@@ -281,7 +281,7 @@ trait ModifierTrait
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYear(int $value = 1): ChronosInterface
+    public function addYear(int $value = 1): static
     {
         return $this->addYears($value);
     }
@@ -294,7 +294,7 @@ trait ModifierTrait
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYears(int $value): ChronosInterface
+    public function subYears(int $value): static
     {
         return $this->addYears(-1 * $value);
     }
@@ -307,7 +307,7 @@ trait ModifierTrait
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYear(int $value = 1): ChronosInterface
+    public function subYear(int $value = 1): static
     {
         return $this->subYears($value);
     }
@@ -327,7 +327,7 @@ trait ModifierTrait
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYearsWithOverflow(int $value): ChronosInterface
+    public function addYearsWithOverflow(int $value): static
     {
         return $this->modify($value . ' year');
     }
@@ -340,7 +340,7 @@ trait ModifierTrait
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYearWithOverflow(int $value = 1): ChronosInterface
+    public function addYearWithOverflow(int $value = 1): static
     {
         return $this->addYearsWithOverflow($value);
     }
@@ -353,7 +353,7 @@ trait ModifierTrait
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYearsWithOverflow(int $value): ChronosInterface
+    public function subYearsWithOverflow(int $value): static
     {
         return $this->addYearsWithOverflow(-1 * $value);
     }
@@ -366,7 +366,7 @@ trait ModifierTrait
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYearWithOverflow(int $value = 1): ChronosInterface
+    public function subYearWithOverflow(int $value = 1): static
     {
         return $this->subYearsWithOverflow($value);
     }
@@ -390,7 +390,7 @@ trait ModifierTrait
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonths(int $value): ChronosInterface
+    public function addMonths(int $value): static
     {
         $day = $this->day;
         $date = $this->modify($value . ' month');
@@ -410,7 +410,7 @@ trait ModifierTrait
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonth(int $value = 1): ChronosInterface
+    public function addMonth(int $value = 1): static
     {
         return $this->addMonths($value);
     }
@@ -423,7 +423,7 @@ trait ModifierTrait
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonth(int $value = 1): ChronosInterface
+    public function subMonth(int $value = 1): static
     {
         return $this->subMonths($value);
     }
@@ -436,7 +436,7 @@ trait ModifierTrait
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonths(int $value): ChronosInterface
+    public function subMonths(int $value): static
     {
         return $this->addMonths(-1 * $value);
     }
@@ -456,7 +456,7 @@ trait ModifierTrait
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonthsWithOverflow(int $value): ChronosInterface
+    public function addMonthsWithOverflow(int $value): static
     {
         return $this->modify($value . ' month');
     }
@@ -469,7 +469,7 @@ trait ModifierTrait
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonthWithOverflow(int $value = 1): ChronosInterface
+    public function addMonthWithOverflow(int $value = 1): static
     {
         return $this->modify($value . ' month');
     }
@@ -482,7 +482,7 @@ trait ModifierTrait
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonthsWithOverflow(int $value): ChronosInterface
+    public function subMonthsWithOverflow(int $value): static
     {
         return $this->addMonthsWithOverflow(-1 * $value);
     }
@@ -495,7 +495,7 @@ trait ModifierTrait
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonthWithOverflow(int $value = 1): ChronosInterface
+    public function subMonthWithOverflow(int $value = 1): static
     {
         return $this->subMonthsWithOverflow($value);
     }
@@ -507,7 +507,7 @@ trait ModifierTrait
      * @param int $value The number of days to add.
      * @return static
      */
-    public function addDays(int $value): ChronosInterface
+    public function addDays(int $value): static
     {
         return $this->modify("$value day");
     }
@@ -518,7 +518,7 @@ trait ModifierTrait
      * @param int $value The number of days to add.
      * @return static
      */
-    public function addDay(int $value = 1): ChronosInterface
+    public function addDay(int $value = 1): static
     {
         return $this->modify("$value day");
     }
@@ -529,7 +529,7 @@ trait ModifierTrait
      * @param int $value The number of days to remove.
      * @return static
      */
-    public function subDay(int $value = 1): ChronosInterface
+    public function subDay(int $value = 1): static
     {
         return $this->modify("-$value day");
     }
@@ -540,7 +540,7 @@ trait ModifierTrait
      * @param int $value The number of days to remove.
      * @return static
      */
-    public function subDays(int $value): ChronosInterface
+    public function subDays(int $value): static
     {
         return $this->modify("-$value day");
     }
@@ -552,7 +552,7 @@ trait ModifierTrait
      * @param int $value The number of weekdays to add.
      * @return static
      */
-    public function addWeekdays(int $value): ChronosInterface
+    public function addWeekdays(int $value): static
     {
         return $this->modify((int)$value . ' weekdays ' . $this->format('H:i:s'));
     }
@@ -563,7 +563,7 @@ trait ModifierTrait
      * @param int $value The number of weekdays to add.
      * @return static
      */
-    public function addWeekday(int $value = 1): ChronosInterface
+    public function addWeekday(int $value = 1): static
     {
         return $this->addWeekdays($value);
     }
@@ -574,7 +574,7 @@ trait ModifierTrait
      * @param int $value The number of weekdays to remove.
      * @return static
      */
-    public function subWeekdays(int $value): ChronosInterface
+    public function subWeekdays(int $value): static
     {
         return $this->modify("$value weekdays ago, " . $this->format('H:i:s'));
     }
@@ -585,7 +585,7 @@ trait ModifierTrait
      * @param int $value The number of weekdays to remove.
      * @return static
      */
-    public function subWeekday(int $value = 1): ChronosInterface
+    public function subWeekday(int $value = 1): static
     {
         return $this->subWeekdays($value);
     }
@@ -597,7 +597,7 @@ trait ModifierTrait
      * @param int $value The number of weeks to add.
      * @return static
      */
-    public function addWeeks(int $value): ChronosInterface
+    public function addWeeks(int $value): static
     {
         return $this->modify("$value week");
     }
@@ -608,7 +608,7 @@ trait ModifierTrait
      * @param int $value The number of weeks to add.
      * @return static
      */
-    public function addWeek(int $value = 1): ChronosInterface
+    public function addWeek(int $value = 1): static
     {
         return $this->modify("$value week");
     }
@@ -619,7 +619,7 @@ trait ModifierTrait
      * @param int $value The number of weeks to remove.
      * @return static
      */
-    public function subWeek(int $value = 1): ChronosInterface
+    public function subWeek(int $value = 1): static
     {
         return $this->modify("-$value week");
     }
@@ -630,7 +630,7 @@ trait ModifierTrait
      * @param int $value The number of weeks to remove.
      * @return static
      */
-    public function subWeeks(int $value): ChronosInterface
+    public function subWeeks(int $value): static
     {
         return $this->modify("-$value week");
     }
@@ -642,7 +642,7 @@ trait ModifierTrait
      * @param int $value The number of hours to add.
      * @return static
      */
-    public function addHours(int $value): ChronosInterface
+    public function addHours(int $value): static
     {
         return $this->modify("$value hour");
     }
@@ -653,7 +653,7 @@ trait ModifierTrait
      * @param int $value The number of hours to add.
      * @return static
      */
-    public function addHour(int $value = 1): ChronosInterface
+    public function addHour(int $value = 1): static
     {
         return $this->modify("$value hour");
     }
@@ -664,7 +664,7 @@ trait ModifierTrait
      * @param int $value The number of hours to remove.
      * @return static
      */
-    public function subHour(int $value = 1): ChronosInterface
+    public function subHour(int $value = 1): static
     {
         return $this->modify("-$value hour");
     }
@@ -675,7 +675,7 @@ trait ModifierTrait
      * @param int $value The number of hours to remove.
      * @return static
      */
-    public function subHours(int $value): ChronosInterface
+    public function subHours(int $value): static
     {
         return $this->modify("-$value hour");
     }
@@ -687,7 +687,7 @@ trait ModifierTrait
      * @param int $value The number of minutes to add.
      * @return static
      */
-    public function addMinutes(int $value): ChronosInterface
+    public function addMinutes(int $value): static
     {
         return $this->modify("$value minute");
     }
@@ -698,7 +698,7 @@ trait ModifierTrait
      * @param int $value The number of minutes to add.
      * @return static
      */
-    public function addMinute(int $value = 1): ChronosInterface
+    public function addMinute(int $value = 1): static
     {
         return $this->modify("$value minute");
     }
@@ -709,7 +709,7 @@ trait ModifierTrait
      * @param int $value The number of minutes to remove.
      * @return static
      */
-    public function subMinute(int $value = 1): ChronosInterface
+    public function subMinute(int $value = 1): static
     {
         return $this->modify("-$value minute");
     }
@@ -720,7 +720,7 @@ trait ModifierTrait
      * @param int $value The number of minutes to remove.
      * @return static
      */
-    public function subMinutes(int $value): ChronosInterface
+    public function subMinutes(int $value): static
     {
         return $this->modify("-$value minute");
     }
@@ -732,7 +732,7 @@ trait ModifierTrait
      * @param int $value The number of seconds to add.
      * @return static
      */
-    public function addSeconds(int $value): ChronosInterface
+    public function addSeconds(int $value): static
     {
         return $this->modify("$value second");
     }
@@ -743,7 +743,7 @@ trait ModifierTrait
      * @param int $value The number of seconds to add.
      * @return static
      */
-    public function addSecond(int $value = 1): ChronosInterface
+    public function addSecond(int $value = 1): static
     {
         return $this->modify("$value second");
     }
@@ -754,7 +754,7 @@ trait ModifierTrait
      * @param int $value The number of seconds to remove.
      * @return static
      */
-    public function subSecond(int $value = 1): ChronosInterface
+    public function subSecond(int $value = 1): static
     {
         return $this->modify("-$value second");
     }
@@ -765,7 +765,7 @@ trait ModifierTrait
      * @param int $value The number of seconds to remove.
      * @return static
      */
-    public function subSeconds(int $value): ChronosInterface
+    public function subSeconds(int $value): static
     {
         return $this->modify("-$value second");
     }
@@ -775,7 +775,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfDay(): ChronosInterface
+    public function startOfDay(): static
     {
         return $this->modify('midnight');
     }
@@ -785,7 +785,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfDay(): ChronosInterface
+    public function endOfDay(): static
     {
         return $this->modify('23:59:59');
     }
@@ -795,7 +795,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfMonth(): ChronosInterface
+    public function startOfMonth(): static
     {
         return $this->modify('first day of this month midnight');
     }
@@ -805,7 +805,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfMonth(): ChronosInterface
+    public function endOfMonth(): static
     {
         return $this->modify('last day of this month, 23:59:59');
     }
@@ -815,7 +815,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfYear(): ChronosInterface
+    public function startOfYear(): static
     {
         return $this->modify('first day of january midnight');
     }
@@ -825,7 +825,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfYear(): ChronosInterface
+    public function endOfYear(): static
     {
         return $this->modify('last day of december, 23:59:59');
     }
@@ -835,7 +835,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfDecade(): ChronosInterface
+    public function startOfDecade(): static
     {
         $year = $this->year - $this->year % ChronosInterface::YEARS_PER_DECADE;
 
@@ -847,7 +847,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfDecade(): ChronosInterface
+    public function endOfDecade(): static
     {
         $year = $this->year - $this->year % ChronosInterface::YEARS_PER_DECADE + ChronosInterface::YEARS_PER_DECADE - 1;
 
@@ -859,7 +859,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfCentury(): ChronosInterface
+    public function startOfCentury(): static
     {
         $year = $this->startOfYear()
             ->year($this->year - 1 - ($this->year - 1) % ChronosInterface::YEARS_PER_CENTURY + 1)
@@ -873,7 +873,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfCentury(): ChronosInterface
+    public function endOfCentury(): static
     {
         $y = $this->year - 1
             - ($this->year - 1)
@@ -892,7 +892,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfWeek(): ChronosInterface
+    public function startOfWeek(): static
     {
         $dt = $this;
         if ($dt->dayOfWeek !== static::$weekStartsAt) {
@@ -907,7 +907,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfWeek(): ChronosInterface
+    public function endOfWeek(): static
     {
         $dt = $this;
         if ($dt->dayOfWeek !== static::$weekEndsAt) {
@@ -924,9 +924,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function next(?int $dayOfWeek = null)
+    public function next(?int $dayOfWeek = null): static
     {
         if ($dayOfWeek === null) {
             $dayOfWeek = $this->dayOfWeek;
@@ -944,9 +944,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function previous(?int $dayOfWeek = null)
+    public function previous(?int $dayOfWeek = null): static
     {
         if ($dayOfWeek === null) {
             $dayOfWeek = $this->dayOfWeek;
@@ -964,9 +964,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfMonth(?int $dayOfWeek = null)
+    public function firstOfMonth(?int $dayOfWeek = null): static
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -980,9 +980,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfMonth(?int $dayOfWeek = null)
+    public function lastOfMonth(?int $dayOfWeek = null): static
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -997,9 +997,9 @@ trait ModifierTrait
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfMonth(int $nth, int $dayOfWeek)
+    public function nthOfMonth(int $nth, int $dayOfWeek): static|false
     {
         $dt = $this->copy()->firstOfMonth();
         $check = $dt->format('Y-m');
@@ -1015,9 +1015,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfQuarter(?int $dayOfWeek = null)
+    public function firstOfQuarter(?int $dayOfWeek = null): static
     {
         return $this
             ->day(1)
@@ -1032,9 +1032,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfQuarter(?int $dayOfWeek = null)
+    public function lastOfQuarter(?int $dayOfWeek = null): static
     {
         return $this
             ->day(1)
@@ -1050,9 +1050,9 @@ trait ModifierTrait
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfQuarter(int $nth, int $dayOfWeek)
+    public function nthOfQuarter(int $nth, int $dayOfWeek): static|false
     {
         $dt = $this->copy()->day(1)->month($this->quarter * ChronosInterface::MONTHS_PER_QUARTER);
         $lastMonth = $dt->month;
@@ -1069,9 +1069,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfYear(?int $dayOfWeek = null)
+    public function firstOfYear(?int $dayOfWeek = null): static
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -1085,9 +1085,9 @@ trait ModifierTrait
      * to indicate the desired dayOfWeek, ex. ChronosInterface::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfYear(?int $dayOfWeek = null)
+    public function lastOfYear(?int $dayOfWeek = null): static
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -1102,9 +1102,9 @@ trait ModifierTrait
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfYear(int $nth, int $dayOfWeek)
+    public function nthOfYear(int $nth, int $dayOfWeek): static|false
     {
         $dt = $this->copy()->firstOfYear()->modify("+$nth " . static::$days[$dayOfWeek]);
 
@@ -1117,7 +1117,7 @@ trait ModifierTrait
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
      * @return static
      */
-    public function average(?ChronosInterface $dt = null): ChronosInterface
+    public function average(?ChronosInterface $dt = null): static
     {
         $dt = $dt ?? static::now($this->tz);
 

--- a/src/Traits/TimezoneTrait.php
+++ b/src/Traits/TimezoneTrait.php
@@ -15,8 +15,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
-
 /**
  * Methods for modifying/reading timezone data.
  */
@@ -28,7 +26,7 @@ trait TimezoneTrait
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function timezone($value): ChronosInterface
+    public function timezone($value): static
     {
         return $this->setTimezone($value);
     }
@@ -39,7 +37,7 @@ trait TimezoneTrait
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function tz($value): ChronosInterface
+    public function tz($value): static
     {
         return $this->setTimezone($value);
     }
@@ -50,7 +48,7 @@ trait TimezoneTrait
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function setTimezone($value): ChronosInterface
+    public function setTimezone($value): static
     {
         return parent::setTimezone(static::safeCreateDateTimeZone($value));
     }


### PR DESCRIPTION
Refs https://github.com/cakephp/chronos/issues/293

This starts preparing Chronos for php 8.1 support which requires compatible return types for internal methods.

This replaces all return types with `static` except for `closest()`, `farthest()`, `min()` and `max()`. These functions return the `ChronosInterface` that was passed in which presents a static analysis issue. You can't show that `ChronosInterface` is `static`. 



