### PR TITLE
3.0 - Add php type declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - 2.x
       - 2.next
+      - 3.x
   pull_request:
     branches:
       - '*'
@@ -15,10 +16,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        php-version: ['8.1', '8.2']
         prefer-lowest: ['']
         include:
-          - php-version: '7.2'
+          - php-version: '8.1'
             prefer-lowest: 'prefer-lowest'
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "php": ">=7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 || ^9.0",
-        "cakephp/cakephp-codesniffer": "^4.5"
+        "cakephp/cakephp-codesniffer": "5.x-dev",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Cake\Chronos;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
 
 /**
@@ -69,14 +70,14 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      *
      * @var \Cake\Chronos\ChronosInterface|null
      */
-    protected static $testNow;
+    protected static ?ChronosInterface $testNow = null;
 
     /**
      * Format to use for __toString method when type juggling occurs.
      *
      * @var string
      */
-    protected static $toStringFormat = ChronosInterface::DEFAULT_TO_STRING_FORMAT;
+    protected static string $toStringFormat = ChronosInterface::DEFAULT_TO_STRING_FORMAT;
 
     /**
      * Create a new Chronos instance.
@@ -87,7 +88,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      * @param \DateTimeInterface|string|int|null $time Fixed or relative time
      * @param \DateTimeZone|string|null $tz The timezone for the instance
      */
