### PR TITLE
Add `ReturnTypeWillChange` annotation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0']
+        php-version: ['7.2', '7.4', '8.0', '8.1']
         prefer-lowest: ['']
         include:
           - php-version: '7.2'
@@ -48,8 +48,10 @@ jobs:
       run: |
         if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then
           composer update --prefer-lowest --prefer-stable
+        elif ${{ matrix.php-version == '8.1' }}; then
+          composer update --ignore-platform-reqs
         else
-          composer install
+          composer update
         fi
 
     - name: Setup problem matchers for PHPUnit
@@ -63,6 +65,7 @@ jobs:
         else
           vendor/bin/phpunit
         fi
+      continue-on-error: ${{ matrix.php-version == '8.1' }}
 
     - name: Submit code coverage
       if: matrix.php-version == '7.4'

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",
-        "cakephp/cakephp-codesniffer": "^4.0"
+        "cakephp/cakephp-codesniffer": "^4.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -18,6 +18,7 @@ use Cake\Chronos\ChronosInterface;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 
 /**
  * Provides a number of datetime related factory methods.
@@ -230,6 +231,7 @@ trait FactoryTrait
      * @return static
      * @throws \InvalidArgumentException
      */
+    #[ReturnTypeWillChange]
     public static function createFromFormat($format, $time, $tz = null): ChronosInterface
     {
         if ($tz !== null) {

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -16,6 +16,7 @@ namespace Cake\Chronos\Traits;
 use Cake\Chronos\ChronosInterface;
 use DateTimeImmutable;
 use DateTimeInterface;
+use ReturnTypeWillChange;
 
 /**
  * A trait for freezing the time aspect of a DateTime.
@@ -75,6 +76,7 @@ trait FrozenTimeTrait
      * @param int $microseconds The microseconds to set (ignored)
      * @return static A modified Date instance.
      */
+    #[ReturnTypeWillChange]
     public function setTime($hours, $minutes, $seconds = null, $microseconds = null): ChronosInterface
     {
         return parent::setTime(0, 0, 0, 0);
@@ -88,6 +90,7 @@ trait FrozenTimeTrait
      * @param \DateInterval $interval The interval to modify this date by.
      * @return static A modified Date instance
      */
+    #[ReturnTypeWillChange]
     public function add($interval): ChronosInterface
     {
         return parent::add($interval)->setTime(0, 0, 0);
@@ -101,6 +104,7 @@ trait FrozenTimeTrait
      * @param \DateInterval $interval The interval to modify this date by.
      * @return static A modified Date instance
      */
+    #[ReturnTypeWillChange]
     public function sub($interval): ChronosInterface
     {
         return parent::sub($interval)->setTime(0, 0, 0);
@@ -140,6 +144,7 @@ trait FrozenTimeTrait
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return $this
      */
+    #[ReturnTypeWillChange]
     public function setTimezone($value)
     {
         return $this;
@@ -154,6 +159,7 @@ trait FrozenTimeTrait
      * @param int $value The timestamp value to set.
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function setTimestamp($value): ChronosInterface
     {
         return parent::setTimestamp($value)->setTime(0, 0, 0);
@@ -168,6 +174,7 @@ trait FrozenTimeTrait
      * @param string $relative The relative change to make.
      * @return static A new date with the applied date changes.
      */
+    #[ReturnTypeWillChange]
     public function modify($relative): ChronosInterface
     {
         if (preg_match('/hour|minute|second/', $relative)) {

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Cake\Chronos\Traits;
 
 use Cake\Chronos\ChronosInterface;
+use ReturnTypeWillChange;
 
 /**
  * Provides a suite of modifier methods.
@@ -109,6 +110,7 @@ trait ModifierTrait
      * @param int $day The day to set.
      * @return static
      */
+    #[ReturnTypeWillChange]
     public function setDate($year, $month, $day): ChronosInterface
     {
         return $this->modify('+0 day')->setDateParent($year, $month, $day);


### PR DESCRIPTION
This prevents deprecation errors on PHP 8.1.