### PR TITLE
Remove not needed legacy API method.

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -547,7 +547,7 @@ class Chronos
      */
     public static function maxValue(): static
     {
-        return static::createFromTimestampUTC(PHP_INT_MAX);
+        return static::createFromTimestamp(PHP_INT_MAX);
     }
 
     /**
@@ -559,7 +559,7 @@ class Chronos
     {
         $max = PHP_INT_SIZE === 4 ? PHP_INT_MAX : PHP_INT_MAX / 10;
 
-        return static::createFromTimestampUTC(~$max);
+        return static::createFromTimestamp(~$max);
     }
 
     /**
@@ -751,17 +751,6 @@ class Chronos
     public static function createFromTimestamp(int $timestamp, DateTimeZone|string|null $timezone = null): static
     {
         return static::now($timezone)->setTimestamp($timestamp);
-    }
-
-    /**
-     * Create an instance from an UTC timestamp
-     *
-     * @param int $timestamp The UTC timestamp to create an instance from.
-     * @return static
-     */
-    public static function createFromTimestampUTC(int $timestamp): static
-    {
-        return new static($timestamp);
     }
 
     /**

--- a/tests/Benchmark/ConstructBench.php
+++ b/tests/Benchmark/ConstructBench.php
@@ -170,6 +170,6 @@ class ConstructBench
     public function benchFromTimestampUTC($params)
     {
         $class = $params['class'];
-        $class::createFromTimestampUTC(1454284800);
+        $class::createFromTimestamp(1454284800);
     }
 }

--- a/tests/TestCase/DateTime/CreateFromTimestampTest.php
+++ b/tests/TestCase/DateTime/CreateFromTimestampTest.php
@@ -50,11 +50,4 @@ class CreateFromTimestampTest extends TestCase
         $this->assertSame(0, $d->offset);
         $this->assertSame('UTC', $d->tzName);
     }
-
-    public function testCreateFromTimestampGMTDoesNotUseDefaultTimezone()
-    {
-        $d = Chronos::createFromTimestampUTC(0);
-        $this->assertDateTime($d, 1970, 1, 1, 0, 0, 0);
-        $this->assertSame(0, $d->offset);
-    }
 }


### PR DESCRIPTION
If we now fix up the API and method naming, I suggest renaming this as the current one, removes the acronym here.
Is already a duplicate somewhat in naming anyway ("TimestampUTC" => TimestampUniversalTimeCoordinated)