-    public function __construct($time = 'now', $tz = null)
+    public function __construct(DateTimeInterface|string|int|null $time = 'now', DateTimeZone|string|null $tz = null)
     {
         if (is_int($time)) {
             parent::__construct('@' . $time);
@@ -99,7 +100,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
             $tz = $tz instanceof DateTimeZone ? $tz : new DateTimeZone($tz);
         }
 
-        if ($time instanceof \DateTimeInterface) {
+        if ($time instanceof DateTimeInterface) {
             $time = $time->format('Y-m-d H:i:s.u');
         }
 
@@ -137,7 +138,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      *
      * @return static
      */
-    public function copy(): ChronosInterface
+    public function copy(): static
     {
         return clone $this;
     }
@@ -160,7 +161,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      * @param \Cake\Chronos\ChronosInterface|string|null $testNow The instance to use for all future instances.
      * @return void
      */
-    public static function setTestNow($testNow = null): void
+    public static function setTestNow(ChronosInterface|string|null $testNow = null): void
     {
         static::$testNow = is_string($testNow) ? static::parse($testNow) : $testNow;
     }

--- a/src/ChronosInterface.php
+++ b/src/ChronosInterface.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Cake\Chronos;
 
 use DateTimeInterface;
+use DateTimeZone;
 
 /**
  * An extension to the DateTimeInterface for a friendlier API
@@ -102,14 +103,14 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function now($tz): self;
+    public static function now(DateTimeZone|string|null $tz): static;
 
     /**
      * Get a copy of the instance
      *
      * @return static
      */
-    public function copy(): self;
+    public function copy(): static;
 
     /**
      * Set the instance's year
@@ -117,7 +118,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The year value.
      * @return static
      */
-    public function year(int $value): self;
+    public function year(int $value): static;
 
     /**
      * Set the instance's month
@@ -125,7 +126,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The month value.
      * @return static
      */
-    public function month(int $value): self;
+    public function month(int $value): static;
 
     /**
      * Set the instance's day
@@ -133,7 +134,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The day value.
      * @return static
      */
-    public function day(int $value): self;
+    public function day(int $value): static;
 
     /**
      * Set the instance's hour
@@ -141,7 +142,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The hour value.
      * @return static
      */
-    public function hour(int $value): self;
+    public function hour(int $value): static;
 
     /**
      * Set the instance's minute
@@ -149,7 +150,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The minute value.
      * @return static
      */
-    public function minute(int $value): self;
+    public function minute(int $value): static;
 
     /**
      * Set the instance's second
@@ -157,7 +158,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The seconds value.
      * @return static
      */
-    public function second(int $value): self;
+    public function second(int $value): static;
 
     /**
      * Set the date and time all together
@@ -170,7 +171,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $second The second to set.
      * @return static
      */
-    public function setDateTime(int $year, int $month, int $day, int $hour, int $minute, int $second = 0): self;
+    public function setDateTime(int $year, int $month, int $day, int $hour, int $minute, int $second = 0): static;
 
     /**
      * Set the time by time string
@@ -178,7 +179,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param string $time Time as string.
      * @return static
      */
-    public function setTimeFromTimeString(string $time): self;
+    public function setTimeFromTimeString(string $time): static;
 
     /**
      * Set the instance's timestamp
@@ -186,7 +187,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $value The timestamp value to set.
      * @return static
      */
-    public function timestamp(int $value): self;
+    public function timestamp(int $value): static;
 
     /**
      * Alias for setTimezone()
@@ -194,7 +195,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function timezone($value);
+    public function timezone(DateTimeZone|string $value): static;
 
     /**
      * Alias for setTimezone()
@@ -202,7 +203,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function tz($value);
+    public function tz(DateTimeZone|string $value): static;
 
     /**
      * Set the instance's timezone from a string or object
@@ -210,7 +211,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function setTimezone($value);
+    public function setTimezone(DateTimeZone|string $value): static;
 
     /**
      * Format the instance as date
@@ -339,7 +340,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function equals(ChronosInterface $dt);
+    public function equals(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is not equal to another
@@ -356,7 +357,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function notEquals(ChronosInterface $dt);
+    public function notEquals(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is greater (after) than another
@@ -373,7 +374,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function greaterThan(ChronosInterface $dt);
+    public function greaterThan(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is greater (after) than or equal to another
@@ -390,7 +391,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function greaterThanOrEquals(ChronosInterface $dt);
+    public function greaterThanOrEquals(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is less (before) than another
@@ -407,7 +408,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function lessThan(ChronosInterface $dt);
+    public function lessThan(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is less (before) or equal to another
@@ -424,7 +425,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function lessThanOrEquals(ChronosInterface $dt);
+    public function lessThanOrEquals(ChronosInterface $dt): bool;
 
     /**
      * Determines if the instance is between two others
@@ -441,34 +442,34 @@ interface ChronosInterface extends DateTimeInterface
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
      * @param \Cake\Chronos\ChronosInterface $dt2 The instance to compare with.
-     * @return static
+     * @return self
      */
-    public function closest(ChronosInterface $dt1, ChronosInterface $dt2): self;
+    public function closest(ChronosInterface $dt1, ChronosInterface $dt2): ChronosInterface;
 
     /**
      * Get the farthest date from the instance.
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
      * @param \Cake\Chronos\ChronosInterface $dt2 The instance to compare with.
-     * @return static
+     * @return self
      */
-    public function farthest(ChronosInterface $dt1, ChronosInterface $dt2): self;
+    public function farthest(ChronosInterface $dt1, ChronosInterface $dt2): ChronosInterface;
 
     /**
      * Get the minimum instance between a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return static
+     * @return self
      */
-    public function min(?ChronosInterface $dt = null): self;
+    public function min(?ChronosInterface $dt = null): ChronosInterface;
 
     /**
      * Get the maximum instance between a given instance (default now) and the current instance.
      *
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
-     * @return static
+     * @return self
      */
-    public function max(?ChronosInterface $dt = null): self;
+    public function max(?ChronosInterface $dt = null): ChronosInterface;
 
     /**
      * Determines if the instance is a weekday
@@ -1245,7 +1246,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function next(?int $dayOfWeek = null);
+    public function next(?int $dayOfWeek = null): mixed;
 
     /**
      * Modify to the previous occurrence of a given day of the week.
@@ -1256,7 +1257,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function previous(?int $dayOfWeek = null);
+    public function previous(?int $dayOfWeek = null): mixed;
 
     /**
      * Modify to the first occurrence of a given day of the week
@@ -1267,7 +1268,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function firstOfMonth(?int $dayOfWeek = null);
+    public function firstOfMonth(?int $dayOfWeek = null): mixed;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1278,7 +1279,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function lastOfMonth(?int $dayOfWeek = null);
+    public function lastOfMonth(?int $dayOfWeek = null): mixed;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1290,7 +1291,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function nthOfMonth(int $nth, int $dayOfWeek);
+    public function nthOfMonth(int $nth, int $dayOfWeek): mixed;
 
     /**
      * Modify to the first occurrence of a given day of the week
@@ -1301,7 +1302,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function firstOfQuarter(?int $dayOfWeek = null);
+    public function firstOfQuarter(?int $dayOfWeek = null): mixed;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1312,7 +1313,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function lastOfQuarter(?int $dayOfWeek = null);
+    public function lastOfQuarter(?int $dayOfWeek = null): mixed;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1324,7 +1325,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function nthOfQuarter(int $nth, int $dayOfWeek);
+    public function nthOfQuarter(int $nth, int $dayOfWeek): mixed;
 
     /**
      * Modify to the first occurrence of a given day of the week
@@ -1335,7 +1336,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function firstOfYear(?int $dayOfWeek = null);
+    public function firstOfYear(?int $dayOfWeek = null): mixed;
 
     /**
      * Modify to the last occurrence of a given day of the week
@@ -1346,7 +1347,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function lastOfYear(?int $dayOfWeek = null);
+    public function lastOfYear(?int $dayOfWeek = null): mixed;
 
     /**
      * Modify to the given occurrence of a given day of the week
@@ -1358,7 +1359,7 @@ interface ChronosInterface extends DateTimeInterface
      * @param int $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function nthOfYear(int $nth, int $dayOfWeek);
+    public function nthOfYear(int $nth, int $dayOfWeek): mixed;
 
     /**
      * Modify the current instance to the average of a given instance (default now) and the current instance.
@@ -1383,7 +1384,7 @@ interface ChronosInterface extends DateTimeInterface
      *    Example of valid types: 6 hours, 2 days, 1 minute.
      * @return bool
      */
-    public function wasWithinLast($timeInterval): bool;
+    public function wasWithinLast(string|int $timeInterval): bool;
 
     /**
      * Returns true this instance will happen within the specified interval
@@ -1392,5 +1393,5 @@ interface ChronosInterface extends DateTimeInterface
      *    Example of valid types: 6 hours, 2 days, 1 minute.
      * @return bool
      */
-    public function isWithinNext($timeInterval): bool;
+    public function isWithinNext(string|int $timeInterval): bool;
 }

--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -267,7 +267,7 @@ class ChronosInterval extends DateInterval
      * @throws \InvalidArgumentException
      * @return int
      */
-    public function __get(string $name)
+    public function __get(string $name): int
     {
         switch ($name) {
             case 'years':
@@ -307,11 +307,11 @@ class ChronosInterval extends DateInterval
      * Set a part of the ChronosInterval object
      *
      * @param string $name The property to augment.
-     * @param int $val The value to change.
+     * @param int|false $val The value to change.
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function __set(string $name, $val): void
+    public function __set(string $name, int|false $val): void
     {
         switch ($name) {
             case 'years':

--- a/src/Date.php
+++ b/src/Date.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Cake\Chronos;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
 
 /**
@@ -67,7 +68,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
      *
      * @var string
      */
-    protected static $toStringFormat = 'Y-m-d';
+    protected static string $toStringFormat = 'Y-m-d';
 
     /**
      * Create a new Immutable Date instance.
@@ -89,7 +90,7 @@ class Date extends DateTimeImmutable implements ChronosInterface
      * @param \DateTimeInterface|string|int|null $time Fixed or relative time
      * @param \DateTimeZone|string|null $tz The timezone in which the date is taken
      */
-    public function __construct($time = 'now', $tz = null)
+    public function __construct(DateTimeInterface|string|int|null $time = 'now', DateTimeZone|string|null $tz = null)
     {
         if ($tz !== null) {
             $tz = $tz instanceof DateTimeZone ? $tz : new DateTimeZone($tz);

--- a/src/DifferenceFormatter.php
+++ b/src/DifferenceFormatter.php
@@ -27,7 +27,7 @@ class DifferenceFormatter implements DifferenceFormatterInterface
      *
      * @var \Cake\Chronos\Translator
      */
-    protected $translate;
+    protected Translator $translate;
 
     /**
      * Constructor.

--- a/src/Traits/ComparisonTrait.php
+++ b/src/Traits/ComparisonTrait.php
@@ -28,7 +28,7 @@ trait ComparisonTrait
      *
      * @var array
      */
-    protected static $weekendDays = [ChronosInterface::SATURDAY, ChronosInterface::SUNDAY];
+    protected static array $weekendDays = [ChronosInterface::SATURDAY, ChronosInterface::SUNDAY];
 
     /**
      * Get weekend days
@@ -68,7 +68,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function equals(ChronosInterface $dt)
+    public function equals(ChronosInterface $dt): bool
     {
         return $this->eq($dt);
     }
@@ -90,7 +90,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function notEquals(ChronosInterface $dt)
+    public function notEquals(ChronosInterface $dt): bool
     {
         return $this->ne($dt);
     }
@@ -112,7 +112,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function greaterThan(ChronosInterface $dt)
+    public function greaterThan(ChronosInterface $dt): bool
     {
         return $this->gt($dt);
     }
@@ -134,7 +134,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function greaterThanOrEquals(ChronosInterface $dt)
+    public function greaterThanOrEquals(ChronosInterface $dt): bool
     {
         return $this->gte($dt);
     }
@@ -156,7 +156,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function lessThan(ChronosInterface $dt)
+    public function lessThan(ChronosInterface $dt): bool
     {
         return $this->lt($dt);
     }
@@ -178,7 +178,7 @@ trait ComparisonTrait
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
      */
-    public function lessThanOrEquals(ChronosInterface $dt)
+    public function lessThanOrEquals(ChronosInterface $dt): bool
     {
         return $this->lte($dt);
     }
@@ -527,7 +527,7 @@ trait ComparisonTrait
      *    Example of valid types: 6 hours, 2 days, 1 minute.
      * @return bool
      */
-    public function wasWithinLast($timeInterval): bool
+    public function wasWithinLast(string|int $timeInterval): bool
     {
         $now = new static();
         $interval = $now->copy()->modify('-' . $timeInterval);
@@ -543,7 +543,7 @@ trait ComparisonTrait
      *    Example of valid types: 6 hours, 2 days, 1 minute.
      * @return bool
      */
-    public function isWithinNext($timeInterval): bool
+    public function isWithinNext(string|int $timeInterval): bool
     {
         $now = new static();
         $interval = $now->copy()->modify('+' . $timeInterval);

--- a/src/Traits/CopyTrait.php
+++ b/src/Traits/CopyTrait.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
-
 /**
  * Provides methods for copying datetime objects.
  *
@@ -28,7 +26,7 @@ trait CopyTrait
      *
      * @return static
      */
-    public function copy(): ChronosInterface
+    public function copy(): static
     {
         return static::instance($this);
     }

--- a/src/Traits/DifferenceTrait.php
+++ b/src/Traits/DifferenceTrait.php
@@ -18,7 +18,10 @@ use Cake\Chronos\ChronosInterface;
 use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\DifferenceFormatter;
 use Cake\Chronos\DifferenceFormatterInterface;
+use DateInterval;
 use DatePeriod;
+use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 
@@ -38,7 +41,7 @@ trait DifferenceTrait
      *
      * @var \Cake\Chronos\DifferenceFormatterInterface|null
      */
-    protected static $diffFormatter;
+    protected static ?DifferenceFormatterInterface $diffFormatter = null;
 
     /**
      * Get the difference in years
@@ -276,7 +279,7 @@ trait DifferenceTrait
      * @param \DateTime|\DateTimeImmutable $datetime The date to get the remaining time from.
      * @return \DateInterval|bool The DateInterval object representing the difference between the two dates or FALSE on failure.
      */
-    public static function fromNow($datetime)
+    public static function fromNow(DateTime|DateTimeImmutable $datetime): DateInterval|bool
     {
         $timeNow = new static();
 

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
@@ -30,7 +29,7 @@ trait FactoryTrait
      *
      * @var array
      */
-    protected static $_lastErrors = [];
+    protected static array $_lastErrors = [];
 
     /**
      * Create a ChronosInterface instance from a DateTimeInterface one
@@ -38,7 +37,7 @@ trait FactoryTrait
      * @param \DateTimeInterface $dt The datetime instance to convert.
      * @return static
      */
-    public static function instance(DateTimeInterface $dt): ChronosInterface
+    public static function instance(DateTimeInterface $dt): static
     {
         if ($dt instanceof static) {
             return clone $dt;
@@ -53,12 +52,14 @@ trait FactoryTrait
      * ChronosInterface::parse('Monday next week')->fn() rather than
      * (new Chronos('Monday next week'))->fn()
      *
-     * @param \DateTimeInterface|string|int $time The strtotime compatible string to parse
+     * @param \DateTimeInterface|string|int|null $time The strtotime compatible string to parse
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function parse($time = 'now', $tz = null): ChronosInterface
-    {
+    public static function parse(
+        DateTimeInterface|string|int|null $time = 'now',
+        DateTimeZone|string|null $tz = null
+    ): static {
         return new static($time, $tz);
     }
 
@@ -68,7 +69,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name.
      * @return static
      */
-    public static function now($tz = null): ChronosInterface
+    public static function now(DateTimeZone|string|null $tz = null): static
     {
         return new static('now', $tz);
     }
@@ -79,7 +80,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The timezone to use.
      * @return static
      */
-    public static function today($tz = null): ChronosInterface
+    public static function today(DateTimeZone|string|null $tz = null): static
     {
         return new static('midnight', $tz);
     }
@@ -90,7 +91,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function tomorrow($tz = null): ChronosInterface
+    public static function tomorrow(DateTimeZone|string|null $tz = null): static
     {
         return new static('tomorrow, midnight', $tz);
     }
@@ -101,7 +102,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function yesterday($tz = null): ChronosInterface
+    public static function yesterday(DateTimeZone|string|null $tz = null): static
     {
         return new static('yesterday, midnight', $tz);
     }
@@ -109,9 +110,9 @@ trait FactoryTrait
     /**
      * Create a ChronosInterface instance for the greatest supported date.
      *
-     * @return \Cake\Chronos\ChronosInterface
+     * @return static
      */
-    public static function maxValue(): ChronosInterface
+    public static function maxValue(): static
     {
         return static::createFromTimestampUTC(PHP_INT_MAX);
     }
@@ -119,9 +120,9 @@ trait FactoryTrait
     /**
      * Create a ChronosInterface instance for the lowest supported date.
      *
-     * @return \Cake\Chronos\ChronosInterface
+     * @return static
      */
-    public static function minValue(): ChronosInterface
+    public static function minValue(): static
     {
         $max = PHP_INT_SIZE === 4 ? PHP_INT_MAX : PHP_INT_MAX / 10;
 
@@ -157,8 +158,8 @@ trait FactoryTrait
         ?int $minute = null,
         ?int $second = null,
         ?int $microsecond = null,
-        $tz = null
-    ): ChronosInterface {
+        DateTimeZone|string|null $tz = null
+    ): static {
         $now = static::now();
         $year = $year ?? (int)$now->format('Y');
         $month = $month ?? $now->format('m');
@@ -197,8 +198,8 @@ trait FactoryTrait
         ?int $year = null,
         ?int $month = null,
         ?int $day = null,
-        $tz = null
-    ): ChronosInterface {
+        DateTimeZone|string|null $tz = null
+    ): static {
         return static::create($year, $month, $day, null, null, null, null, $tz);
     }
 
@@ -217,8 +218,8 @@ trait FactoryTrait
         ?int $minute = null,
         ?int $second = null,
         ?int $microsecond = null,
-        $tz = null
-    ): ChronosInterface {
+        DateTimeZone|string|null $tz = null
+    ): static {
         return static::create(null, null, null, $hour, $minute, $second, $microsecond, $tz);
     }
 
@@ -232,7 +233,7 @@ trait FactoryTrait
      * @throws \InvalidArgumentException
      */
     #[ReturnTypeWillChange]
-    public static function createFromFormat($format, $time, $tz = null): ChronosInterface
+    public static function createFromFormat(string $format, string $time, DateTimeZone|string|null $tz = null): static
     {
         if ($tz !== null) {
             $dt = parent::createFromFormat($format, $time, static::safeCreateDateTimeZone($tz));
@@ -246,7 +247,7 @@ trait FactoryTrait
         }
 
         $dt = new static($dt->format('Y-m-d H:i:s.u'), $dt->getTimezone());
-        static::$_lastErrors = $errors;
+        static::$_lastErrors = $errors ?: [];
 
         return $dt;
     }
@@ -270,10 +271,10 @@ trait FactoryTrait
      *  - meridian ('am' or 'pm')
      *  - timezone
      *
-     * @param (int|string)[] $values Array of date and time values.
+     * @param array<int|string> $values Array of date and time values.
      * @return static
      */
-    public static function createFromArray(array $values): ChronosInterface
+    public static function createFromArray(array $values): static
     {
         $values += ['hour' => 0, 'minute' => 0, 'second' => 0, 'microsecond' => 0, 'timezone' => null];
 
@@ -313,7 +314,7 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function createFromTimestamp(int $timestamp, $tz = null): ChronosInterface
+    public static function createFromTimestamp(int $timestamp, DateTimeZone|string|null $tz = null): static
     {
         return static::now($tz)->setTimestamp($timestamp);
     }
@@ -324,7 +325,7 @@ trait FactoryTrait
      * @param int $timestamp The UTC timestamp to create an instance from.
      * @return static
      */
-    public static function createFromTimestampUTC(int $timestamp): ChronosInterface
+    public static function createFromTimestampUTC(int $timestamp): static
     {
         return new static($timestamp);
     }
@@ -336,7 +337,7 @@ trait FactoryTrait
      * @return \DateTimeZone
      * @throws \InvalidArgumentException
      */
-    protected static function safeCreateDateTimeZone($object): DateTimeZone
+    protected static function safeCreateDateTimeZone(DateTimeZone|string|null $object): DateTimeZone
     {
         if ($object === null) {
             return new DateTimeZone(date_default_timezone_get());
@@ -358,7 +359,7 @@ trait FactoryTrait
     public static function getLastErrors(): array
     {
         if (empty(static::$_lastErrors)) {
-            return parent::getLastErrors();
+            return parent::getLastErrors() ?: [];
         }
 
         return static::$_lastErrors;

--- a/src/Traits/FormattingTrait.php
+++ b/src/Traits/FormattingTrait.php
@@ -40,7 +40,7 @@ trait FormattingTrait
      * @param string $format The format to use in future __toString() calls.
      * @return void
      */
-    public static function setToStringFormat($format): void
+    public static function setToStringFormat(string $format): void
     {
         static::$toStringFormat = $format;
     }
@@ -235,9 +235,9 @@ trait FormattingTrait
      * Returns the quarter
      *
      * @param bool $range Range.
-     * @return int|array 1, 2, 3, or 4 quarter of year or array if $range true
+     * @return array|int 1, 2, 3, or 4 quarter of year or array if $range true
      */
-    public function toQuarter(bool $range = false)
+    public function toQuarter(bool $range = false): int|array
     {
         $quarter = (int)ceil($this->format('m') / 3);
         if ($range === false) {

--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
+use DateInterval;
+use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use ReturnTypeWillChange;
 
 /**
@@ -37,7 +39,7 @@ trait FrozenTimeTrait
      * @param \DateTimeZone|null $tz The timezone in which the date is taken
      * @return string The date component of $time.
      */
-    protected function stripTime($time, $tz): string
+    protected function stripTime(DateTime|DateTimeImmutable|string|int|null $time, ?DateTimeZone $tz): string
     {
         if (is_int($time)) {
             return gmdate('Y-m-d 00:00:00', $time);
@@ -77,7 +79,7 @@ trait FrozenTimeTrait
      * @return static A modified Date instance.
      */
     #[ReturnTypeWillChange]
-    public function setTime($hours, $minutes, $seconds = null, $microseconds = null): ChronosInterface
+    public function setTime(int $hours, int $minutes, ?int $seconds = null, ?int $microseconds = null): static
     {
         return parent::setTime(0, 0, 0, 0);
     }
@@ -91,7 +93,7 @@ trait FrozenTimeTrait
      * @return static A modified Date instance
      */
     #[ReturnTypeWillChange]
-    public function add($interval): ChronosInterface
+    public function add(DateInterval $interval): static
     {
         return parent::add($interval)->setTime(0, 0, 0);
     }
@@ -105,7 +107,7 @@ trait FrozenTimeTrait
      * @return static A modified Date instance
      */
     #[ReturnTypeWillChange]
-    public function sub($interval): ChronosInterface
+    public function sub(DateInterval $interval): static
     {
         return parent::sub($interval)->setTime(0, 0, 0);
     }
@@ -116,9 +118,9 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return static
      */
-    public function timezone($value)
+    public function timezone(DateTimeZone|string $value): static
     {
         return $this;
     }
@@ -129,9 +131,9 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return static
      */
-    public function tz($value)
+    public function tz(DateTimeZone|string $value): static
     {
         return $this;
     }
@@ -142,10 +144,10 @@ trait FrozenTimeTrait
      * Timezones have no effect on calendar dates.
      *
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
-     * @return $this
+     * @return static
      */
     #[ReturnTypeWillChange]
-    public function setTimezone($value)
+    public function setTimezone(DateTimeZone|string $value): static
     {
         return $this;
     }
@@ -160,7 +162,7 @@ trait FrozenTimeTrait
      * @return static
      */
     #[ReturnTypeWillChange]
-    public function setTimestamp($value): ChronosInterface
+    public function setTimestamp(int $value): static
     {
         return parent::setTimestamp($value)->setTime(0, 0, 0);
     }
@@ -175,7 +177,7 @@ trait FrozenTimeTrait
      * @return static A new date with the applied date changes.
      */
     #[ReturnTypeWillChange]
-    public function modify($relative): ChronosInterface
+    public function modify(string $relative): static
     {
         if (preg_match('/hour|minute|second/', $relative)) {
             return $this;

--- a/src/Traits/MagicPropertyTrait.php
+++ b/src/Traits/MagicPropertyTrait.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Chronos\Traits;
 
 use Cake\Chronos\ChronosInterface;
+use DateTimeZone;
 use InvalidArgumentException;
 
 /**
@@ -55,10 +56,10 @@ trait MagicPropertyTrait
      * Get a part of the ChronosInterface object
      *
      * @param string $name The property name to read.
-     * @return string|int|bool|\DateTimeZone The property value.
+     * @return \DateTimeZone|string|float|int|bool The property value.
      * @throws \InvalidArgumentException
      */
-    public function __get(string $name)
+    public function __get(string $name): string|float|int|bool|DateTimeZone
     {
         static $formats = [
             'year' => 'Y',

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -34,7 +34,7 @@ trait ModifierTrait
      *
      * @var array
      */
-    protected static $days = [
+    protected static array $days = [
         ChronosInterface::MONDAY => 'Monday',
         ChronosInterface::TUESDAY => 'Tuesday',
         ChronosInterface::WEDNESDAY => 'Wednesday',
@@ -49,14 +49,14 @@ trait ModifierTrait
      *
      * @var int
      */
-    protected static $weekStartsAt = ChronosInterface::MONDAY;
+    protected static int $weekStartsAt = ChronosInterface::MONDAY;
 
     /**
      * Last day of week
      *
      * @var int
      */
-    protected static $weekEndsAt = ChronosInterface::SUNDAY;
+    protected static int $weekEndsAt = ChronosInterface::SUNDAY;
 
     /**
      * Get the first day of week
@@ -111,7 +111,7 @@ trait ModifierTrait
      * @return static
      */
     #[ReturnTypeWillChange]
-    public function setDate($year, $month, $day): ChronosInterface
+    public function setDate(int $year, int $month, int $day): static
     {
         return $this->modify('+0 day')->setDateParent($year, $month, $day);
     }
@@ -125,7 +125,7 @@ trait ModifierTrait
      * @param int $day The day to set.
      * @return static
      */
-    private function setDateParent(int $year, int $month, int $day): ChronosInterface
+    private function setDateParent(int $year, int $month, int $day): static
     {
         return parent::setDate($year, $month, $day);
     }
@@ -148,7 +148,7 @@ trait ModifierTrait
         int $hour,
         int $minute,
         int $second = 0
-    ): ChronosInterface {
+    ): static {
         return $this->setDate($year, $month, $day)->setTime($hour, $minute, $second);
     }
 
@@ -158,7 +158,7 @@ trait ModifierTrait
      * @param string $time Time as string.
      * @return static
      */
-    public function setTimeFromTimeString(string $time): ChronosInterface
+    public function setTimeFromTimeString(string $time): static
     {
         $time = explode(':', $time);
         $hour = $time[0];
@@ -174,7 +174,7 @@ trait ModifierTrait
      * @param int $value The timestamp value to set.
      * @return static
      */
-    public function timestamp(int $value): ChronosInterface
+    public function timestamp(int $value): static
     {
         return $this->setTimestamp($value);
     }
@@ -185,7 +185,7 @@ trait ModifierTrait
      * @param int $value The year value.
      * @return static
      */
-    public function year(int $value): ChronosInterface
+    public function year(int $value): static
     {
         return $this->setDate($value, $this->month, $this->day);
     }
@@ -196,7 +196,7 @@ trait ModifierTrait
      * @param int $value The month value.
      * @return static
      */
-    public function month(int $value): ChronosInterface
+    public function month(int $value): static
     {
         return $this->setDate($this->year, $value, $this->day);
     }
@@ -207,7 +207,7 @@ trait ModifierTrait
      * @param int $value The day value.
      * @return static
      */
-    public function day(int $value): ChronosInterface
+    public function day(int $value): static
     {
         return $this->setDate($this->year, $this->month, $value);
     }
@@ -218,7 +218,7 @@ trait ModifierTrait
      * @param int $value The hour value.
      * @return static
      */
-    public function hour(int $value): ChronosInterface
+    public function hour(int $value): static
     {
         return $this->setTime($value, $this->minute, $this->second);
     }
@@ -229,7 +229,7 @@ trait ModifierTrait
      * @param int $value The minute value.
      * @return static
      */
-    public function minute(int $value): ChronosInterface
+    public function minute(int $value): static
     {
         return $this->setTime($this->hour, $value, $this->second);
     }
@@ -240,7 +240,7 @@ trait ModifierTrait
      * @param int $value The seconds value.
      * @return static
      */
-    public function second(int $value): ChronosInterface
+    public function second(int $value): static
     {
         return $this->setTime($this->hour, $this->minute, $value);
     }
@@ -251,7 +251,7 @@ trait ModifierTrait
      * @param int $value The microsecond value.
      * @return static
      */
-    public function microsecond(int $value): ChronosInterface
+    public function microsecond(int $value): static
     {
         return $this->setTime($this->hour, $this->minute, $this->second, $value);
     }
@@ -274,7 +274,7 @@ trait ModifierTrait
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYears(int $value): ChronosInterface
+    public function addYears(int $value): static
     {
         $month = $this->month;
         $date = $this->modify($value . ' year');
@@ -294,7 +294,7 @@ trait ModifierTrait
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYear(int $value = 1): ChronosInterface
+    public function addYear(int $value = 1): static
     {
         return $this->addYears($value);
     }
@@ -307,7 +307,7 @@ trait ModifierTrait
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYears(int $value): ChronosInterface
+    public function subYears(int $value): static
     {
         return $this->addYears(-1 * $value);
     }
@@ -320,7 +320,7 @@ trait ModifierTrait
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYear(int $value = 1): ChronosInterface
+    public function subYear(int $value = 1): static
     {
         return $this->subYears($value);
     }
@@ -340,7 +340,7 @@ trait ModifierTrait
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYearsWithOverflow(int $value): ChronosInterface
+    public function addYearsWithOverflow(int $value): static
     {
         return $this->modify($value . ' year');
     }
@@ -353,7 +353,7 @@ trait ModifierTrait
      * @param int $value The number of years to add.
      * @return static
      */
-    public function addYearWithOverflow(int $value = 1): ChronosInterface
+    public function addYearWithOverflow(int $value = 1): static
     {
         return $this->addYearsWithOverflow($value);
     }
@@ -366,7 +366,7 @@ trait ModifierTrait
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYearsWithOverflow(int $value): ChronosInterface
+    public function subYearsWithOverflow(int $value): static
     {
         return $this->addYearsWithOverflow(-1 * $value);
     }
@@ -379,7 +379,7 @@ trait ModifierTrait
      * @param int $value The number of years to remove.
      * @return static
      */
-    public function subYearWithOverflow(int $value = 1): ChronosInterface
+    public function subYearWithOverflow(int $value = 1): static
     {
         return $this->subYearsWithOverflow($value);
     }
@@ -403,7 +403,7 @@ trait ModifierTrait
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonths(int $value): ChronosInterface
+    public function addMonths(int $value): static
     {
         $day = $this->day;
         $date = $this->modify($value . ' month');
@@ -423,7 +423,7 @@ trait ModifierTrait
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonth(int $value = 1): ChronosInterface
+    public function addMonth(int $value = 1): static
     {
         return $this->addMonths($value);
     }
@@ -436,7 +436,7 @@ trait ModifierTrait
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonth(int $value = 1): ChronosInterface
+    public function subMonth(int $value = 1): static
     {
         return $this->subMonths($value);
     }
@@ -449,7 +449,7 @@ trait ModifierTrait
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonths(int $value): ChronosInterface
+    public function subMonths(int $value): static
     {
         return $this->addMonths(-1 * $value);
     }
@@ -469,7 +469,7 @@ trait ModifierTrait
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonthsWithOverflow(int $value): ChronosInterface
+    public function addMonthsWithOverflow(int $value): static
     {
         return $this->modify($value . ' month');
     }
@@ -482,7 +482,7 @@ trait ModifierTrait
      * @param int $value The number of months to add.
      * @return static
      */
-    public function addMonthWithOverflow(int $value = 1): ChronosInterface
+    public function addMonthWithOverflow(int $value = 1): static
     {
         return $this->modify($value . ' month');
     }
@@ -495,7 +495,7 @@ trait ModifierTrait
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonthsWithOverflow(int $value): ChronosInterface
+    public function subMonthsWithOverflow(int $value): static
     {
         return $this->addMonthsWithOverflow(-1 * $value);
     }
@@ -508,7 +508,7 @@ trait ModifierTrait
      * @param int $value The number of months to remove.
      * @return static
      */
-    public function subMonthWithOverflow(int $value = 1): ChronosInterface
+    public function subMonthWithOverflow(int $value = 1): static
     {
         return $this->subMonthsWithOverflow($value);
     }
@@ -520,7 +520,7 @@ trait ModifierTrait
      * @param int $value The number of days to add.
      * @return static
      */
-    public function addDays(int $value): ChronosInterface
+    public function addDays(int $value): static
     {
         return $this->modify("$value day");
     }
@@ -531,7 +531,7 @@ trait ModifierTrait
      * @param int $value The number of days to add.
      * @return static
      */
-    public function addDay(int $value = 1): ChronosInterface
+    public function addDay(int $value = 1): static
     {
         return $this->modify("$value day");
     }
@@ -542,7 +542,7 @@ trait ModifierTrait
      * @param int $value The number of days to remove.
      * @return static
      */
-    public function subDay(int $value = 1): ChronosInterface
+    public function subDay(int $value = 1): static
     {
         return $this->modify("-$value day");
     }
@@ -553,7 +553,7 @@ trait ModifierTrait
      * @param int $value The number of days to remove.
      * @return static
      */
-    public function subDays(int $value): ChronosInterface
+    public function subDays(int $value): static
     {
         return $this->modify("-$value day");
     }
@@ -565,7 +565,7 @@ trait ModifierTrait
      * @param int $value The number of weekdays to add.
      * @return static
      */
-    public function addWeekdays(int $value): ChronosInterface
+    public function addWeekdays(int $value): static
     {
         return $this->modify((int)$value . ' weekdays ' . $this->format('H:i:s'));
     }
@@ -576,7 +576,7 @@ trait ModifierTrait
      * @param int $value The number of weekdays to add.
      * @return static
      */
-    public function addWeekday(int $value = 1): ChronosInterface
+    public function addWeekday(int $value = 1): static
     {
         return $this->addWeekdays($value);
     }
@@ -587,7 +587,7 @@ trait ModifierTrait
      * @param int $value The number of weekdays to remove.
      * @return static
      */
-    public function subWeekdays(int $value): ChronosInterface
+    public function subWeekdays(int $value): static
     {
         return $this->modify("$value weekdays ago, " . $this->format('H:i:s'));
     }
@@ -598,7 +598,7 @@ trait ModifierTrait
      * @param int $value The number of weekdays to remove.
      * @return static
      */
-    public function subWeekday(int $value = 1): ChronosInterface
+    public function subWeekday(int $value = 1): static
     {
         return $this->subWeekdays($value);
     }
@@ -610,7 +610,7 @@ trait ModifierTrait
      * @param int $value The number of weeks to add.
      * @return static
      */
-    public function addWeeks(int $value): ChronosInterface
+    public function addWeeks(int $value): static
     {
         return $this->modify("$value week");
     }
@@ -621,7 +621,7 @@ trait ModifierTrait
      * @param int $value The number of weeks to add.
      * @return static
      */
-    public function addWeek(int $value = 1): ChronosInterface
+    public function addWeek(int $value = 1): static
     {
         return $this->modify("$value week");
     }
@@ -632,7 +632,7 @@ trait ModifierTrait
      * @param int $value The number of weeks to remove.
      * @return static
      */
-    public function subWeek(int $value = 1): ChronosInterface
+    public function subWeek(int $value = 1): static
     {
         return $this->modify("-$value week");
     }
@@ -643,7 +643,7 @@ trait ModifierTrait
      * @param int $value The number of weeks to remove.
      * @return static
      */
-    public function subWeeks(int $value): ChronosInterface
+    public function subWeeks(int $value): static
     {
         return $this->modify("-$value week");
     }
@@ -655,7 +655,7 @@ trait ModifierTrait
      * @param int $value The number of hours to add.
      * @return static
      */
-    public function addHours(int $value): ChronosInterface
+    public function addHours(int $value): static
     {
         return $this->modify("$value hour");
     }
@@ -666,7 +666,7 @@ trait ModifierTrait
      * @param int $value The number of hours to add.
      * @return static
      */
-    public function addHour(int $value = 1): ChronosInterface
+    public function addHour(int $value = 1): static
     {
         return $this->modify("$value hour");
     }
@@ -677,7 +677,7 @@ trait ModifierTrait
      * @param int $value The number of hours to remove.
      * @return static
      */
-    public function subHour(int $value = 1): ChronosInterface
+    public function subHour(int $value = 1): static
     {
         return $this->modify("-$value hour");
     }
@@ -688,7 +688,7 @@ trait ModifierTrait
      * @param int $value The number of hours to remove.
      * @return static
      */
-    public function subHours(int $value): ChronosInterface
+    public function subHours(int $value): static
     {
         return $this->modify("-$value hour");
     }
@@ -700,7 +700,7 @@ trait ModifierTrait
      * @param int $value The number of minutes to add.
      * @return static
      */
-    public function addMinutes(int $value): ChronosInterface
+    public function addMinutes(int $value): static
     {
         return $this->modify("$value minute");
     }
@@ -711,7 +711,7 @@ trait ModifierTrait
      * @param int $value The number of minutes to add.
      * @return static
      */
-    public function addMinute(int $value = 1): ChronosInterface
+    public function addMinute(int $value = 1): static
     {
         return $this->modify("$value minute");
     }
@@ -722,7 +722,7 @@ trait ModifierTrait
      * @param int $value The number of minutes to remove.
      * @return static
      */
-    public function subMinute(int $value = 1): ChronosInterface
+    public function subMinute(int $value = 1): static
     {
         return $this->modify("-$value minute");
     }
@@ -733,7 +733,7 @@ trait ModifierTrait
      * @param int $value The number of minutes to remove.
      * @return static
      */
-    public function subMinutes(int $value): ChronosInterface
+    public function subMinutes(int $value): static
     {
         return $this->modify("-$value minute");
     }
@@ -745,7 +745,7 @@ trait ModifierTrait
      * @param int $value The number of seconds to add.
      * @return static
      */
-    public function addSeconds(int $value): ChronosInterface
+    public function addSeconds(int $value): static
     {
         return $this->modify("$value second");
     }
@@ -756,7 +756,7 @@ trait ModifierTrait
      * @param int $value The number of seconds to add.
      * @return static
      */
-    public function addSecond(int $value = 1): ChronosInterface
+    public function addSecond(int $value = 1): static
     {
         return $this->modify("$value second");
     }
@@ -767,7 +767,7 @@ trait ModifierTrait
      * @param int $value The number of seconds to remove.
      * @return static
      */
-    public function subSecond(int $value = 1): ChronosInterface
+    public function subSecond(int $value = 1): static
     {
         return $this->modify("-$value second");
     }
@@ -778,7 +778,7 @@ trait ModifierTrait
      * @param int $value The number of seconds to remove.
      * @return static
      */
-    public function subSeconds(int $value): ChronosInterface
+    public function subSeconds(int $value): static
     {
         return $this->modify("-$value second");
     }
@@ -788,7 +788,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfDay(): ChronosInterface
+    public function startOfDay(): static
     {
         return $this->modify('midnight');
     }
@@ -798,7 +798,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfDay(): ChronosInterface
+    public function endOfDay(): static
     {
         return $this->modify('23:59:59');
     }
@@ -808,7 +808,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfMonth(): ChronosInterface
+    public function startOfMonth(): static
     {
         return $this->modify('first day of this month midnight');
     }
@@ -818,7 +818,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfMonth(): ChronosInterface
+    public function endOfMonth(): static
     {
         return $this->modify('last day of this month, 23:59:59');
     }
@@ -828,7 +828,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfYear(): ChronosInterface
+    public function startOfYear(): static
     {
         return $this->modify('first day of january midnight');
     }
@@ -838,7 +838,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfYear(): ChronosInterface
+    public function endOfYear(): static
     {
         return $this->modify('last day of december, 23:59:59');
     }
@@ -848,7 +848,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfDecade(): ChronosInterface
+    public function startOfDecade(): static
     {
         $year = $this->year - $this->year % ChronosInterface::YEARS_PER_DECADE;
 
@@ -860,7 +860,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfDecade(): ChronosInterface
+    public function endOfDecade(): static
     {
         $year = $this->year - $this->year % ChronosInterface::YEARS_PER_DECADE + ChronosInterface::YEARS_PER_DECADE - 1;
 
@@ -872,7 +872,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfCentury(): ChronosInterface
+    public function startOfCentury(): static
     {
         $year = $this->startOfYear()
             ->year($this->year - 1 - ($this->year - 1) % ChronosInterface::YEARS_PER_CENTURY + 1)
@@ -886,7 +886,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfCentury(): ChronosInterface
+    public function endOfCentury(): static
     {
         $y = $this->year - 1
             - ($this->year - 1)
@@ -905,7 +905,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function startOfWeek(): ChronosInterface
+    public function startOfWeek(): static
     {
         $dt = $this;
         if ($dt->dayOfWeek !== static::$weekStartsAt) {
@@ -920,7 +920,7 @@ trait ModifierTrait
      *
      * @return static
      */
-    public function endOfWeek(): ChronosInterface
+    public function endOfWeek(): static
     {
         $dt = $this;
         if ($dt->dayOfWeek !== static::$weekEndsAt) {
@@ -939,7 +939,7 @@ trait ModifierTrait
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function next(?int $dayOfWeek = null)
+    public function next(?int $dayOfWeek = null): mixed
     {
         if ($dayOfWeek === null) {
             $dayOfWeek = $this->dayOfWeek;
@@ -959,7 +959,7 @@ trait ModifierTrait
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function previous(?int $dayOfWeek = null)
+    public function previous(?int $dayOfWeek = null): mixed
     {
         if ($dayOfWeek === null) {
             $dayOfWeek = $this->dayOfWeek;
@@ -979,7 +979,7 @@ trait ModifierTrait
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function firstOfMonth(?int $dayOfWeek = null)
+    public function firstOfMonth(?int $dayOfWeek = null): mixed
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -995,7 +995,7 @@ trait ModifierTrait
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function lastOfMonth(?int $dayOfWeek = null)
+    public function lastOfMonth(?int $dayOfWeek = null): mixed
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -1012,7 +1012,7 @@ trait ModifierTrait
      * @param int $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function nthOfMonth(int $nth, int $dayOfWeek)
+    public function nthOfMonth(int $nth, int $dayOfWeek): mixed
     {
         $dt = $this->copy()->firstOfMonth();
         $check = $dt->format('Y-m');
@@ -1030,7 +1030,7 @@ trait ModifierTrait
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function firstOfQuarter(?int $dayOfWeek = null)
+    public function firstOfQuarter(?int $dayOfWeek = null): mixed
     {
         return $this
             ->day(1)
@@ -1047,7 +1047,7 @@ trait ModifierTrait
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function lastOfQuarter(?int $dayOfWeek = null)
+    public function lastOfQuarter(?int $dayOfWeek = null): mixed
     {
         return $this
             ->day(1)
@@ -1065,7 +1065,7 @@ trait ModifierTrait
      * @param int $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function nthOfQuarter(int $nth, int $dayOfWeek)
+    public function nthOfQuarter(int $nth, int $dayOfWeek): mixed
     {
         $dt = $this->copy()->day(1)->month($this->quarter * ChronosInterface::MONTHS_PER_QUARTER);
         $lastMonth = $dt->month;
@@ -1084,7 +1084,7 @@ trait ModifierTrait
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function firstOfYear(?int $dayOfWeek = null)
+    public function firstOfYear(?int $dayOfWeek = null): mixed
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -1100,7 +1100,7 @@ trait ModifierTrait
      * @param int|null $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function lastOfYear(?int $dayOfWeek = null)
+    public function lastOfYear(?int $dayOfWeek = null): mixed
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -1117,7 +1117,7 @@ trait ModifierTrait
      * @param int $dayOfWeek The day of the week to move to.
      * @return mixed
      */
-    public function nthOfYear(int $nth, int $dayOfWeek)
+    public function nthOfYear(int $nth, int $dayOfWeek): mixed
     {
         $dt = $this->copy()->firstOfYear()->modify("+$nth " . static::$days[$dayOfWeek]);
 
@@ -1130,7 +1130,7 @@ trait ModifierTrait
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to compare with.
      * @return static
      */
-    public function average(?ChronosInterface $dt = null): ChronosInterface
+    public function average(?ChronosInterface $dt = null): static
     {
         $dt = $dt ?? static::now($this->tz);
 

--- a/src/Traits/RelativeKeywordTrait.php
+++ b/src/Traits/RelativeKeywordTrait.php
@@ -15,6 +15,8 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
+use DateTimeInterface;
+
 /**
  * Provides methods for testing if strings contain relative keywords.
  */
@@ -25,15 +27,16 @@ trait RelativeKeywordTrait
      *
      * @var string
      */
-    protected static $relativePattern = '/this|next|last|tomorrow|yesterday|midnight|today|[+-]|first|last|ago/i';
+    // phpcs:disable Generic.Files.LineLength.TooLong
+    protected static string $relativePattern = '/this|next|last|tomorrow|yesterday|midnight|today|[+-]|first|last|ago/i';
 
     /**
      * Determine if there is just a time in the time string
      *
-     * @param string $time The time string to check.
+     * @param string|null $time The time string to check.
      * @return bool true if there is a keyword, otherwise false
      */
-    private static function isTimeExpression($time)
+    private static function isTimeExpression(?string $time): bool
     {
         // Just a time
         if (is_string($time) && preg_match('/^[0-2]?[0-9]:[0-5][0-9](?::[0-5][0-9](?:\.[0-9]{1,6})?)?$/', $time)) {
@@ -69,7 +72,7 @@ trait RelativeKeywordTrait
      * @param \DateTimeInterface|string|null $time The time string to check
      * @return bool true if doesn't contain a fixed date
      */
-    private static function isRelativeOnly($time): bool
+    private static function isRelativeOnly(DateTimeInterface|string|null $time): bool
     {
         if ($time === null) {
             return true;

--- a/src/Traits/TestingAidTrait.php
+++ b/src/Traits/TestingAidTrait.php
@@ -31,7 +31,7 @@ trait TestingAidTrait
      * @param \Cake\Chronos\ChronosInterface|string|null $testNow The instance to use for all future instances.
      * @return void
      */
-    public static function setTestNow($testNow = null): void
+    public static function setTestNow(ChronosInterface|string|null $testNow = null): void
     {
         Chronos::setTestNow($testNow);
     }

--- a/src/Traits/TimezoneTrait.php
+++ b/src/Traits/TimezoneTrait.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
+use DateTimeZone;
 use ReturnTypeWillChange;
 
 /**
@@ -29,7 +29,7 @@ trait TimezoneTrait
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function timezone($value): ChronosInterface
+    public function timezone(DateTimeZone|string $value): static
     {
         return $this->setTimezone($value);
     }
@@ -40,7 +40,7 @@ trait TimezoneTrait
      * @param \DateTimeZone|string $value The DateTimeZone object or timezone name to use.
      * @return static
      */
-    public function tz($value): ChronosInterface
+    public function tz(DateTimeZone|string $value): static
     {
         return $this->setTimezone($value);
     }
@@ -52,7 +52,7 @@ trait TimezoneTrait
      * @return static
      */
     #[ReturnTypeWillChange]
-    public function setTimezone($value): ChronosInterface
+    public function setTimezone(DateTimeZone|string $value): static
     {
         return parent::setTimezone(static::safeCreateDateTimeZone($value));
     }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -23,7 +23,7 @@ class Translator
      *
      * @var array
      */
-    public static $strings = [
+    public static array $strings = [
         'year' => '1 year',
         'year_plural' => '{count} years',
         'month' => '1 month',

--- a/src/carbon_compat.php
+++ b/src/carbon_compat.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
 
 // Check if the interface alias exists and don't redeclare it in case we are in
 // a preloaded context.
-if (!\class_exists('Carbon\Carbon') && !\interface_exists('Carbon\CarbonInterface', false)) {
+if (!class_exists('Carbon\Carbon') && !interface_exists('Carbon\CarbonInterface', false)) {
     // Create class aliases for Carbon so applications
     // can upgrade more easily.
     class_alias('Cake\Chronos\Chronos', 'Carbon\MutableDateTime');

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -16,6 +16,7 @@ namespace Cake\Chronos\Test\TestCase\Date;
 use Cake\Chronos\Chronos;
 use Cake\Chronos\Date;
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 
@@ -161,7 +162,7 @@ class ConstructTest extends TestCase
     public function testSettingTimezoneIgnored($class)
     {
         $timezone = 'Europe/London';
-        $dtz = new \DateTimeZone($timezone);
+        $dtz = new DateTimeZone($timezone);
         $c = new $class('now', $dtz);
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
@@ -389,12 +390,12 @@ class ConstructTest extends TestCase
      */
     public function testCreateFromDateTimeInterface($class)
     {
-        $existingClass = new \DateTimeImmutable();
+        $existingClass = new DateTimeImmutable();
         $newClass = new $class($existingClass);
         $this->assertInstanceOf($class, $newClass);
         $this->assertSame($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
 
-        $existingClass = new \DateTime();
+        $existingClass = new DateTime();
         $newClass = new $class($existingClass);
         $this->assertInstanceOf($class, $newClass);
         $this->assertSame($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));

--- a/tests/TestCase/Date/StringsTest.php
+++ b/tests/TestCase/Date/StringsTest.php
@@ -15,6 +15,7 @@ namespace Cake\Chronos\Test\TestCase\Date;
 
 use Cake\Chronos\Date;
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTime;
 
 class StringsTest extends TestCase
 {
@@ -143,7 +144,7 @@ class StringsTest extends TestCase
     public function testToCOOKIEString($class)
     {
         $d = $class::create(1975, 12, 25, 14, 15, 16);
-        if (\DateTime::COOKIE === 'l, d-M-y H:i:s T') {
+        if (DateTime::COOKIE === 'l, d-M-y H:i:s T') {
             $cookieString = 'Thursday, 25-Dec-75 00:00:00 UTC';
         } else {
             $cookieString = 'Thursday, 25-Dec-1975 00:00:00 UTC';

--- a/tests/TestCase/DateTime/ConstructTest.php
+++ b/tests/TestCase/DateTime/ConstructTest.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeZone;
 
 class ConstructTest extends TestCase
 {
@@ -117,8 +120,8 @@ class ConstructTest extends TestCase
     public function testSettingTimezone($class)
     {
         $timezone = 'Europe/London';
-        $dtz = new \DateTimeZone($timezone);
-        $dt = new \DateTime('now', $dtz);
+        $dtz = new DateTimeZone($timezone);
+        $dt = new DateTime('now', $dtz);
         $dayLightSavingTimeOffset = (int)$dt->format('I');
 
         $c = new $class('now', $dtz);
@@ -133,8 +136,8 @@ class ConstructTest extends TestCase
     public function testParseSettingTimezone($class)
     {
         $timezone = 'Europe/London';
-        $dtz = new \DateTimeZone($timezone);
-        $dt = new \DateTime('now', $dtz);
+        $dtz = new DateTimeZone($timezone);
+        $dt = new DateTime('now', $dtz);
         $dayLightSavingTimeOffset = (int)$dt->format('I');
 
         $c = $class::parse('now', $dtz);
@@ -149,8 +152,8 @@ class ConstructTest extends TestCase
     public function testSettingTimezoneWithString($class)
     {
         $timezone = 'Asia/Tokyo';
-        $dtz = new \DateTimeZone($timezone);
-        $dt = new \DateTime('now', $dtz);
+        $dtz = new DateTimeZone($timezone);
+        $dt = new DateTime('now', $dtz);
         $dayLightSavingTimeOffset = (int)$dt->format('I');
 
         $c = new $class('now', $timezone);
@@ -165,8 +168,8 @@ class ConstructTest extends TestCase
     public function testParseSettingTimezoneWithString($class)
     {
         $timezone = 'Asia/Tokyo';
-        $dtz = new \DateTimeZone($timezone);
-        $dt = new \DateTime('now', $dtz);
+        $dtz = new DateTimeZone($timezone);
+        $dt = new DateTime('now', $dtz);
         $dayLightSavingTimeOffset = (int)$dt->format('I');
 
         $c = $class::parse('now', $timezone);
@@ -194,15 +197,15 @@ class ConstructTest extends TestCase
      */
     public function testCreateFromDateTimeInterface($class)
     {
-        $existingClass = new \DateTimeImmutable();
+        $existingClass = new DateTimeImmutable();
         $newClass = new $class($existingClass);
         $this->assertSame($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
-        $existingClass = new \DateTime();
+        $existingClass = new DateTime();
         $newClass = new $class($existingClass);
         $this->assertSame($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
-        $existingClass = new \DateTime('2019-01-15 00:15:22.139302');
+        $existingClass = new DateTime('2019-01-15 00:15:22.139302');
         $newClass = new $class($existingClass);
         $this->assertDateTime($newClass, 2019, 01, 15, 0, 15, 22);
         $this->assertSame(139302, $newClass->micro);

--- a/tests/TestCase/DateTime/CreateFromDateTest.php
+++ b/tests/TestCase/DateTime/CreateFromDateTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTimeZone;
 
 class CreateFromDateTest extends TestCase
 {
@@ -86,7 +87,7 @@ class CreateFromDateTest extends TestCase
      */
     public function testCreateFromDateWithDateTimeZone($class)
     {
-        $d = $class::createFromDate(1975, 5, 21, new \DateTimeZone('Europe/London'));
+        $d = $class::createFromDate(1975, 5, 21, new DateTimeZone('Europe/London'));
         $this->assertDateTime($d, 1975, 5, 21);
         $this->assertSame('Europe/London', $d->tzName);
     }

--- a/tests/TestCase/DateTime/CreateFromFormatTest.php
+++ b/tests/TestCase/DateTime/CreateFromFormatTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTimeZone;
 
 class CreateFromFormatTest extends TestCase
 {
@@ -47,7 +48,7 @@ class CreateFromFormatTest extends TestCase
      */
     public function testCreateFromFormatWithTimezone($class)
     {
-        $d = $class::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11', new \DateTimeZone('Europe/London'));
+        $d = $class::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11', new DateTimeZone('Europe/London'));
         $this->assertDateTime($d, 1975, 5, 21, 22, 32, 11);
         $this->assertSame('Europe/London', $d->tzName);
     }

--- a/tests/TestCase/DateTime/CreateFromTimeTest.php
+++ b/tests/TestCase/DateTime/CreateFromTimeTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTimeZone;
 
 class CreateFromTimeTest extends TestCase
 {
@@ -88,7 +89,7 @@ class CreateFromTimeTest extends TestCase
     public function testCreateFromTimeWithDateTimeZone($class)
     {
         $now = $class::now();
-        $d = $class::createFromTime(12, 0, 0, 0, new \DateTimeZone('Europe/London'));
+        $d = $class::createFromTime(12, 0, 0, 0, new DateTimeZone('Europe/London'));
         $this->assertDateTime($d, $now->year, $now->month, $now->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }

--- a/tests/TestCase/DateTime/CreateFromTimestampTest.php
+++ b/tests/TestCase/DateTime/CreateFromTimestampTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTimeZone;
 
 class CreateFromTimestampTest extends TestCase
 {
@@ -48,7 +49,7 @@ class CreateFromTimestampTest extends TestCase
      */
     public function testCreateFromTimestampWithDateTimeZone($class)
     {
-        $d = $class::createFromTimestamp(0, new \DateTimeZone('UTC'));
+        $d = $class::createFromTimestamp(0, new DateTimeZone('UTC'));
         $this->assertSame('UTC', $d->tzName);
         $this->assertDateTime($d, 1970, 1, 1, 0, 0, 0);
     }

--- a/tests/TestCase/DateTime/CreateTest.php
+++ b/tests/TestCase/DateTime/CreateTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTimeZone;
+use InvalidArgumentException;
 
 class CreateTest extends TestCase
 {
@@ -95,7 +97,7 @@ class CreateTest extends TestCase
      */
     public function testCreateWithInvalidMonth($class)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $class::create(null, -5);
     }
@@ -126,7 +128,7 @@ class CreateTest extends TestCase
      */
     public function testCreateWithInvalidDay($class)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $class::create(null, null, -4);
     }
@@ -159,7 +161,7 @@ class CreateTest extends TestCase
      */
     public function testCreateWithInvalidHour($class)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $class::create(null, null, null, -1);
     }
@@ -190,7 +192,7 @@ class CreateTest extends TestCase
      */
     public function testCreateWithInvalidMinute($class)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $class::create(2011, 1, 1, 0, -2, 0);
     }
@@ -221,7 +223,7 @@ class CreateTest extends TestCase
      */
     public function testCreateWithInvalidSecond($class)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $class::create(null, null, null, null, null, -2);
     }
@@ -242,7 +244,7 @@ class CreateTest extends TestCase
      */
     public function testCreateWithDateTimeZone($class)
     {
-        $d = $class::create(2012, 1, 1, 0, 0, 0, 0, new \DateTimeZone('Europe/London'));
+        $d = $class::create(2012, 1, 1, 0, 0, 0, 0, new DateTimeZone('Europe/London'));
         $this->assertDateTime($d, 2012, 1, 1, 0, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -16,6 +16,7 @@ namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosInterval;
+use Cake\Chronos\DifferenceFormatter;
 use Cake\Chronos\Test\TestCase\TestCase;
 use Closure;
 use DateTimeZone;
@@ -865,7 +866,7 @@ class DiffTest extends TestCase
 
     public function testDiffFormatterSetter()
     {
-        $formatter = new \Cake\Chronos\DifferenceFormatter();
+        $formatter = new DifferenceFormatter();
         $result = Chronos::diffFormatter($formatter);
         $this->assertSame($result, $formatter, 'Should return parameter');
 

--- a/tests/TestCase/DateTime/GettersTest.php
+++ b/tests/TestCase/DateTime/GettersTest.php
@@ -17,6 +17,7 @@ namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\ChronosInterface;
 use Cake\Chronos\Test\TestCase\TestCase;
+use InvalidArgumentException;
 
 class GettersTest extends TestCase
 {
@@ -26,7 +27,7 @@ class GettersTest extends TestCase
      */
     public function testGettersThrowExceptionOnUnknownGetter($class)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $class::create(1234, 5, 6, 7, 8, 9)->sdfsdfss;
     }
@@ -492,7 +493,7 @@ class GettersTest extends TestCase
      */
     public function testInvalidGetter($class)
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $d = $class::now();
         $bb = $d->doesNotExit;

--- a/tests/TestCase/DateTime/InstanceTest.php
+++ b/tests/TestCase/DateTime/InstanceTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTime;
+use DateTimeZone;
 
 class InstanceTest extends TestCase
 {
@@ -25,7 +27,7 @@ class InstanceTest extends TestCase
      */
     public function testInstanceFromDateTime($class)
     {
-        $dating = $class::instance(\DateTime::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11'));
+        $dating = $class::instance(DateTime::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11'));
         $this->assertDateTime($dating, 1975, 5, 21, 22, 32, 11);
     }
 
@@ -35,10 +37,10 @@ class InstanceTest extends TestCase
      */
     public function testInstanceFromDateTimeKeepsTimezoneName($class)
     {
-        $dating = $class::instance(\DateTime::createFromFormat(
+        $dating = $class::instance(DateTime::createFromFormat(
             'Y-m-d H:i:s',
             '1975-05-21 22:32:11'
-        )->setTimezone(new \DateTimeZone('America/Vancouver')));
+        )->setTimezone(new DateTimeZone('America/Vancouver')));
         $this->assertSame('America/Vancouver', $dating->tzName);
     }
 
@@ -49,7 +51,7 @@ class InstanceTest extends TestCase
     public function testInstanceFromDateTimeKeepsMicros($class)
     {
         $micro = 254687;
-        $datetime = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2014-02-01 03:45:27.' . $micro);
+        $datetime = DateTime::createFromFormat('Y-m-d H:i:s.u', '2014-02-01 03:45:27.' . $micro);
         $carbon = $class::instance($datetime);
         $this->assertSame($micro, $carbon->micro);
     }

--- a/tests/TestCase/DateTime/NowAndOtherStaticHelpersTest.php
+++ b/tests/TestCase/DateTime/NowAndOtherStaticHelpersTest.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTime;
+use DateTimeZone;
 
 class NowAndOtherStaticHelpersTest extends TestCase
 {
@@ -57,7 +59,7 @@ class NowAndOtherStaticHelpersTest extends TestCase
     public function testTodayWithTimezone($class)
     {
         $dt = $class::today('Europe/London');
-        $dt2 = new \DateTime('now', new \DateTimeZone('Europe/London'));
+        $dt2 = new DateTime('now', new DateTimeZone('Europe/London'));
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
@@ -68,7 +70,7 @@ class NowAndOtherStaticHelpersTest extends TestCase
     public function testTomorrow($class)
     {
         $dt = $class::tomorrow();
-        $dt2 = new \DateTime('tomorrow');
+        $dt2 = new DateTime('tomorrow');
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
@@ -79,7 +81,7 @@ class NowAndOtherStaticHelpersTest extends TestCase
     public function testTomorrowWithTimezone($class)
     {
         $dt = $class::tomorrow('Europe/London');
-        $dt2 = new \DateTime('tomorrow', new \DateTimeZone('Europe/London'));
+        $dt2 = new DateTime('tomorrow', new DateTimeZone('Europe/London'));
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
@@ -90,7 +92,7 @@ class NowAndOtherStaticHelpersTest extends TestCase
     public function testYesterday($class)
     {
         $dt = $class::yesterday();
-        $dt2 = new \DateTime('yesterday');
+        $dt2 = new DateTime('yesterday');
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
@@ -101,7 +103,7 @@ class NowAndOtherStaticHelpersTest extends TestCase
     public function testYesterdayWithTimezone($class)
     {
         $dt = $class::yesterday('Europe/London');
-        $dt2 = new \DateTime('yesterday', new \DateTimeZone('Europe/London'));
+        $dt2 = new DateTime('yesterday', new DateTimeZone('Europe/London'));
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 

--- a/tests/TestCase/DateTime/StringsTest.php
+++ b/tests/TestCase/DateTime/StringsTest.php
@@ -17,6 +17,7 @@ namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTime;
 
 class StringsTest extends TestCase
 {
@@ -130,7 +131,7 @@ class StringsTest extends TestCase
     public function testToCOOKIEString($class)
     {
         $d = $class::create(1975, 12, 25, 14, 15, 16);
-        if (\DateTime::COOKIE === 'l, d-M-y H:i:s T') {
+        if (DateTime::COOKIE === 'l, d-M-y H:i:s T') {
             $cookieString = 'Thursday, 25-Dec-75 14:15:16 EST';
         } else {
             $cookieString = 'Thursday, 25-Dec-1975 14:15:16 EST';

--- a/tests/TestCase/Interval/IntervalConstructTest.php
+++ b/tests/TestCase/Interval/IntervalConstructTest.php
@@ -19,6 +19,7 @@ use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateInterval;
+use InvalidArgumentException;
 
 class IntervalConstructTest extends TestCase
 {
@@ -254,7 +255,7 @@ class IntervalConstructTest extends TestCase
 
     public function testInstanceWithDaysThrowsException()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $ci = ChronosInterval::instance(Chronos::now()->diff(Chronos::now()->addWeeks(3)));
     }

--- a/tests/TestCase/Interval/IntervalGettersTest.php
+++ b/tests/TestCase/Interval/IntervalGettersTest.php
@@ -17,12 +17,13 @@ namespace Cake\Chronos\Test\TestCase\Interval;
 
 use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\Test\TestCase\TestCase;
+use InvalidArgumentException;
 
 class IntervalGettersTest extends TestCase
 {
     public function testGettersThrowExceptionOnUnknownGetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         ChronosInterval::year()->sdfsdfss;
     }


### PR DESCRIPTION
This enables the cake5 phpcs branch.

Various self, $this and ChronosInterface return types were synchronized between the interface and traits/classes. 