### PR TITLE
Add missing bool return type to comparison functions

### DIFF
--- a/src/ChronosInterface.php
+++ b/src/ChronosInterface.php
@@ -339,7 +339,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function equals(ChronosInterface $dt);
+    public function equals(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is not equal to another
@@ -356,7 +356,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function notEquals(ChronosInterface $dt);
+    public function notEquals(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is greater (after) than another
@@ -373,7 +373,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function greaterThan(ChronosInterface $dt);
+    public function greaterThan(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is greater (after) than or equal to another
@@ -390,7 +390,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function greaterThanOrEquals(ChronosInterface $dt);
+    public function greaterThanOrEquals(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is less (before) than another
@@ -407,7 +407,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function lessThan(ChronosInterface $dt);
+    public function lessThan(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is less (before) or equal to another
@@ -424,7 +424,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function lessThanOrEquals(ChronosInterface $dt);
+    public function lessThanOrEquals(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is between two others

--- a/src/Traits/ComparisonTrait.php
+++ b/src/Traits/ComparisonTrait.php
@@ -69,7 +69,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function equals(ChronosInterface $dt)
+    public function equals(ChronosInterface $dt): bool
     {
         return $this->eq($dt);
     }
@@ -91,7 +91,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function notEquals(ChronosInterface $dt)
+    public function notEquals(ChronosInterface $dt): bool
     {
         return $this->ne($dt);
     }
@@ -113,7 +113,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function greaterThan(ChronosInterface $dt)
+    public function greaterThan(ChronosInterface $dt): bool
     {
         return $this->gt($dt);
     }
@@ -135,7 +135,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function greaterThanOrEquals(ChronosInterface $dt)
+    public function greaterThanOrEquals(ChronosInterface $dt): bool
     {
         return $this->gte($dt);
     }
@@ -157,7 +157,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function lessThan(ChronosInterface $dt)
+    public function lessThan(ChronosInterface $dt): bool
     {
         return $this->lt($dt);
     }
@@ -179,7 +179,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function lessThanOrEquals(ChronosInterface $dt)
+    public function lessThanOrEquals(ChronosInterface $dt): bool
     {
         return $this->lte($dt);
     }


### PR DESCRIPTION
I don't know why these were missing.

We might as well clean this sort of stuff up in a 3.0 release.