### PR TITLE
Workflow PHP Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.2'
+        php-version: '8.1'
         extensions: mbstring, intl
         tools: cs2pr
         coverage: none


### PR DESCRIPTION
Because static analysis tools don't run the code they are not tied to the actual PHP version and benefit from all the latest and greatest of newer PHP versions (in this case most keenly: performance).