### PR TITLE
Start deprecations for 2.next

### DIFF
--- a/src/Traits/ComparisonTrait.php
+++ b/src/Traits/ComparisonTrait.php
@@ -314,7 +314,7 @@ trait ComparisonTrait
      */
     public function isNextWeek(): bool
     {
-        return $this->format('W o') === static::now($this->tz)->addWeek()->format('W o');
+        return $this->format('W o') === static::now($this->tz)->addWeeks(1)->format('W o');
     }
 
     /**
@@ -324,7 +324,7 @@ trait ComparisonTrait
      */
     public function isLastWeek(): bool
     {
-        return $this->format('W o') === static::now($this->tz)->subWeek()->format('W o');
+        return $this->format('W o') === static::now($this->tz)->subWeeks(1)->format('W o');
     }
 
     /**
@@ -334,7 +334,7 @@ trait ComparisonTrait
      */
     public function isNextMonth(): bool
     {
-        return $this->format('m Y') === static::now($this->tz)->addMonth()->format('m Y');
+        return $this->format('m Y') === static::now($this->tz)->addMonths(1)->format('m Y');
     }
 
     /**
@@ -344,7 +344,7 @@ trait ComparisonTrait
      */
     public function isLastMonth(): bool
     {
-        return $this->format('m Y') === static::now($this->tz)->subMonth()->format('m Y');
+        return $this->format('m Y') === static::now($this->tz)->subMonths(1)->format('m Y');
     }
 
     /**
@@ -354,7 +354,7 @@ trait ComparisonTrait
      */
     public function isNextYear(): bool
     {
-        return $this->year === static::now($this->tz)->addYear()->year;
+        return $this->year === static::now($this->tz)->addYears(1)->year;
     }
 
     /**
@@ -364,7 +364,7 @@ trait ComparisonTrait
      */
     public function isLastYear(): bool
     {
-        return $this->year === static::now($this->tz)->subYear()->year;
+        return $this->year === static::now($this->tz)->subYears(1)->year;
     }
 
     /**

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -494,7 +494,10 @@ trait ModifierTrait
      */
     public function addMonthWithOverflow(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addMonthWithOverflow() is deprecated. Use addMonthsWithOverflow() instead.', E_USER_DEPRECATED);
+        trigger_error(
+            '2.4 - addMonthWithOverflow() is deprecated. Use addMonthsWithOverflow() instead.',
+            E_USER_DEPRECATED
+        );
 
         return $this->modify($value . ' months');
     }
@@ -522,7 +525,10 @@ trait ModifierTrait
      */
     public function subMonthWithOverflow(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subMonthWithOverflow() is deprecated. Use subMonthsWithOverflow() instead.', E_USER_DEPRECATED);
+        trigger_error(
+            '2.4 - subMonthWithOverflow() is deprecated. Use subMonthsWithOverflow() instead.',
+            E_USER_DEPRECATED
+        );
 
         return $this->subMonthsWithOverflow($value);
     }

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -296,7 +296,7 @@ trait ModifierTrait
      */
     public function addYear(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addYear() is deprecated. Use addYears() instead.');
+        trigger_error('2.4 - addYear() is deprecated. Use addYears() instead.', E_USER_DEPRECATED);
 
         return $this->addYears($value);
     }
@@ -324,7 +324,7 @@ trait ModifierTrait
      */
     public function subYear(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subYear() is deprecated. Use subYears() instead.');
+        trigger_error('2.4 - subYear() is deprecated. Use subYears() instead.', E_USER_DEPRECATED);
 
         return $this->addYears(-$value);
     }
@@ -359,7 +359,7 @@ trait ModifierTrait
      */
     public function addYearWithOverflow(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addYearWithOverflow() is deprecated.');
+        trigger_error('2.4 - addYearWithOverflow() is deprecated.', E_USER_DEPRECATED);
 
         return $this->addYearsWithOverflow($value);
     }
@@ -431,7 +431,7 @@ trait ModifierTrait
      */
     public function addMonth(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addMonth() is deprecated. Use addMonths() instead.');
+        trigger_error('2.4 - addMonth() is deprecated. Use addMonths() instead.', E_USER_DEPRECATED);
 
         return $this->addMonths($value);
     }
@@ -446,7 +446,7 @@ trait ModifierTrait
      */
     public function subMonth(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subMonth() is deprecated. Use subMonths() instead.');
+        trigger_error('2.4 - subMonth() is deprecated. Use subMonths() instead.', E_USER_DEPRECATED);
 
         return $this->addMonths(-$value);
     }
@@ -494,7 +494,7 @@ trait ModifierTrait
      */
     public function addMonthWithOverflow(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addMonthWithOverflow() is deprecated. Use addMonthsWithOverflow() instead.');
+        trigger_error('2.4 - addMonthWithOverflow() is deprecated. Use addMonthsWithOverflow() instead.', E_USER_DEPRECATED);
 
         return $this->modify($value . ' months');
     }
@@ -522,7 +522,7 @@ trait ModifierTrait
      */
     public function subMonthWithOverflow(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subMonthWithOverflow() is deprecated. Use subMonthsWithOverflow() instead.');
+        trigger_error('2.4 - subMonthWithOverflow() is deprecated. Use subMonthsWithOverflow() instead.', E_USER_DEPRECATED);
 
         return $this->subMonthsWithOverflow($value);
     }
@@ -547,7 +547,7 @@ trait ModifierTrait
      */
     public function addDay(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addYear() is deprecated. Use addYears() instead.');
+        trigger_error('2.4 - addYear() is deprecated. Use addYears() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value days");
     }
@@ -560,7 +560,7 @@ trait ModifierTrait
      */
     public function subDay(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subDay() is deprecated. Use subDays() instead.');
+        trigger_error('2.4 - subDay() is deprecated. Use subDays() instead.', E_USER_DEPRECATED);
 
         return $this->addDays(-$value);
     }
@@ -596,7 +596,7 @@ trait ModifierTrait
      */
     public function addWeekday(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addWeekday() is deprecated. Use addWeekdays() instead.');
+        trigger_error('2.4 - addWeekday() is deprecated. Use addWeekdays() instead.', E_USER_DEPRECATED);
 
         return $this->addWeekdays($value);
     }
@@ -643,7 +643,7 @@ trait ModifierTrait
      */
     public function addWeek(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addWeek() is deprecated. Use addWeeks() instead.');
+        trigger_error('2.4 - addWeek() is deprecated. Use addWeeks() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value week");
     }
@@ -656,7 +656,7 @@ trait ModifierTrait
      */
     public function subWeek(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subWeek() is deprecated. Use subWeeks() instead.');
+        trigger_error('2.4 - subWeek() is deprecated. Use subWeeks() instead.', E_USER_DEPRECATED);
 
         return $this->addWeeks(-$value);
     }
@@ -692,7 +692,7 @@ trait ModifierTrait
      */
     public function addHour(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addHour() is deprecated. Use addHours() instead.');
+        trigger_error('2.4 - addHour() is deprecated. Use addHours() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value hour");
     }
@@ -705,7 +705,7 @@ trait ModifierTrait
      */
     public function subHour(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subHour() is deprecated. Use subHours() instead.');
+        trigger_error('2.4 - subHour() is deprecated. Use subHours() instead.', E_USER_DEPRECATED);
 
         return $this->addHours(-$value);
     }
@@ -741,7 +741,7 @@ trait ModifierTrait
      */
     public function addMinute(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addMinute() is deprecated. Use addMinutes() instead.');
+        trigger_error('2.4 - addMinute() is deprecated. Use addMinutes() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value minute");
     }
@@ -754,7 +754,7 @@ trait ModifierTrait
      */
     public function subMinute(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subMinute() is deprecated. Use subMinutes() instead.');
+        trigger_error('2.4 - subMinute() is deprecated. Use subMinutes() instead.', E_USER_DEPRECATED);
 
         return $this->addMinutes(-$value);
     }
@@ -790,7 +790,7 @@ trait ModifierTrait
      */
     public function addSecond(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addSecond() is deprecated. Use addSeconds() instead.');
+        trigger_error('2.4 - addSecond() is deprecated. Use addSeconds() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value second");
     }
@@ -803,7 +803,7 @@ trait ModifierTrait
      */
     public function subSecond(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subSecond() is deprecated. Use subSeconds() instead.');
+        trigger_error('2.4 - subSecond() is deprecated. Use subSeconds() instead.', E_USER_DEPRECATED);
 
         return $this->addSeconds(-$value);
     }

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -296,7 +296,7 @@ trait ModifierTrait
      */
     public function addYear(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addYear() is deprecated. Use addYears() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addYear() is deprecated. Use addYears() instead.', E_USER_DEPRECATED);
 
         return $this->addYears($value);
     }
@@ -324,7 +324,7 @@ trait ModifierTrait
      */
     public function subYear(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subYear() is deprecated. Use subYears() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - subYear() is deprecated. Use subYears() instead.', E_USER_DEPRECATED);
 
         return $this->addYears(-$value);
     }
@@ -359,7 +359,7 @@ trait ModifierTrait
      */
     public function addYearWithOverflow(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addYearWithOverflow() is deprecated.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addYearWithOverflow() is deprecated.', E_USER_DEPRECATED);
 
         return $this->addYearsWithOverflow($value);
     }
@@ -431,7 +431,7 @@ trait ModifierTrait
      */
     public function addMonth(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addMonth() is deprecated. Use addMonths() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addMonth() is deprecated. Use addMonths() instead.', E_USER_DEPRECATED);
 
         return $this->addMonths($value);
     }
@@ -446,7 +446,7 @@ trait ModifierTrait
      */
     public function subMonth(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subMonth() is deprecated. Use subMonths() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - subMonth() is deprecated. Use subMonths() instead.', E_USER_DEPRECATED);
 
         return $this->addMonths(-$value);
     }
@@ -495,7 +495,7 @@ trait ModifierTrait
     public function addMonthWithOverflow(int $value = 1): ChronosInterface
     {
         trigger_error(
-            '2.4 - addMonthWithOverflow() is deprecated. Use addMonthsWithOverflow() instead.',
+            'Since 2.4 - addMonthWithOverflow() is deprecated. Use addMonthsWithOverflow() instead.',
             E_USER_DEPRECATED
         );
 
@@ -526,7 +526,7 @@ trait ModifierTrait
     public function subMonthWithOverflow(int $value = 1): ChronosInterface
     {
         trigger_error(
-            '2.4 - subMonthWithOverflow() is deprecated. Use subMonthsWithOverflow() instead.',
+            'Since 2.4 - subMonthWithOverflow() is deprecated. Use subMonthsWithOverflow() instead.',
             E_USER_DEPRECATED
         );
 
@@ -553,7 +553,7 @@ trait ModifierTrait
      */
     public function addDay(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addDay() is deprecated. Use addDays() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addDay() is deprecated. Use addDays() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value days");
     }
@@ -566,7 +566,7 @@ trait ModifierTrait
      */
     public function subDay(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subDay() is deprecated. Use subDays() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - subDay() is deprecated. Use subDays() instead.', E_USER_DEPRECATED);
 
         return $this->addDays(-$value);
     }
@@ -602,7 +602,7 @@ trait ModifierTrait
      */
     public function addWeekday(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addWeekday() is deprecated. Use addWeekdays() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addWeekday() is deprecated. Use addWeekdays() instead.', E_USER_DEPRECATED);
 
         return $this->addWeekdays($value);
     }
@@ -649,7 +649,7 @@ trait ModifierTrait
      */
     public function addWeek(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addWeek() is deprecated. Use addWeeks() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addWeek() is deprecated. Use addWeeks() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value week");
     }
@@ -662,7 +662,7 @@ trait ModifierTrait
      */
     public function subWeek(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subWeek() is deprecated. Use subWeeks() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - subWeek() is deprecated. Use subWeeks() instead.', E_USER_DEPRECATED);
 
         return $this->addWeeks(-$value);
     }
@@ -698,7 +698,7 @@ trait ModifierTrait
      */
     public function addHour(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addHour() is deprecated. Use addHours() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addHour() is deprecated. Use addHours() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value hour");
     }
@@ -711,7 +711,7 @@ trait ModifierTrait
      */
     public function subHour(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subHour() is deprecated. Use subHours() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - subHour() is deprecated. Use subHours() instead.', E_USER_DEPRECATED);
 
         return $this->addHours(-$value);
     }
@@ -747,7 +747,7 @@ trait ModifierTrait
      */
     public function addMinute(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addMinute() is deprecated. Use addMinutes() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addMinute() is deprecated. Use addMinutes() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value minute");
     }
@@ -760,7 +760,7 @@ trait ModifierTrait
      */
     public function subMinute(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subMinute() is deprecated. Use subMinutes() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - subMinute() is deprecated. Use subMinutes() instead.', E_USER_DEPRECATED);
 
         return $this->addMinutes(-$value);
     }
@@ -796,7 +796,7 @@ trait ModifierTrait
      */
     public function addSecond(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addSecond() is deprecated. Use addSeconds() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - addSecond() is deprecated. Use addSeconds() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value second");
     }
@@ -809,7 +809,7 @@ trait ModifierTrait
      */
     public function subSecond(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - subSecond() is deprecated. Use subSeconds() instead.', E_USER_DEPRECATED);
+        trigger_error('Since 2.4 - subSecond() is deprecated. Use subSeconds() instead.', E_USER_DEPRECATED);
 
         return $this->addSeconds(-$value);
     }

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -296,6 +296,8 @@ trait ModifierTrait
      */
     public function addYear(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addYear() is deprecated. Use addYears() instead.');
+
         return $this->addYears($value);
     }
 
@@ -322,6 +324,8 @@ trait ModifierTrait
      */
     public function subYear(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - subYear() is deprecated. Use subYears() instead.');
+
         return $this->addYears(-$value);
     }
 
@@ -355,6 +359,8 @@ trait ModifierTrait
      */
     public function addYearWithOverflow(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addYearWithOverflow() is deprecated.');
+
         return $this->addYearsWithOverflow($value);
     }
 
@@ -425,6 +431,8 @@ trait ModifierTrait
      */
     public function addMonth(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addMonth() is deprecated. Use addMonths() instead.');
+
         return $this->addMonths($value);
     }
 
@@ -438,6 +446,8 @@ trait ModifierTrait
      */
     public function subMonth(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - subMonth() is deprecated. Use subMonths() instead.');
+
         return $this->addMonths(-$value);
     }
 
@@ -484,6 +494,8 @@ trait ModifierTrait
      */
     public function addMonthWithOverflow(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addMonthWithOverflow() is deprecated. Use addMonthsWithOverflow() instead.');
+
         return $this->modify($value . ' months');
     }
 
@@ -510,6 +522,8 @@ trait ModifierTrait
      */
     public function subMonthWithOverflow(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - subMonthWithOverflow() is deprecated. Use subMonthsWithOverflow() instead.');
+
         return $this->subMonthsWithOverflow($value);
     }
 
@@ -533,6 +547,8 @@ trait ModifierTrait
      */
     public function addDay(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addYear() is deprecated. Use addYears() instead.');
+
         return $this->modify("$value days");
     }
 
@@ -544,6 +560,8 @@ trait ModifierTrait
      */
     public function subDay(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - subDay() is deprecated. Use subDays() instead.');
+
         return $this->addDays(-$value);
     }
 
@@ -578,6 +596,8 @@ trait ModifierTrait
      */
     public function addWeekday(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addWeekday() is deprecated. Use addWeekdays() instead.');
+
         return $this->addWeekdays($value);
     }
 
@@ -623,6 +643,8 @@ trait ModifierTrait
      */
     public function addWeek(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addWeek() is deprecated. Use addWeeks() instead.');
+
         return $this->modify("$value week");
     }
 
@@ -634,6 +656,8 @@ trait ModifierTrait
      */
     public function subWeek(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - subWeek() is deprecated. Use subWeeks() instead.');
+
         return $this->addWeeks(-$value);
     }
 
@@ -668,6 +692,8 @@ trait ModifierTrait
      */
     public function addHour(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addHour() is deprecated. Use addHours() instead.');
+
         return $this->modify("$value hour");
     }
 
@@ -679,6 +705,8 @@ trait ModifierTrait
      */
     public function subHour(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - subHour() is deprecated. Use subHours() instead.');
+
         return $this->addHours(-$value);
     }
 
@@ -713,6 +741,8 @@ trait ModifierTrait
      */
     public function addMinute(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addMinute() is deprecated. Use addMinutes() instead.');
+
         return $this->modify("$value minute");
     }
 
@@ -724,6 +754,8 @@ trait ModifierTrait
      */
     public function subMinute(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - subMinute() is deprecated. Use subMinutes() instead.');
+
         return $this->addMinutes(-$value);
     }
 
@@ -758,6 +790,8 @@ trait ModifierTrait
      */
     public function addSecond(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - addSecond() is deprecated. Use addSeconds() instead.');
+
         return $this->modify("$value second");
     }
 
@@ -769,6 +803,8 @@ trait ModifierTrait
      */
     public function subSecond(int $value = 1): ChronosInterface
     {
+        trigger_error('2.4 - subSecond() is deprecated. Use subSeconds() instead.');
+
         return $this->addSeconds(-$value);
     }
 

--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -547,7 +547,7 @@ trait ModifierTrait
      */
     public function addDay(int $value = 1): ChronosInterface
     {
-        trigger_error('2.4 - addYear() is deprecated. Use addYears() instead.', E_USER_DEPRECATED);
+        trigger_error('2.4 - addDay() is deprecated. Use addDays() instead.', E_USER_DEPRECATED);
 
         return $this->modify("$value days");
     }

--- a/tests/TestCase/Date/IsTest.php
+++ b/tests/TestCase/Date/IsTest.php
@@ -46,6 +46,6 @@ class IsTest extends TestCase
      */
     public function testIsTodayFalseWithYesterday($class)
     {
-        $this->assertFalse($class::now()->subDay()->endOfDay()->isToday());
+        $this->assertFalse($class::now()->subDays(1)->endOfDay()->isToday());
     }
 }

--- a/tests/TestCase/DateTime/AddTest.php
+++ b/tests/TestCase/DateTime/AddTest.php
@@ -52,7 +52,9 @@ class AddTest extends TestCase
      */
     public function testAddYear($class)
     {
-        $this->assertSame(1976, $class::createFromDate(1975)->addYear()->year);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(1976, $class::createFromDate(1975)->addYear()->year);
+        });
     }
 
     /**
@@ -88,7 +90,9 @@ class AddTest extends TestCase
      */
     public function testAddMonth($class)
     {
-        $this->assertSame(1, $class::createFromDate(1975, 12)->addMonth()->month);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(1, $class::createFromDate(1975, 12)->addMonth()->month);
+        });
     }
 
     /**
@@ -97,7 +101,9 @@ class AddTest extends TestCase
      */
     public function testAddMonthWithOverflow($class)
     {
-        $this->assertSame(3, $class::createFromDate(2012, 1, 31)->addMonthWithOverflow()->month);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(3, $class::createFromDate(2012, 1, 31)->addMonthWithOverflow()->month);
+        });
     }
 
     /**
@@ -106,9 +112,9 @@ class AddTest extends TestCase
      */
     public function testAddMonthsNoOverflowPositive($class)
     {
-        $this->assertSame('2012-02-29', $class::createFromDate(2012, 1, 31)->addMonth()->toDateString());
+        $this->assertSame('2012-02-29', $class::createFromDate(2012, 1, 31)->addMonths(1)->toDateString());
         $this->assertSame('2012-03-31', $class::createFromDate(2012, 1, 31)->addMonths(2)->toDateString());
-        $this->assertSame('2012-03-29', $class::createFromDate(2012, 2, 29)->addMonth()->toDateString());
+        $this->assertSame('2012-03-29', $class::createFromDate(2012, 2, 29)->addMonths(1)->toDateString());
         $this->assertSame('2012-02-29', $class::createFromDate(2011, 12, 31)->addMonths(2)->toDateString());
     }
 
@@ -166,7 +172,9 @@ class AddTest extends TestCase
      */
     public function testAddDay($class)
     {
-        $this->assertSame(1, $class::createFromDate(1975, 5, 31)->addDay()->day);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(1, $class::createFromDate(1975, 5, 31)->addDay()->day);
+        });
     }
 
     /**
@@ -175,7 +183,9 @@ class AddTest extends TestCase
      */
     public function testAddWeekdayDuringWeekend($class)
     {
-        $this->assertSame(9, $class::createFromDate(2012, 1, 7)->addWeekday()->day);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(9, $class::createFromDate(2012, 1, 7)->addWeekday()->day);
+        });
     }
 
     /**
@@ -217,7 +227,9 @@ class AddTest extends TestCase
      */
     public function testAddWeekday($class)
     {
-        $this->assertSame(9, $class::createFromDate(2012, 1, 6)->addWeekday()->day);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(9, $class::createFromDate(2012, 1, 6)->addWeekday()->day);
+        });
     }
 
     /**
@@ -253,7 +265,9 @@ class AddTest extends TestCase
      */
     public function testAddWeek($class)
     {
-        $this->assertSame(28, $class::createFromDate(1975, 5, 21)->addWeek()->day);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(28, $class::createFromDate(1975, 5, 21)->addWeek()->day);
+        });
     }
 
     /**
@@ -289,7 +303,9 @@ class AddTest extends TestCase
      */
     public function testAddHour($class)
     {
-        $this->assertSame(1, $class::createFromTime(0)->addHour()->hour);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(1, $class::createFromTime(0)->addHour()->hour);
+        });
     }
 
     /**
@@ -325,7 +341,9 @@ class AddTest extends TestCase
      */
     public function testAddMinute($class)
     {
-        $this->assertSame(1, $class::createFromTime(0, 0)->addMinute()->minute);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(1, $class::createFromTime(0, 0)->addMinute()->minute);
+        });
     }
 
     /**
@@ -361,7 +379,7 @@ class AddTest extends TestCase
      */
     public function testAddSecond($class)
     {
-        $this->assertSame(1, $class::createFromTime(0, 0, 0)->addSecond()->second);
+        $this->assertSame(1, $class::createFromTime(0, 0, 0)->addSeconds(1)->second);
     }
 
     /***** Test non plural methods with non default args *****/
@@ -372,7 +390,9 @@ class AddTest extends TestCase
      */
     public function testAddYearPassingArg($class)
     {
-        $this->assertSame(1977, $class::createFromDate(1975)->addYear(2)->year);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(1977, $class::createFromDate(1975)->addYear(2)->year);
+        });
     }
 
     /**
@@ -381,7 +401,9 @@ class AddTest extends TestCase
      */
     public function testAddYearWithOverflow($class)
     {
-        $this->assertSame('2013-03-01', $class::createFromDate(2012, 2, 29)->addYearWithOverflow()->toDateString());
+        $this->deprecated(function () use ($class) {
+            $this->assertSame('2013-03-01', $class::createFromDate(2012, 2, 29)->addYearWithOverflow()->toDateString());
+        });
     }
 
     /**
@@ -390,9 +412,9 @@ class AddTest extends TestCase
      */
     public function testAddYearsNoOverflowPositive($class)
     {
-        $this->assertSame('2013-01-31', $class::createFromDate(2012, 1, 31)->addYear()->toDateString());
+        $this->assertSame('2013-01-31', $class::createFromDate(2012, 1, 31)->addYears(1)->toDateString());
         $this->assertSame('2014-01-31', $class::createFromDate(2012, 1, 31)->addYears(2)->toDateString());
-        $this->assertSame('2013-02-28', $class::createFromDate(2012, 2, 29)->addYear()->toDateString());
+        $this->assertSame('2013-02-28', $class::createFromDate(2012, 2, 29)->addYears(1)->toDateString());
         $this->assertSame('2013-12-31', $class::createFromDate(2011, 12, 31)->addYears(2)->toDateString());
     }
 
@@ -423,7 +445,9 @@ class AddTest extends TestCase
      */
     public function testAddMonthPassingArg($class)
     {
-        $this->assertSame(7, $class::createFromDate(1975, 5, 1)->addMonth(2)->month);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(7, $class::createFromDate(1975, 5, 1)->addMonth(2)->month);
+        });
     }
 
     /**
@@ -432,10 +456,12 @@ class AddTest extends TestCase
      */
     public function testAddMonthNoOverflowPassingArg($class)
     {
-        $dt = $class::createFromDate(2010, 12, 31)->addMonth(2);
-        $this->assertSame(2011, $dt->year);
-        $this->assertSame(2, $dt->month);
-        $this->assertSame(28, $dt->day);
+        $this->deprecated(function () use ($class) {
+            $dt = $class::createFromDate(2010, 12, 31)->addMonth(2);
+            $this->assertSame(2011, $dt->year);
+            $this->assertSame(2, $dt->month);
+            $this->assertSame(28, $dt->day);
+        });
     }
 
     /**
@@ -444,7 +470,9 @@ class AddTest extends TestCase
      */
     public function testAddDayPassingArg($class)
     {
-        $this->assertSame(12, $class::createFromDate(1975, 5, 10)->addDay(2)->day);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(12, $class::createFromDate(1975, 5, 10)->addDay(2)->day);
+        });
     }
 
     /**
@@ -453,7 +481,9 @@ class AddTest extends TestCase
      */
     public function testAddHourPassingArg($class)
     {
-        $this->assertSame(2, $class::createFromTime(0)->addHour(2)->hour);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(2, $class::createFromTime(0)->addHour(2)->hour);
+        });
     }
 
     /**
@@ -462,7 +492,9 @@ class AddTest extends TestCase
      */
     public function testAddMinutePassingArg($class)
     {
-        $this->assertSame(2, $class::createFromTime(0)->addMinute(2)->minute);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(2, $class::createFromTime(0)->addMinute(2)->minute);
+        });
     }
 
     /**
@@ -471,6 +503,8 @@ class AddTest extends TestCase
      */
     public function testAddSecondPassingArg($class)
     {
-        $this->assertSame(2, $class::createFromTime(0)->addSecond(2)->second);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(2, $class::createFromTime(0)->addSecond(2)->second);
+        });
     }
 }

--- a/tests/TestCase/DateTime/ComparisonTest.php
+++ b/tests/TestCase/DateTime/ComparisonTest.php
@@ -442,9 +442,9 @@ class ComparisonTest extends TestCase
     public function testIsBirthday($class)
     {
         $dt = $class::now();
-        $aBirthday = $dt->subYear();
+        $aBirthday = $dt->subYears(1);
         $this->assertTrue($aBirthday->isBirthday());
-        $notABirthday = $dt->subDay();
+        $notABirthday = $dt->subDays(1);
         $this->assertFalse($notABirthday->isBirthday());
         $alsoNotABirthday = $dt->addDays(2);
         $this->assertFalse($alsoNotABirthday->isBirthday());

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -34,7 +34,7 @@ class DiffTest extends TestCase
     public function testDiffInYearsPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(1, $dt->diffInYears($dt->copy()->addYear()));
+        $this->assertSame(1, $dt->diffInYears($dt->copy()->addYears(1)));
     }
 
     /**
@@ -44,7 +44,7 @@ class DiffTest extends TestCase
     public function testDiffInYearsNegativeWithSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(-1, $dt->diffInYears($dt->copy()->subYear(), false));
+        $this->assertSame(-1, $dt->diffInYears($dt->copy()->subYears(1), false));
     }
 
     /**
@@ -54,7 +54,7 @@ class DiffTest extends TestCase
     public function testDiffInYearsNegativeNoSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(1, $dt->diffInYears($dt->copy()->subYear()));
+        $this->assertSame(1, $dt->diffInYears($dt->copy()->subYears(1)));
     }
 
     /**
@@ -64,7 +64,7 @@ class DiffTest extends TestCase
     public function testDiffInYearsVsDefaultNow($class)
     {
         $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(1, $class::now()->subYear()->diffInYears());
+            $this->assertSame(1, $class::now()->subYears(1)->diffInYears());
         });
     }
 
@@ -75,7 +75,7 @@ class DiffTest extends TestCase
     public function testDiffInYearsEnsureIsTruncated($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(1, $dt->diffInYears($dt->copy()->addYear()->addMonths(7)));
+        $this->assertSame(1, $dt->diffInYears($dt->copy()->addYears(1)->addMonths(7)));
     }
 
     /**
@@ -85,7 +85,7 @@ class DiffTest extends TestCase
     public function testDiffInMonthsPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(13, $dt->diffInMonths($dt->copy()->addYear()->addMonth()));
+        $this->assertSame(13, $dt->diffInMonths($dt->copy()->addYears(1)->addMonths(1)));
     }
 
     /**
@@ -95,7 +95,7 @@ class DiffTest extends TestCase
     public function testDiffInMonthsNegativeWithSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(-11, $dt->diffInMonths($dt->copy()->subYear()->addMonth(), false));
+        $this->assertSame(-11, $dt->diffInMonths($dt->copy()->subYears(1)->addMonths(1), false));
     }
 
     /**
@@ -105,7 +105,7 @@ class DiffTest extends TestCase
     public function testDiffInMonthsNegativeNoSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(11, $dt->diffInMonths($dt->copy()->subYear()->addMonth()));
+        $this->assertSame(11, $dt->diffInMonths($dt->copy()->subYears(1)->addMonths(1)));
     }
 
     /**
@@ -115,7 +115,7 @@ class DiffTest extends TestCase
     public function testDiffInMonthsVsDefaultNow($class)
     {
         $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(12, $class::now()->subYear()->diffInMonths());
+            $this->assertSame(12, $class::now()->subYears(1)->diffInMonths());
         });
     }
 
@@ -126,7 +126,7 @@ class DiffTest extends TestCase
     public function testDiffInMonthsEnsureIsTruncated($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(1, $dt->diffInMonths($dt->copy()->addMonth()->addDays(16)));
+        $this->assertSame(1, $dt->diffInMonths($dt->copy()->addMonths(1)->addDays(16)));
     }
 
     /**
@@ -148,7 +148,7 @@ class DiffTest extends TestCase
         }
 
         $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(1, $class::now()->subMonth()->startOfMonth()->diffInMonthsIgnoreTimezone());
+            $this->assertSame(1, $class::now()->subMonths(1)->startOfMonth()->diffInMonthsIgnoreTimezone());
         });
     }
 
@@ -159,7 +159,7 @@ class DiffTest extends TestCase
     public function testDiffInDaysPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(366, $dt->diffInDays($dt->copy()->addYear()));
+        $this->assertSame(366, $dt->diffInDays($dt->copy()->addYears(1)));
     }
 
     /**
@@ -169,7 +169,7 @@ class DiffTest extends TestCase
     public function testDiffInDaysNegativeWithSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(-365, $dt->diffInDays($dt->copy()->subYear(), false));
+        $this->assertSame(-365, $dt->diffInDays($dt->copy()->subYears(1), false));
     }
 
     /**
@@ -179,7 +179,7 @@ class DiffTest extends TestCase
     public function testDiffInDaysNegativeNoSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(365, $dt->diffInDays($dt->copy()->subYear()));
+        $this->assertSame(365, $dt->diffInDays($dt->copy()->subYears(1)));
     }
 
     /**
@@ -189,7 +189,7 @@ class DiffTest extends TestCase
     public function testDiffInDaysVsDefaultNow($class)
     {
         $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(7, $class::now()->subWeek()->diffInDays());
+            $this->assertSame(7, $class::now()->subWeeks(1)->diffInDays());
         });
     }
 
@@ -200,7 +200,7 @@ class DiffTest extends TestCase
     public function testDiffInDaysEnsureIsTruncated($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(1, $dt->diffInDays($dt->copy()->addDay()->addHours(13)));
+        $this->assertSame(1, $dt->diffInDays($dt->copy()->addDays(1)->addHours(13)));
     }
 
     /**
@@ -435,7 +435,7 @@ class DiffTest extends TestCase
     public function testBug188DiffWithSameDates1DayApart($class)
     {
         $start = $class::create(2014, 10, 8, 15, 20, 0);
-        $end = $start->copy()->addDay();
+        $end = $start->copy()->addDays(1);
 
         $this->assertSame(1, $start->diffInDays($end));
         $this->assertSame(1, $start->diffInWeekdays($end));
@@ -449,7 +449,7 @@ class DiffTest extends TestCase
     {
         $start = $class::create(2014, 1, 1, 0, 0, 0);
         $start = $start->next($class::SATURDAY);
-        $end = $start->copy()->addDay();
+        $end = $start->copy()->addDays(1);
 
         $this->assertSame(1, $start->diffInDays($end));
         $this->assertSame(0, $start->diffInWeekdays($end));
@@ -522,7 +522,7 @@ class DiffTest extends TestCase
     public function testDiffInWeeksPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(52, $dt->diffInWeeks($dt->copy()->addYear()));
+        $this->assertSame(52, $dt->diffInWeeks($dt->copy()->addYears(1)));
     }
 
     /**
@@ -532,7 +532,7 @@ class DiffTest extends TestCase
     public function testDiffInWeeksNegativeWithSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(-52, $dt->diffInWeeks($dt->copy()->subYear(), false));
+        $this->assertSame(-52, $dt->diffInWeeks($dt->copy()->subYears(1), false));
     }
 
     /**
@@ -542,7 +542,7 @@ class DiffTest extends TestCase
     public function testDiffInWeeksNegativeNoSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(52, $dt->diffInWeeks($dt->copy()->subYear()));
+        $this->assertSame(52, $dt->diffInWeeks($dt->copy()->subYears(1)));
     }
 
     /**
@@ -552,7 +552,7 @@ class DiffTest extends TestCase
     public function testDiffInWeeksVsDefaultNow($class)
     {
         $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(1, $class::now()->subWeek()->diffInWeeks());
+            $this->assertSame(1, $class::now()->subWeeks(1)->diffInWeeks());
         });
     }
 
@@ -563,7 +563,7 @@ class DiffTest extends TestCase
     public function testDiffInWeeksEnsureIsTruncated($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(0, $dt->diffInWeeks($dt->copy()->addWeek()->subDay()));
+        $this->assertSame(0, $dt->diffInWeeks($dt->copy()->addWeeks(1)->subDays(1)));
     }
 
     /**
@@ -573,7 +573,7 @@ class DiffTest extends TestCase
     public function testDiffInHoursPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(26, $dt->diffInHours($dt->copy()->addDay()->addHours(2)));
+        $this->assertSame(26, $dt->diffInHours($dt->copy()->addDays(1)->addHours(2)));
     }
 
     /**
@@ -583,7 +583,7 @@ class DiffTest extends TestCase
     public function testDiffInHoursNegativeWithSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(-22, $dt->diffInHours($dt->copy()->subDay()->addHours(2), false));
+        $this->assertSame(-22, $dt->diffInHours($dt->copy()->subDays(1)->addHours(2), false));
     }
 
     /**
@@ -593,7 +593,7 @@ class DiffTest extends TestCase
     public function testDiffInHoursNegativeNoSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(22, $dt->diffInHours($dt->copy()->subDay()->addHours(2)));
+        $this->assertSame(22, $dt->diffInHours($dt->copy()->subDays(1)->addHours(2)));
     }
 
     /**
@@ -615,7 +615,7 @@ class DiffTest extends TestCase
     public function testDiffInHoursEnsureIsTruncated($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(1, $dt->diffInHours($dt->copy()->addHour()->addMinutes(31)));
+        $this->assertSame(1, $dt->diffInHours($dt->copy()->addHours(1)->addMinutes(31)));
     }
 
     /**
@@ -625,7 +625,7 @@ class DiffTest extends TestCase
     public function testDiffInMinutesPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(62, $dt->diffInMinutes($dt->copy()->addHour()->addMinutes(2)));
+        $this->assertSame(62, $dt->diffInMinutes($dt->copy()->addHours(1)->addMinutes(2)));
     }
 
     /**
@@ -645,7 +645,7 @@ class DiffTest extends TestCase
     public function testDiffInMinutesNegativeWithSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(-58, $dt->diffInMinutes($dt->copy()->subHour()->addMinutes(2), false));
+        $this->assertSame(-58, $dt->diffInMinutes($dt->copy()->subHours(1)->addMinutes(2), false));
     }
 
     /**
@@ -655,7 +655,7 @@ class DiffTest extends TestCase
     public function testDiffInMinutesNegativeNoSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(58, $dt->diffInMinutes($dt->copy()->subHour()->addMinutes(2)));
+        $this->assertSame(58, $dt->diffInMinutes($dt->copy()->subHours(1)->addMinutes(2)));
     }
 
     /**
@@ -665,7 +665,7 @@ class DiffTest extends TestCase
     public function testDiffInMinutesVsDefaultNow($class)
     {
         $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(60, $class::now()->subHour()->diffInMinutes());
+            $this->assertSame(60, $class::now()->subHours(1)->diffInMinutes());
         });
     }
 
@@ -676,7 +676,7 @@ class DiffTest extends TestCase
     public function testDiffInMinutesEnsureIsTruncated($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(1, $dt->diffInMinutes($dt->copy()->addMinute()->addSeconds(31)));
+        $this->assertSame(1, $dt->diffInMinutes($dt->copy()->addMinutes(1)->addSeconds(31)));
     }
 
     /**
@@ -686,7 +686,7 @@ class DiffTest extends TestCase
     public function testDiffInSecondsPositive($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(62, $dt->diffInSeconds($dt->copy()->addMinute()->addSeconds(2)));
+        $this->assertSame(62, $dt->diffInSeconds($dt->copy()->addMinutes(1)->addSeconds(2)));
     }
 
     /**
@@ -706,7 +706,7 @@ class DiffTest extends TestCase
     public function testDiffInSecondsNegativeWithSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(-58, $dt->diffInSeconds($dt->copy()->subMinute()->addSeconds(2), false));
+        $this->assertSame(-58, $dt->diffInSeconds($dt->copy()->subMinutes(1)->addSeconds(2), false));
     }
 
     /**
@@ -716,7 +716,7 @@ class DiffTest extends TestCase
     public function testDiffInSecondsNegativeNoSign($class)
     {
         $dt = $class::createFromDate(2000, 1, 1);
-        $this->assertSame(58, $dt->diffInSeconds($dt->copy()->subMinute()->addSeconds(2)));
+        $this->assertSame(58, $dt->diffInSeconds($dt->copy()->subMinutes(1)->addSeconds(2)));
     }
 
     /**
@@ -726,7 +726,7 @@ class DiffTest extends TestCase
     public function testDiffInSecondsVsDefaultNow($class)
     {
         $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(3600, $class::now()->subHour()->diffInSeconds());
+            $this->assertSame(3600, $class::now()->subHours(1)->diffInSeconds());
         });
     }
 

--- a/tests/TestCase/DateTime/IsTest.php
+++ b/tests/TestCase/DateTime/IsTest.php
@@ -61,7 +61,7 @@ class IsTest extends TestCase
      */
     public function testIsYesterdayTrue($class)
     {
-        $this->assertTrue($class::now()->subDay()->isYesterday());
+        $this->assertTrue($class::now()->subDays(1)->isYesterday());
     }
 
     /**
@@ -97,7 +97,7 @@ class IsTest extends TestCase
      */
     public function testIsTodayFalseWithYesterday($class)
     {
-        $this->assertFalse($class::now()->subDay()->endOfDay()->isToday());
+        $this->assertFalse($class::now()->subDays(1)->endOfDay()->isToday());
     }
 
     /**
@@ -106,7 +106,7 @@ class IsTest extends TestCase
      */
     public function testIsTodayFalseWithTomorrow($class)
     {
-        $this->assertFalse($class::now()->addDay()->startOfDay()->isToday());
+        $this->assertFalse($class::now()->addDays(1)->startOfDay()->isToday());
     }
 
     /**
@@ -124,7 +124,7 @@ class IsTest extends TestCase
      */
     public function testIsTomorrowTrue($class)
     {
-        $this->assertTrue($class::now()->addDay()->isTomorrow());
+        $this->assertTrue($class::now()->addDays(1)->isTomorrow());
     }
 
     /**
@@ -151,7 +151,7 @@ class IsTest extends TestCase
      */
     public function testIsNextWeekTrue($class)
     {
-        $this->assertTrue($class::now()->addWeek()->isNextWeek());
+        $this->assertTrue($class::now()->addWeeks(1)->isNextWeek());
     }
 
     /**
@@ -160,7 +160,7 @@ class IsTest extends TestCase
      */
     public function testIsLastWeekTrue($class)
     {
-        $this->assertTrue($class::now()->subWeek()->isLastWeek());
+        $this->assertTrue($class::now()->subWeeks(1)->isLastWeek());
     }
 
     /**
@@ -169,7 +169,7 @@ class IsTest extends TestCase
      */
     public function testIsNextWeekFalse($class)
     {
-        $this->assertFalse($class::now()->addWeek(2)->isNextWeek());
+        $this->assertFalse($class::now()->addWeeks(2)->isNextWeek());
 
         $class::setTestNow('2017-W01');
         $time = new $class('2018-W02');
@@ -182,7 +182,7 @@ class IsTest extends TestCase
      */
     public function testIsLastWeekFalse($class)
     {
-        $this->assertFalse($class::now()->subWeek(2)->isLastWeek());
+        $this->assertFalse($class::now()->subWeeks(2)->isLastWeek());
 
         $class::setTestNow('2018-W02');
         $time = new $class('2017-W01');
@@ -195,7 +195,7 @@ class IsTest extends TestCase
      */
     public function testIsNextMonthTrue($class)
     {
-        $this->assertTrue($class::now()->addMonth()->isNextMonth());
+        $this->assertTrue($class::now()->addMonths(1)->isNextMonth());
     }
 
     /**
@@ -204,7 +204,7 @@ class IsTest extends TestCase
      */
     public function testIsLastMonthTrue($class)
     {
-        $this->assertTrue($class::now()->subMonth()->isLastMonth());
+        $this->assertTrue($class::now()->subMonths(1)->isLastMonth());
     }
 
     /**
@@ -213,7 +213,7 @@ class IsTest extends TestCase
      */
     public function testIsNextMonthFalse($class)
     {
-        $this->assertFalse($class::now()->addMonth(2)->isNextMonth());
+        $this->assertFalse($class::now()->addMonths(2)->isNextMonth());
 
         $class::setTestNow('2017-12-31');
         $time = new $class('2017-01-01');
@@ -226,7 +226,7 @@ class IsTest extends TestCase
      */
     public function testIsLastMonthFalse($class)
     {
-        $this->assertFalse($class::now()->subMonth(2)->isLastMonth());
+        $this->assertFalse($class::now()->subMonths(2)->isLastMonth());
 
         $class::setTestNow('2017-01-01');
         $time = new $class('2017-12-31');
@@ -239,7 +239,7 @@ class IsTest extends TestCase
      */
     public function testIsNextYearTrue($class)
     {
-        $this->assertTrue($class::now()->addYear()->isNextYear());
+        $this->assertTrue($class::now()->addYears(1)->isNextYear());
     }
 
     /**
@@ -248,7 +248,7 @@ class IsTest extends TestCase
      */
     public function testIsLastYearTrue($class)
     {
-        $this->assertTrue($class::now()->subYear()->isLastYear());
+        $this->assertTrue($class::now()->subYears(1)->isLastYear());
     }
 
     /**
@@ -257,7 +257,7 @@ class IsTest extends TestCase
      */
     public function testIsNextYearFalse($class)
     {
-        $this->assertFalse($class::now()->addYear(2)->isNextYear());
+        $this->assertFalse($class::now()->addYears(2)->isNextYear());
     }
 
     /**
@@ -266,7 +266,7 @@ class IsTest extends TestCase
      */
     public function testIsLastYearFalse($class)
     {
-        $this->assertFalse($class::now()->subYear(2)->isLastYear());
+        $this->assertFalse($class::now()->subYears(2)->isLastYear());
     }
 
     /**
@@ -275,7 +275,7 @@ class IsTest extends TestCase
      */
     public function testIsFutureTrue($class)
     {
-        $this->assertTrue($class::now()->addSecond()->isFuture());
+        $this->assertTrue($class::now()->addSeconds(1)->isFuture());
     }
 
     /**
@@ -293,7 +293,7 @@ class IsTest extends TestCase
      */
     public function testIsFutureFalseInThePast($class)
     {
-        $this->assertFalse($class::now()->subSecond()->isFuture());
+        $this->assertFalse($class::now()->subSeconds(1)->isFuture());
     }
 
     /**
@@ -302,7 +302,7 @@ class IsTest extends TestCase
      */
     public function testIsPastTrue($class)
     {
-        $this->assertTrue($class::now()->subSecond()->isPast());
+        $this->assertTrue($class::now()->subSeconds(1)->isPast());
     }
 
     /**
@@ -311,7 +311,7 @@ class IsTest extends TestCase
      */
     public function testIsPastFalse($class)
     {
-        $this->assertFalse($class::now()->addSecond()->isPast());
+        $this->assertFalse($class::now()->addSeconds(1)->isPast());
     }
 
     /**
@@ -361,19 +361,19 @@ class IsTest extends TestCase
         // True in the past past
         $this->assertTrue($class::createFromDate(2015, 5, 31)->isSunday());
         $this->assertTrue($class::createFromDate(2015, 6, 21)->isSunday());
-        $this->assertTrue($class::now()->subWeek()->previous($class::SUNDAY)->isSunday());
+        $this->assertTrue($class::now()->subWeeks(1)->previous($class::SUNDAY)->isSunday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeek()->previous($class::SUNDAY)->isSunday());
-        $this->assertTrue($class::now()->addMonth()->previous($class::SUNDAY)->isSunday());
+        $this->assertTrue($class::now()->addWeeks(1)->previous($class::SUNDAY)->isSunday());
+        $this->assertTrue($class::now()->addMonths(1)->previous($class::SUNDAY)->isSunday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeek()->previous($class::MONDAY)->isSunday());
-        $this->assertFalse($class::now()->subMonth()->previous($class::MONDAY)->isSunday());
+        $this->assertFalse($class::now()->subWeeks(1)->previous($class::MONDAY)->isSunday());
+        $this->assertFalse($class::now()->subMonths(1)->previous($class::MONDAY)->isSunday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeek()->previous($class::MONDAY)->isSunday());
-        $this->assertFalse($class::now()->addMonth()->previous($class::MONDAY)->isSunday());
+        $this->assertFalse($class::now()->addWeeks(1)->previous($class::MONDAY)->isSunday());
+        $this->assertFalse($class::now()->addMonths(1)->previous($class::MONDAY)->isSunday());
     }
 
     /**
@@ -384,19 +384,19 @@ class IsTest extends TestCase
     {
         // True in the past past
         $this->assertTrue($class::createFromDate(2015, 6, 1)->isMonday());
-        $this->assertTrue($class::now()->subWeek()->previous($class::MONDAY)->isMonday());
+        $this->assertTrue($class::now()->subWeeks(1)->previous($class::MONDAY)->isMonday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeek()->previous($class::MONDAY)->isMonday());
-        $this->assertTrue($class::now()->addMonth()->previous($class::MONDAY)->isMonday());
+        $this->assertTrue($class::now()->addWeeks(1)->previous($class::MONDAY)->isMonday());
+        $this->assertTrue($class::now()->addMonths(1)->previous($class::MONDAY)->isMonday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeek()->previous($class::TUESDAY)->isMonday());
-        $this->assertFalse($class::now()->subMonth()->previous($class::TUESDAY)->isMonday());
+        $this->assertFalse($class::now()->subWeeks(1)->previous($class::TUESDAY)->isMonday());
+        $this->assertFalse($class::now()->subMonths(1)->previous($class::TUESDAY)->isMonday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeek()->previous($class::TUESDAY)->isMonday());
-        $this->assertFalse($class::now()->addMonth()->previous($class::TUESDAY)->isMonday());
+        $this->assertFalse($class::now()->addWeeks(1)->previous($class::TUESDAY)->isMonday());
+        $this->assertFalse($class::now()->addMonths(1)->previous($class::TUESDAY)->isMonday());
     }
 
     /**
@@ -407,19 +407,19 @@ class IsTest extends TestCase
     {
         // True in the past past
         $this->assertTrue($class::createFromDate(2015, 6, 2)->isTuesday());
-        $this->assertTrue($class::now()->subWeek()->previous($class::TUESDAY)->isTuesday());
+        $this->assertTrue($class::now()->subWeeks(1)->previous($class::TUESDAY)->isTuesday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeek()->previous($class::TUESDAY)->isTuesday());
-        $this->assertTrue($class::now()->addMonth()->previous($class::TUESDAY)->isTuesday());
+        $this->assertTrue($class::now()->addWeeks(1)->previous($class::TUESDAY)->isTuesday());
+        $this->assertTrue($class::now()->addMonths(1)->previous($class::TUESDAY)->isTuesday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeek()->previous($class::WEDNESDAY)->isTuesday());
-        $this->assertFalse($class::now()->subMonth()->previous($class::WEDNESDAY)->isTuesday());
+        $this->assertFalse($class::now()->subWeeks(1)->previous($class::WEDNESDAY)->isTuesday());
+        $this->assertFalse($class::now()->subMonths(1)->previous($class::WEDNESDAY)->isTuesday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeek()->previous($class::WEDNESDAY)->isTuesday());
-        $this->assertFalse($class::now()->addMonth()->previous($class::WEDNESDAY)->isTuesday());
+        $this->assertFalse($class::now()->addWeeks(1)->previous($class::WEDNESDAY)->isTuesday());
+        $this->assertFalse($class::now()->addMonths(1)->previous($class::WEDNESDAY)->isTuesday());
     }
 
     /**
@@ -430,19 +430,19 @@ class IsTest extends TestCase
     {
         // True in the past past
         $this->assertTrue($class::createFromDate(2015, 6, 3)->isWednesday());
-        $this->assertTrue($class::now()->subWeek()->previous($class::WEDNESDAY)->isWednesday());
+        $this->assertTrue($class::now()->subWeeks(1)->previous($class::WEDNESDAY)->isWednesday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeek()->previous($class::WEDNESDAY)->isWednesday());
-        $this->assertTrue($class::now()->addMonth()->previous($class::WEDNESDAY)->isWednesday());
+        $this->assertTrue($class::now()->addWeeks(1)->previous($class::WEDNESDAY)->isWednesday());
+        $this->assertTrue($class::now()->addMonths(1)->previous($class::WEDNESDAY)->isWednesday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeek()->previous($class::THURSDAY)->isWednesday());
-        $this->assertFalse($class::now()->subMonth()->previous($class::THURSDAY)->isWednesday());
+        $this->assertFalse($class::now()->subWeeks(1)->previous($class::THURSDAY)->isWednesday());
+        $this->assertFalse($class::now()->subMonths(1)->previous($class::THURSDAY)->isWednesday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeek()->previous($class::THURSDAY)->isWednesday());
-        $this->assertFalse($class::now()->addMonth()->previous($class::THURSDAY)->isWednesday());
+        $this->assertFalse($class::now()->addWeeks(1)->previous($class::THURSDAY)->isWednesday());
+        $this->assertFalse($class::now()->addMonths(1)->previous($class::THURSDAY)->isWednesday());
     }
 
     /**
@@ -453,19 +453,19 @@ class IsTest extends TestCase
     {
         // True in the past past
         $this->assertTrue($class::createFromDate(2015, 6, 4)->isThursday());
-        $this->assertTrue($class::now()->subWeek()->previous($class::THURSDAY)->isThursday());
+        $this->assertTrue($class::now()->subWeeks(1)->previous($class::THURSDAY)->isThursday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeek()->previous($class::THURSDAY)->isThursday());
-        $this->assertTrue($class::now()->addMonth()->previous($class::THURSDAY)->isThursday());
+        $this->assertTrue($class::now()->addWeeks(1)->previous($class::THURSDAY)->isThursday());
+        $this->assertTrue($class::now()->addMonths(1)->previous($class::THURSDAY)->isThursday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeek()->previous($class::FRIDAY)->isThursday());
-        $this->assertFalse($class::now()->subMonth()->previous($class::FRIDAY)->isThursday());
+        $this->assertFalse($class::now()->subWeeks(1)->previous($class::FRIDAY)->isThursday());
+        $this->assertFalse($class::now()->subMonths(1)->previous($class::FRIDAY)->isThursday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeek()->previous($class::FRIDAY)->isThursday());
-        $this->assertFalse($class::now()->addMonth()->previous($class::FRIDAY)->isThursday());
+        $this->assertFalse($class::now()->addWeeks(1)->previous($class::FRIDAY)->isThursday());
+        $this->assertFalse($class::now()->addMonths(1)->previous($class::FRIDAY)->isThursday());
     }
 
     /**
@@ -476,19 +476,19 @@ class IsTest extends TestCase
     {
         // True in the past past
         $this->assertTrue($class::createFromDate(2015, 6, 5)->isFriday());
-        $this->assertTrue($class::now()->subWeek()->previous($class::FRIDAY)->isFriday());
+        $this->assertTrue($class::now()->subWeeks(1)->previous($class::FRIDAY)->isFriday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeek()->previous($class::FRIDAY)->isFriday());
-        $this->assertTrue($class::now()->addMonth()->previous($class::FRIDAY)->isFriday());
+        $this->assertTrue($class::now()->addWeeks(1)->previous($class::FRIDAY)->isFriday());
+        $this->assertTrue($class::now()->addMonths(1)->previous($class::FRIDAY)->isFriday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeek()->previous($class::SATURDAY)->isFriday());
-        $this->assertFalse($class::now()->subMonth()->previous($class::SATURDAY)->isFriday());
+        $this->assertFalse($class::now()->subWeeks(1)->previous($class::SATURDAY)->isFriday());
+        $this->assertFalse($class::now()->subMonths(1)->previous($class::SATURDAY)->isFriday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeek()->previous($class::SATURDAY)->isFriday());
-        $this->assertFalse($class::now()->addMonth()->previous($class::SATURDAY)->isFriday());
+        $this->assertFalse($class::now()->addWeeks(1)->previous($class::SATURDAY)->isFriday());
+        $this->assertFalse($class::now()->addMonths(1)->previous($class::SATURDAY)->isFriday());
     }
 
     /**
@@ -499,19 +499,19 @@ class IsTest extends TestCase
     {
         // True in the past past
         $this->assertTrue($class::createFromDate(2015, 6, 6)->isSaturday());
-        $this->assertTrue($class::now()->subWeek()->previous($class::SATURDAY)->isSaturday());
+        $this->assertTrue($class::now()->subWeeks(1)->previous($class::SATURDAY)->isSaturday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeek()->previous($class::SATURDAY)->isSaturday());
-        $this->assertTrue($class::now()->addMonth()->previous($class::SATURDAY)->isSaturday());
+        $this->assertTrue($class::now()->addWeeks(1)->previous($class::SATURDAY)->isSaturday());
+        $this->assertTrue($class::now()->addMonths(1)->previous($class::SATURDAY)->isSaturday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeek()->previous($class::SUNDAY)->isSaturday());
-        $this->assertFalse($class::now()->subMonth()->previous($class::SUNDAY)->isSaturday());
+        $this->assertFalse($class::now()->subWeeks(1)->previous($class::SUNDAY)->isSaturday());
+        $this->assertFalse($class::now()->subMonths(1)->previous($class::SUNDAY)->isSaturday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeek()->previous($class::SUNDAY)->isSaturday());
-        $this->assertFalse($class::now()->addMonth()->previous($class::SUNDAY)->isSaturday());
+        $this->assertFalse($class::now()->addWeeks(1)->previous($class::SUNDAY)->isSaturday());
+        $this->assertFalse($class::now()->addMonths(1)->previous($class::SUNDAY)->isSaturday());
     }
 
     /**

--- a/tests/TestCase/DateTime/MutabilityTest.php
+++ b/tests/TestCase/DateTime/MutabilityTest.php
@@ -23,7 +23,7 @@ class MutabilityTest extends TestCase
     public function testAdd()
     {
         $dt1 = MutableDateTime::createFromDate(2000, 1, 1);
-        $dt2 = $dt1->addDay();
+        $dt2 = $dt1->addDays(1);
         $this->assertSame($dt1, $dt2);
     }
 

--- a/tests/TestCase/DateTime/SubTest.php
+++ b/tests/TestCase/DateTime/SubTest.php
@@ -52,7 +52,9 @@ class SubTest extends TestCase
      */
     public function testSubYear($class)
     {
-        $this->assertSame(1974, $class::createFromDate(1975)->subYear()->year);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(1974, $class::createFromDate(1975)->subYear()->year);
+        });
     }
 
     /**
@@ -61,9 +63,11 @@ class SubTest extends TestCase
      */
     public function testSubYearNoOverflowPassingArg($class)
     {
-        $dt = $class::createFromDate(2013, 2, 28)->subYear();
-        $this->assertSame(2, $dt->month);
-        $this->assertSame(28, $dt->day);
+        $this->deprecated(function () use ($class) {
+            $dt = $class::createFromDate(2013, 2, 28)->subYear();
+            $this->assertSame(2, $dt->month);
+            $this->assertSame(28, $dt->day);
+        });
     }
 
     /**
@@ -121,7 +125,9 @@ class SubTest extends TestCase
      */
     public function testSubMonth($class)
     {
-        $this->assertSame(12, $class::createFromDate(1975, 1, 1)->subMonth()->month);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(12, $class::createFromDate(1975, 1, 1)->subMonth()->month);
+        });
     }
 
     /**
@@ -157,7 +163,9 @@ class SubTest extends TestCase
      */
     public function testSubDay($class)
     {
-        $this->assertSame(30, $class::createFromDate(1975, 5, 1)->subDay()->day);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(30, $class::createFromDate(1975, 5, 1)->subDay()->day);
+        });
     }
 
     /**
@@ -244,7 +252,9 @@ class SubTest extends TestCase
      */
     public function testSubWeek($class)
     {
-        $this->assertSame(14, $class::createFromDate(1975, 5, 21)->subWeek()->day);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(14, $class::createFromDate(1975, 5, 21)->subWeek()->day);
+        });
     }
 
     /**
@@ -280,7 +290,9 @@ class SubTest extends TestCase
      */
     public function testSubHour($class)
     {
-        $this->assertSame(23, $class::createFromTime(0)->subHour()->hour);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(23, $class::createFromTime(0)->subHour()->hour);
+        });
     }
 
     /**
@@ -316,7 +328,9 @@ class SubTest extends TestCase
      */
     public function testSubMinute($class)
     {
-        $this->assertSame(59, $class::createFromTime(0, 0)->subMinute()->minute);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(59, $class::createFromTime(0, 0)->subMinute()->minute);
+        });
     }
 
     /**
@@ -352,7 +366,9 @@ class SubTest extends TestCase
      */
     public function testSubSecond($class)
     {
-        $this->assertSame(59, $class::createFromTime(0, 0, 0)->subSecond()->second);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(59, $class::createFromTime(0, 0, 0)->subSecond()->second);
+        });
     }
 
     /***** Test non plural methods with non default args *****/
@@ -363,7 +379,9 @@ class SubTest extends TestCase
      */
     public function testSubYearPassingArg($class)
     {
-        $this->assertSame(1973, $class::createFromDate(1975)->subYear(2)->year);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(1973, $class::createFromDate(1975)->subYear(2)->year);
+        });
     }
 
     /**
@@ -372,7 +390,9 @@ class SubTest extends TestCase
      */
     public function testSubMonthPassingArg($class)
     {
-        $this->assertSame(3, $class::createFromDate(1975, 5, 1)->subMonth(2)->month);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(3, $class::createFromDate(1975, 5, 1)->subMonth(2)->month);
+        });
     }
 
     /**
@@ -403,9 +423,11 @@ class SubTest extends TestCase
      */
     public function testSubMonthWithOverflowPassingArg($class)
     {
-        $dt = $class::createFromDate(2011, 3, 30)->subMonthWithOverflow();
-        $this->assertSame(3, $dt->month);
-        $this->assertSame(2, $dt->day);
+        $this->deprecated(function () use ($class) {
+            $dt = $class::createFromDate(2011, 3, 30)->subMonthWithOverflow();
+            $this->assertSame(3, $dt->month);
+            $this->assertSame(2, $dt->day);
+        });
     }
 
     /**
@@ -414,7 +436,9 @@ class SubTest extends TestCase
      */
     public function testSubDayPassingArg($class)
     {
-        $this->assertSame(8, $class::createFromDate(1975, 5, 10)->subDay(2)->day);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(8, $class::createFromDate(1975, 5, 10)->subDay(2)->day);
+        });
     }
 
     /**
@@ -423,7 +447,9 @@ class SubTest extends TestCase
      */
     public function testSubHourPassingArg($class)
     {
-        $this->assertSame(22, $class::createFromTime(0)->subHour(2)->hour);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(22, $class::createFromTime(0)->subHour(2)->hour);
+        });
     }
 
     /**
@@ -432,7 +458,9 @@ class SubTest extends TestCase
      */
     public function testSubMinutePassingArg($class)
     {
-        $this->assertSame(58, $class::createFromTime(0)->subMinute(2)->minute);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(58, $class::createFromTime(0)->subMinute(2)->minute);
+        });
     }
 
     /**
@@ -441,6 +469,8 @@ class SubTest extends TestCase
      */
     public function testSubSecondPassingArg($class)
     {
-        $this->assertSame(58, $class::createFromTime(0)->subSecond(2)->second);
+        $this->deprecated(function () use ($class) {
+            $this->assertSame(58, $class::createFromTime(0)->subSecond(2)->second);
+        });
     }
 }


### PR DESCRIPTION
The tests are currently failing, but I was conflicted on how to proceed.

* Should we add a method like `deprecated(Closure)` to chronos' test library?
* Should we copy the `deprecationWarning` helper from Cake to chronos as well?