### PR TITLE
Remove classNameProvider() and dateClassProvider()

### DIFF
--- a/tests/TestCase/Date/AddTest.php
+++ b/tests/TestCase/Date/AddTest.php
@@ -14,18 +14,16 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Test\TestCase\Date;
 
+use Cake\Chronos\Date;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateInterval;
 
 class AddTest extends TestCase
 {
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testAddFullDay($class)
+    public function testAddFullDay()
     {
         $interval = DateInterval::createFromDateString('1 day');
-        $date = $class::create(2001, 1, 1);
+        $date = Date::create(2001, 1, 1);
         $new = $date->add($interval);
 
         $this->assertSame(0, $new->hour);
@@ -36,13 +34,10 @@ class AddTest extends TestCase
         $this->assertSame(0, $date->second);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testAddIgnoreTime($class)
+    public function testAddIgnoreTime()
     {
         $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
-        $date = $class::create(2001, 1, 1);
+        $date = Date::create(2001, 1, 1);
         $new = $date->add($interval);
 
         $this->assertSame(0, $new->hour);
@@ -53,13 +48,10 @@ class AddTest extends TestCase
         $this->assertSame(0, $date->second);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testSubFullDay($class)
+    public function testSubFullDay()
     {
         $interval = DateInterval::createFromDateString('1 day');
-        $date = $class::create(2001, 1, 1);
+        $date = Date::create(2001, 1, 1);
         $new = $date->sub($interval);
 
         $this->assertSame(0, $new->hour);
@@ -70,13 +62,10 @@ class AddTest extends TestCase
         $this->assertSame(0, $date->second);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testSubIgnoreTime($class)
+    public function testSubIgnoreTime()
     {
         $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
-        $date = $class::create(2001, 1, 1);
+        $date = Date::create(2001, 1, 1);
         $new = $date->sub($interval);
 
         $this->assertSame(0, $new->hour);
@@ -87,39 +76,27 @@ class AddTest extends TestCase
         $this->assertSame(0, $date->second);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testAddDay($class)
+    public function testAddDay()
     {
-        $this->assertSame(1, $class::create(1975, 5, 31)->addDays(1)->day);
-        $this->assertSame(30, $class::create(1975, 5, 31)->addDays(-1)->day);
+        $this->assertSame(1, Date::create(1975, 5, 31)->addDays(1)->day);
+        $this->assertSame(30, Date::create(1975, 5, 31)->addDays(-1)->day);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testAddMonth($class)
+    public function testAddMonth()
     {
-        $this->assertSame(6, $class::create(1975, 5, 31)->addMonths(1)->month);
-        $this->assertSame(4, $class::create(1975, 5, 31)->addMonths(-1)->month);
+        $this->assertSame(6, Date::create(1975, 5, 31)->addMonths(1)->month);
+        $this->assertSame(4, Date::create(1975, 5, 31)->addMonths(-1)->month);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testAddYears($class)
+    public function testAddYears()
     {
-        $this->assertSame(1976, $class::create(1975, 5, 31)->addYears(1)->year);
-        $this->assertSame(1974, $class::create(1975, 5, 31)->addYears(-1)->year);
+        $this->assertSame(1976, Date::create(1975, 5, 31)->addYears(1)->year);
+        $this->assertSame(1974, Date::create(1975, 5, 31)->addYears(-1)->year);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testAddWeekdays($class)
+    public function testAddWeekdays()
     {
-        $this->assertSame(2, $class::create(1975, 5, 31)->addWeekdays(1)->day);
-        $this->assertSame(30, $class::create(1975, 5, 31)->addWeekdays(-1)->day);
+        $this->assertSame(2, Date::create(1975, 5, 31)->addWeekdays(1)->day);
+        $this->assertSame(30, Date::create(1975, 5, 31)->addWeekdays(-1)->day);
     }
 }

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -25,175 +25,119 @@ use DateTimeZone;
  */
 class ConstructTest extends TestCase
 {
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testCreateFromEmpty($class)
+    public function testCreateFromEmpty()
     {
-        $c = $class::parse(null);
+        $c = Date::parse(null);
         $this->assertSame('00:00:00', $c->format('H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
-        $c = $class::parse('');
+        $c = Date::parse('');
         $this->assertSame('00:00:00', $c->format('H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testCreateFromEmptyWithTestNow($class)
+    public function testCreateFromEmptyWithTestNow()
     {
-        $class::setTestNow($class::create(2001, 1, 1));
+        Date::setTestNow(Date::create(2001, 1, 1));
 
-        $c = $class::parse(null);
+        $c = Date::parse(null);
         $this->assertSame('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
-        $c = $class::parse('');
+        $c = Date::parse('');
         $this->assertSame('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testCreateFromTimestamp($class)
+    public function testCreateFromTimestamp()
     {
-        $this->withTimezone('Europe/Berlin', function () use ($class) {
+        $this->withTimezone('Europe/Berlin', function () {
             $ts = 1454284800;
 
-            $date = $class::createFromTimestamp($ts);
+            $date = Date::createFromTimestamp($ts);
             $this->assertSame('Europe/Berlin', $date->tzName);
             $this->assertSame('2016-02-01', $date->format('Y-m-d'));
 
-            $date = new $class($ts);
+            $date = new Date($ts);
             $this->assertSame('Europe/Berlin', $date->tzName);
             $this->assertSame('2016-02-01', $date->format('Y-m-d'));
         });
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testCreatesAnInstanceDefaultToNow($class)
+    public function testCreatesAnInstanceDefaultToNow()
     {
-        $c = new $class();
-        $now = $class::now();
-        $this->assertInstanceOf($class, $c);
+        $c = new Date();
+        $now = Date::now();
+        $this->assertInstanceOf(Date::class, $c);
         $this->assertSame($now->tzName, $c->tzName);
         $this->assertDateTime($c, $now->year, $now->month, $now->day, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testParseCreatesAnInstanceDefaultToNow($class)
+    public function testParseCreatesAnInstanceDefaultToNow()
     {
-        $c = $class::parse();
-        $now = $class::now();
-        $this->assertInstanceOf($class, $c);
+        $c = Date::parse();
+        $now = Date::now();
+        $this->assertInstanceOf(Date::class, $c);
         $this->assertSame($now->tzName, $c->tzName);
         $this->assertDateTime($c, $now->year, $now->month, $now->day, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testWithFancyString($class)
+    public function testWithFancyString()
     {
-        $c = new $class('first day of January 2008');
+        $c = new Date('first day of January 2008');
         $this->assertDateTime($c, 2008, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testParseWithFancyString($class)
+    public function testParseWithFancyString()
     {
-        $c = $class::parse('first day of January 2008');
+        $c = Date::parse('first day of January 2008');
         $this->assertDateTime($c, 2008, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testParseWithMicroSeconds($class)
+    public function testParseWithMicroSeconds()
     {
-        $date = $class::parse('2016-12-08 18:06:46.510954');
+        $date = Date::parse('2016-12-08 18:06:46.510954');
         $this->assertSame(0, $date->hour);
         $this->assertSame(0, $date->second);
         $this->assertSame(0, $date->minute);
         $this->assertSame(0, $date->micro);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testUsesDefaultTimezone($class)
+    public function testUsesDefaultTimezone()
     {
-        $c = new $class('now');
+        $c = new Date('now');
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testParseUsesDefaultTimezone($class)
+    public function testParseUsesDefaultTimezone()
     {
-        $c = $class::parse('now');
+        $c = Date::parse('now');
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testSettingTimezoneIgnored($class)
+    public function testSettingTimezoneIgnored()
     {
         $timezone = 'Europe/London';
         $dtz = new DateTimeZone($timezone);
-        $c = new $class('now', $dtz);
+        $c = new Date('now', $dtz);
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testParseSettingTimezoneIgnored($class)
+    public function testParseSettingTimezoneIgnored()
     {
-        $c = $class::parse('now', new DateTimeZone('Europe/London'));
+        $c = Date::parse('now', new DateTimeZone('Europe/London'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testSettingTimezoneWithStringIgnored($class)
+    public function testSettingTimezoneWithStringIgnored()
     {
-        $c = new $class('now', 'Asia/Tokyo');
+        $c = new Date('now', 'Asia/Tokyo');
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testParseSettingTimezoneWithStringIgnored($class)
+    public function testParseSettingTimezoneWithStringIgnored()
     {
-        $c = $class::parse('now', 'Asia/Tokyo');
+        $c = Date::parse('now', 'Asia/Tokyo');
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
@@ -234,115 +178,100 @@ class ConstructTest extends TestCase
         $this->assertSame(0, $dt->second);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testConstructWithTestNow($class)
+    public function testConstructWithTestNow()
     {
-        $class::setTestNow($class::create(2001, 1, 1));
-        $date = new $class('+2 days');
+        Date::setTestNow(Date::create(2001, 1, 1));
+        $date = new Date('+2 days');
         $this->assertDateTime($date, 2001, 1, 3);
 
-        $date = new $class('2015-12-12');
+        $date = new Date('2015-12-12');
         $this->assertDateTime($date, 2015, 12, 12);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testConstructWithTestNowNoMutation($class)
+    public function testConstructWithTestNowNoMutation()
     {
-        $class::setTestNow($class::create(2001, 1, 1));
-        $date = new $class('+2 days');
+        Date::setTestNow(Date::create(2001, 1, 1));
+        $date = new Date('+2 days');
         $this->assertDateTime($date, 2001, 1, 3, 0, 0, 0);
 
-        $date = new $class();
+        $date = new Date();
         $this->assertNotEquals('2001-01-03', $date->format('Y-m-d'));
-        $class::setTestNow(null);
+        Date::setTestNow(null);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testConstructWithRelative($class)
+    public function testConstructWithRelative()
     {
-        $c = new $class('+7 days');
+        $c = new Date('+7 days');
         $this->assertSame('00:00:00', $c->format('H:i:s'));
 
-        $c = new $class('+10 minutes');
+        $c = new Date('+10 minutes');
         $this->assertSame('00:00:00', $c->format('H:i:s'));
 
-        $c = new $class('2001-01-01 +7 days');
+        $c = new Date('2001-01-01 +7 days');
         $this->assertSame('2001-01-08', $c->format('Y-m-d'));
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testConstructWithLocalTimezone($class)
+    public function testConstructWithLocalTimezone()
     {
         $londonTimezone = new DateTimeZone('Europe/London');
 
         // now adjusted to London time
         // This test could have different results depending on when now is
-        $c = new $class('now', $londonTimezone);
+        $c = new Date('now', $londonTimezone);
         $london = new DateTimeImmutable('now', $londonTimezone);
         $this->assertSame($london->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // now adjusted to London time
-        $c = $class::today($londonTimezone);
+        $c = Date::today($londonTimezone);
         $this->assertSame(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
 
         // London timezone is used instead of local timezone
-        $c = new $class('2001-01-02 01:00:00', $londonTimezone);
+        $c = new Date('2001-01-02 01:00:00', $londonTimezone);
         $this->assertSame('2001-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // London timezone is ignored when timezone is provided in time string
-        $c = new $class('2001-01-01 23:00:00-400', $londonTimezone);
+        $c = new Date('2001-01-01 23:00:00-400', $londonTimezone);
         $this->assertSame('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // London timezone is ignored when DateTimeInterface instance is provided
-        $c = new $class(new DateTimeImmutable('2001-01-01 23:00:00-400'), $londonTimezone);
+        $c = new Date(new DateTimeImmutable('2001-01-01 23:00:00-400'), $londonTimezone);
         $this->assertSame('2001-01-01 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testConstructWithLocalTimezoneTestNow($class)
+    public function testConstructWithLocalTimezoneTestNow()
     {
-        $class::setTestNow(new Chronos('2010-01-01 23:00:00'));
+        Date::setTestNow(new Chronos('2010-01-01 23:00:00'));
 
         $londonTimezone = new DateTimeZone('Europe/London');
 
         // TestNow is adjusted to London time
-        $c = new $class('now', $londonTimezone);
+        $c = new Date('now', $londonTimezone);
         $this->assertSame('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
-        $c = new $class('+2 days', $londonTimezone);
+        $c = new Date('+2 days', $londonTimezone);
         $this->assertSame('2010-01-04 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
-        $c = $class::today($londonTimezone);
+        $c = Date::today($londonTimezone);
         $this->assertSame('2010-01-02 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(Chronos::today($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is adjusted to London time
-        $c = $class::tomorrow($londonTimezone);
+        $c = Date::tomorrow($londonTimezone);
         $this->assertSame('2010-01-03 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(Chronos::tomorrow($londonTimezone)->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
 
         // TestNow is ignored when specific date is provided
-        $c = new $class('2001-01-05 01:00:00', $londonTimezone);
+        $c = new Date('2001-01-05 01:00:00', $londonTimezone);
         $this->assertSame('2001-01-05 00:00:00', $c->format('Y-m-d H:i:s'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
     }
@@ -351,10 +280,8 @@ class ConstructTest extends TestCase
      * This tests with a large difference between local timezone and
      * timezone provided as parameter.  This is to help guarantee a date
      * change would occur so the tests are more consistent.
-     *
-     * @dataProvider dateClassProvider
      */
-    public function testConstructWithLargeTimezoneChange($class)
+    public function testConstructWithLargeTimezoneChange()
     {
         $savedTz = date_default_timezone_get();
         date_default_timezone_set('Pacific/Kiritimati');
@@ -362,7 +289,7 @@ class ConstructTest extends TestCase
         $samoaTimezone = new DateTimeZone('Pacific/Samoa');
 
         // Pacific/Samoa -11:00 is used intead of local timezone +14:00
-        $c = $class::today($samoaTimezone);
+        $c = Date::today($samoaTimezone);
         $Samoa = new DateTimeImmutable('now', $samoaTimezone);
         $this->assertSame($Samoa->format('Y-m-d'), $c->format('Y-m-d'));
         $this->assertSame(date_default_timezone_get(), $c->tzName);
@@ -370,44 +297,33 @@ class ConstructTest extends TestCase
         date_default_timezone_set($savedTz);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     */
-    public function testCreateFromExistingInstance($class)
+    public function testCreateFromExistingInstance()
     {
-        $existingClass = new $class();
-        $this->assertInstanceOf($class, $existingClass);
+        $existingClass = new Date();
+        $this->assertInstanceOf(Date::class, $existingClass);
 
-        $newClass = new $class($existingClass);
-        $this->assertInstanceOf($class, $newClass);
+        $newClass = new Date($existingClass);
+        $this->assertInstanceOf(Date::class, $newClass);
 
         $this->assertSame((string)$existingClass, (string)$newClass);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testCreateFromDateTimeInterface($class)
+    public function testCreateFromDateTimeInterface()
     {
         $existingClass = new DateTimeImmutable();
-        $newClass = new $class($existingClass);
-        $this->assertInstanceOf($class, $newClass);
+        $newClass = new Date($existingClass);
+        $this->assertInstanceOf(Date::class, $newClass);
         $this->assertSame($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
 
         $existingClass = new DateTime();
-        $newClass = new $class($existingClass);
-        $this->assertInstanceOf($class, $newClass);
+        $newClass = new Date($existingClass);
+        $this->assertInstanceOf(Date::class, $newClass);
         $this->assertSame($existingClass->format('Y-m-d 00:00:00'), $newClass->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testCreateFromFormat($class)
+    public function testCreateFromFormat()
     {
-        $date = $class::createFromFormat('Y-m-d P', '2014-02-01 Asia/Tokyo');
+        $date = Date::createFromFormat('Y-m-d P', '2014-02-01 Asia/Tokyo');
         $this->assertSame('2014-02-01 00:00:00 America/Toronto', $date->format('Y-m-d H:i:s e'));
     }
 }

--- a/tests/TestCase/Date/IsTest.php
+++ b/tests/TestCase/Date/IsTest.php
@@ -14,38 +14,27 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\Date;
 
+use Cake\Chronos\Date;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class IsTest extends TestCase
 {
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testIsTodayTrue($class)
+    public function testIsTodayTrue()
     {
-        $this->assertTrue($class::now()->isToday());
+        $this->assertTrue(Date::now()->isToday());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testIsTodayOtherTimezone($class)
+    public function testIsTodayOtherTimezone()
     {
-        $this->withTimezone('Asia/Tokyo', function () use ($class) {
-            $today = $class::today();
+        $this->withTimezone('Asia/Tokyo', function () {
+            $today = Date::today();
             $this->assertSame('Asia/Tokyo', $today->tzName);
             $this->assertTrue($today->isToday());
         });
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testIsTodayFalseWithYesterday($class)
+    public function testIsTodayFalseWithYesterday()
     {
-        $this->assertFalse($class::now()->subDays(1)->endOfDay()->isToday());
+        $this->assertFalse(Date::now()->subDays(1)->endOfDay()->isToday());
     }
 }

--- a/tests/TestCase/Date/StringsTest.php
+++ b/tests/TestCase/Date/StringsTest.php
@@ -44,106 +44,66 @@ class StringsTest extends TestCase
         unset($this->tz);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToString($class)
+    public function testToString()
     {
-        $d = $class::now();
+        $d = Date::now();
         $this->assertSame(Date::now()->toDateString(), '' . $d);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testSetToStringFormat($class)
+    public function testSetToStringFormat()
     {
-        $class::setToStringFormat('jS \o\f F, Y g:i:s a');
-        $d = $class::create(1975, 12, 25);
+        Date::setToStringFormat('jS \o\f F, Y g:i:s a');
+        $d = Date::create(1975, 12, 25);
         $this->assertSame('25th of December, 1975 12:00:00 am', '' . $d);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testResetToStringFormat($class)
+    public function testResetToStringFormat()
     {
-        $d = $class::now();
-        $class::setToStringFormat('123');
-        $class::resetToStringFormat();
+        $d = Date::now();
+        Date::setToStringFormat('123');
+        Date::resetToStringFormat();
         $this->assertSame($d->toDateTimeString(), '' . $d);
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToDateString($class)
+    public function testToDateString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25', $d->toDateString());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToFormattedDateString($class)
+    public function testToFormattedDateString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Dec 25, 1975', $d->toFormattedDateString());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToTimeString($class)
+    public function testToTimeString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('00:00:00', $d->toTimeString());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToDateTimeString($class)
+    public function testToDateTimeString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25 00:00:00', $d->toDateTimeString());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToDayDateTimeString($class)
+    public function testToDayDateTimeString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, Dec 25, 1975 12:00 AM', $d->toDayDateTimeString());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToAtomString($class)
+    public function testToAtomString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T00:00:00+00:00', $d->toAtomString());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToCOOKIEString($class)
+    public function testToCOOKIEString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         if (DateTime::COOKIE === 'l, d-M-y H:i:s T') {
             $cookieString = 'Thursday, 25-Dec-75 00:00:00 UTC';
         } else {
@@ -153,93 +113,57 @@ class StringsTest extends TestCase
         $this->assertSame($cookieString, $d->toCOOKIEString());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToIso8601String($class)
+    public function testToIso8601String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T00:00:00+00:00', $d->toIso8601String());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToRC822String($class)
+    public function testToRC822String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 75 00:00:00 +0000', $d->toRfc822String());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToRfc850String($class)
+    public function testToRfc850String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thursday, 25-Dec-75 00:00:00 UTC', $d->toRfc850String());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToRfc1036String($class)
+    public function testToRfc1036String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 75 00:00:00 +0000', $d->toRfc1036String());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToRfc1123String($class)
+    public function testToRfc1123String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 1975 00:00:00 +0000', $d->toRfc1123String());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToRfc2822String($class)
+    public function testToRfc2822String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 1975 00:00:00 +0000', $d->toRfc2822String());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToRfc3339String($class)
+    public function testToRfc3339String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T00:00:00+00:00', $d->toRfc3339String());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToRssString($class)
+    public function testToRssString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 1975 00:00:00 +0000', $d->toRssString());
     }
 
-    /**
-     * @dataProvider dateClassProvider
-     * @return void
-     */
-    public function testToW3cString($class)
+    public function testToW3cString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Date::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T00:00:00+00:00', $d->toW3cString());
     }
 }

--- a/tests/TestCase/DateTime/AddTest.php
+++ b/tests/TestCase/DateTime/AddTest.php
@@ -15,176 +15,105 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class AddTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYearsPositive($class)
+    public function testAddYearsPositive()
     {
-        $this->assertSame(1976, $class::createFromDate(1975)->addYears(1)->year);
+        $this->assertSame(1976, Chronos::createFromDate(1975)->addYears(1)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYearsZero($class)
+    public function testAddYearsZero()
     {
-        $this->assertSame(1975, $class::createFromDate(1975)->addYears(0)->year);
+        $this->assertSame(1975, Chronos::createFromDate(1975)->addYears(0)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYearsNegative($class)
+    public function testAddYearsNegative()
     {
-        $this->assertSame(1974, $class::createFromDate(1975)->addYears(-1)->year);
+        $this->assertSame(1974, Chronos::createFromDate(1975)->addYears(-1)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYears($class)
+    public function testAddYears()
     {
-        $this->assertSame(1976, $class::createFromDate(1975)->addYears(1)->year);
+        $this->assertSame(1976, Chronos::createFromDate(1975)->addYears(1)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthsPositive($class)
+    public function testAddMonthsPositive()
     {
-        $this->assertSame(1, $class::createFromDate(1975, 12)->addMonths(1)->month);
+        $this->assertSame(1, Chronos::createFromDate(1975, 12)->addMonths(1)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthsZero($class)
+    public function testAddMonthsZero()
     {
-        $this->assertSame(12, $class::createFromDate(1975, 12)->addMonths(0)->month);
+        $this->assertSame(12, Chronos::createFromDate(1975, 12)->addMonths(0)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthsNegative($class)
+    public function testAddMonthsNegative()
     {
-        $this->assertSame(11, $class::createFromDate(1975, 12, 1)->addMonths(-1)->month);
+        $this->assertSame(11, Chronos::createFromDate(1975, 12, 1)->addMonths(-1)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonth($class)
+    public function testAddMonth()
     {
-        $this->assertSame(1, $class::createFromDate(1975, 12)->addMonths(1)->month);
+        $this->assertSame(1, Chronos::createFromDate(1975, 12)->addMonths(1)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthWithOverflow($class)
+    public function testAddMonthWithOverflow()
     {
-        $this->assertSame(3, $class::createFromDate(2012, 1, 31)->addMonthsWithOverflow(1)->month);
+        $this->assertSame(3, Chronos::createFromDate(2012, 1, 31)->addMonthsWithOverflow(1)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthsNoOverflowPositive($class)
+    public function testAddMonthsNoOverflowPositive()
     {
-        $this->assertSame('2012-02-29', $class::createFromDate(2012, 1, 31)->addMonths(1)->toDateString());
-        $this->assertSame('2012-03-31', $class::createFromDate(2012, 1, 31)->addMonths(2)->toDateString());
-        $this->assertSame('2012-03-29', $class::createFromDate(2012, 2, 29)->addMonths(1)->toDateString());
-        $this->assertSame('2012-02-29', $class::createFromDate(2011, 12, 31)->addMonths(2)->toDateString());
+        $this->assertSame('2012-02-29', Chronos::createFromDate(2012, 1, 31)->addMonths(1)->toDateString());
+        $this->assertSame('2012-03-31', Chronos::createFromDate(2012, 1, 31)->addMonths(2)->toDateString());
+        $this->assertSame('2012-03-29', Chronos::createFromDate(2012, 2, 29)->addMonths(1)->toDateString());
+        $this->assertSame('2012-02-29', Chronos::createFromDate(2011, 12, 31)->addMonths(2)->toDateString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthsNoOverflowZero($class)
+    public function testAddMonthsNoOverflowZero()
     {
-        $this->assertSame(12, $class::createFromDate(1975, 12)->addMonths(0)->month);
+        $this->assertSame(12, Chronos::createFromDate(1975, 12)->addMonths(0)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthsNoOverflowNegative($class)
+    public function testAddMonthsNoOverflowNegative()
     {
-        $this->assertSame('2012-01-29', $class::createFromDate(2012, 2, 29)->addMonths(-1)->toDateString());
-        $this->assertSame('2012-01-31', $class::createFromDate(2012, 3, 31)->addMonths(-2)->toDateString());
-        $this->assertSame('2012-02-29', $class::createFromDate(2012, 3, 31)->addMonths(-1)->toDateString());
-        $this->assertSame('2011-12-31', $class::createFromDate(2012, 1, 31)->addMonths(-1)->toDateString());
+        $this->assertSame('2012-01-29', Chronos::createFromDate(2012, 2, 29)->addMonths(-1)->toDateString());
+        $this->assertSame('2012-01-31', Chronos::createFromDate(2012, 3, 31)->addMonths(-2)->toDateString());
+        $this->assertSame('2012-02-29', Chronos::createFromDate(2012, 3, 31)->addMonths(-1)->toDateString());
+        $this->assertSame('2011-12-31', Chronos::createFromDate(2012, 1, 31)->addMonths(-1)->toDateString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddDaysPositive($class)
+    public function testAddDaysPositive()
     {
-        $this->assertSame(1, $class::createFromDate(1975, 5, 31)->addDays(1)->day);
+        $this->assertSame(1, Chronos::createFromDate(1975, 5, 31)->addDays(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddDaysZero($class)
+    public function testAddDaysZero()
     {
-        $this->assertSame(31, $class::createFromDate(1975, 5, 31)->addDays(0)->day);
+        $this->assertSame(31, Chronos::createFromDate(1975, 5, 31)->addDays(0)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddDaysNegative($class)
+    public function testAddDaysNegative()
     {
-        $this->assertSame(30, $class::createFromDate(1975, 5, 31)->addDays(-1)->day);
+        $this->assertSame(30, Chronos::createFromDate(1975, 5, 31)->addDays(-1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddDay($class)
+    public function testAddDay()
     {
-        $this->assertSame(1, $class::createFromDate(1975, 5, 31)->addDays(1)->day);
+        $this->assertSame(1, Chronos::createFromDate(1975, 5, 31)->addDays(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeekdayDuringWeekend($class)
+    public function testAddWeekdayDuringWeekend()
     {
-        $this->assertSame(9, $class::createFromDate(2012, 1, 7)->addWeekdays(1)->day);
+        $this->assertSame(9, Chronos::createFromDate(2012, 1, 7)->addWeekdays(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeekdaysPositive($class)
+    public function testAddWeekdaysPositive()
     {
-        $dt = $class::create(2012, 1, 4, 13, 2, 1)->addWeekdays(9);
+        $dt = Chronos::create(2012, 1, 4, 13, 2, 1)->addWeekdays(9);
         $this->assertSame(17, $dt->day);
 
         // Test for https://bugs.php.net/bug.php?id=54909
@@ -193,284 +122,164 @@ class AddTest extends TestCase
         $this->assertSame(1, $dt->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeekdaysZero($class)
+    public function testAddWeekdaysZero()
     {
-        $this->assertSame(4, $class::createFromDate(2012, 1, 4)->addWeekdays(0)->day);
+        $this->assertSame(4, Chronos::createFromDate(2012, 1, 4)->addWeekdays(0)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeekdaysNegative($class)
+    public function testAddWeekdaysNegative()
     {
-        $this->assertSame(18, $class::createFromDate(2012, 1, 31)->addWeekdays(-9)->day);
+        $this->assertSame(18, Chronos::createFromDate(2012, 1, 31)->addWeekdays(-9)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeekday($class)
+    public function testAddWeekday()
     {
-        $this->assertSame(9, $class::createFromDate(2012, 1, 6)->addWeekdays(1)->day);
+        $this->assertSame(9, Chronos::createFromDate(2012, 1, 6)->addWeekdays(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeeksPositive($class)
+    public function testAddWeeksPositive()
     {
-        $this->assertSame(28, $class::createFromDate(1975, 5, 21)->addWeeks(1)->day);
+        $this->assertSame(28, Chronos::createFromDate(1975, 5, 21)->addWeeks(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeeksZero($class)
+    public function testAddWeeksZero()
     {
-        $this->assertSame(21, $class::createFromDate(1975, 5, 21)->addWeeks(0)->day);
+        $this->assertSame(21, Chronos::createFromDate(1975, 5, 21)->addWeeks(0)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeeksNegative($class)
+    public function testAddWeeksNegative()
     {
-        $this->assertSame(14, $class::createFromDate(1975, 5, 21)->addWeeks(-1)->day);
+        $this->assertSame(14, Chronos::createFromDate(1975, 5, 21)->addWeeks(-1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddWeek($class)
+    public function testAddWeek()
     {
-        $this->assertSame(28, $class::createFromDate(1975, 5, 21)->addWeeks(1)->day);
+        $this->assertSame(28, Chronos::createFromDate(1975, 5, 21)->addWeeks(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddHoursPositive($class)
+    public function testAddHoursPositive()
     {
-        $this->assertSame(1, $class::createFromTime(0)->addHours(1)->hour);
+        $this->assertSame(1, Chronos::createFromTime(0)->addHours(1)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddHoursZero($class)
+    public function testAddHoursZero()
     {
-        $this->assertSame(0, $class::createFromTime(0)->addHours(0)->hour);
+        $this->assertSame(0, Chronos::createFromTime(0)->addHours(0)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddHoursNegative($class)
+    public function testAddHoursNegative()
     {
-        $this->assertSame(23, $class::createFromTime(0)->addHours(-1)->hour);
+        $this->assertSame(23, Chronos::createFromTime(0)->addHours(-1)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddHour($class)
+    public function testAddHour()
     {
-        $this->assertSame(1, $class::createFromTime(0)->addHours(1)->hour);
+        $this->assertSame(1, Chronos::createFromTime(0)->addHours(1)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMinutesPositive($class)
+    public function testAddMinutesPositive()
     {
-        $this->assertSame(1, $class::createFromTime(0, 0)->addMinutes(1)->minute);
+        $this->assertSame(1, Chronos::createFromTime(0, 0)->addMinutes(1)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMinutesZero($class)
+    public function testAddMinutesZero()
     {
-        $this->assertSame(0, $class::createFromTime(0, 0)->addMinutes(0)->minute);
+        $this->assertSame(0, Chronos::createFromTime(0, 0)->addMinutes(0)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMinutesNegative($class)
+    public function testAddMinutesNegative()
     {
-        $this->assertSame(59, $class::createFromTime(0, 0)->addMinutes(-1)->minute);
+        $this->assertSame(59, Chronos::createFromTime(0, 0)->addMinutes(-1)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMinute($class)
+    public function testAddMinute()
     {
-        $this->assertSame(1, $class::createFromTime(0, 0)->addMinutes(1)->minute);
+        $this->assertSame(1, Chronos::createFromTime(0, 0)->addMinutes(1)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddSecondsPositive($class)
+    public function testAddSecondsPositive()
     {
-        $this->assertSame(1, $class::createFromTime(0, 0, 0)->addSeconds(1)->second);
+        $this->assertSame(1, Chronos::createFromTime(0, 0, 0)->addSeconds(1)->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddSecondsZero($class)
+    public function testAddSecondsZero()
     {
-        $this->assertSame(0, $class::createFromTime(0, 0, 0)->addSeconds(0)->second);
+        $this->assertSame(0, Chronos::createFromTime(0, 0, 0)->addSeconds(0)->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddSecondsNegative($class)
+    public function testAddSecondsNegative()
     {
-        $this->assertSame(59, $class::createFromTime(0, 0, 0)->addSeconds(-1)->second);
+        $this->assertSame(59, Chronos::createFromTime(0, 0, 0)->addSeconds(-1)->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddSecond($class)
+    public function testAddSecond()
     {
-        $this->assertSame(1, $class::createFromTime(0, 0, 0)->addSeconds(1)->second);
+        $this->assertSame(1, Chronos::createFromTime(0, 0, 0)->addSeconds(1)->second);
     }
 
     /***** Test non plural methods with non default args *****/
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYearPassingArg($class)
+    public function testAddYearPassingArg()
     {
-        $this->assertSame(1977, $class::createFromDate(1975)->addYears(2)->year);
+        $this->assertSame(1977, Chronos::createFromDate(1975)->addYears(2)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYearWithOverflow($class)
+    public function testAddYearWithOverflow()
     {
-        $this->assertSame('2013-03-01', $class::createFromDate(2012, 2, 29)->addYearsWithOverflow(1)->toDateString());
+        $this->assertSame('2013-03-01', Chronos::createFromDate(2012, 2, 29)->addYearsWithOverflow(1)->toDateString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYearsNoOverflowPositive($class)
+    public function testAddYearsNoOverflowPositive()
     {
-        $this->assertSame('2013-01-31', $class::createFromDate(2012, 1, 31)->addYears(1)->toDateString());
-        $this->assertSame('2014-01-31', $class::createFromDate(2012, 1, 31)->addYears(2)->toDateString());
-        $this->assertSame('2013-02-28', $class::createFromDate(2012, 2, 29)->addYears(1)->toDateString());
-        $this->assertSame('2013-12-31', $class::createFromDate(2011, 12, 31)->addYears(2)->toDateString());
+        $this->assertSame('2013-01-31', Chronos::createFromDate(2012, 1, 31)->addYears(1)->toDateString());
+        $this->assertSame('2014-01-31', Chronos::createFromDate(2012, 1, 31)->addYears(2)->toDateString());
+        $this->assertSame('2013-02-28', Chronos::createFromDate(2012, 2, 29)->addYears(1)->toDateString());
+        $this->assertSame('2013-12-31', Chronos::createFromDate(2011, 12, 31)->addYears(2)->toDateString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYearsNoOverflowZero($class)
+    public function testAddYearsNoOverflowZero()
     {
-        $this->assertSame('1975-12-31', $class::createFromDate(1975, 12, 31)->addYears(0)->toDateString());
+        $this->assertSame('1975-12-31', Chronos::createFromDate(1975, 12, 31)->addYears(0)->toDateString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddYearsNoOverflowNegative($class)
+    public function testAddYearsNoOverflowNegative()
     {
-        $this->assertSame('2011-02-28', $class::createFromDate(2012, 2, 29)->addYears(-1)->toDateString());
-        $this->assertSame('2010-03-31', $class::createFromDate(2012, 3, 31)->addYears(-2)->toDateString());
-        $this->assertSame('2011-03-31', $class::createFromDate(2012, 3, 31)->addYears(-1)->toDateString());
-        $this->assertSame('2011-01-31', $class::createFromDate(2012, 1, 31)->addYears(-1)->toDateString());
+        $this->assertSame('2011-02-28', Chronos::createFromDate(2012, 2, 29)->addYears(-1)->toDateString());
+        $this->assertSame('2010-03-31', Chronos::createFromDate(2012, 3, 31)->addYears(-2)->toDateString());
+        $this->assertSame('2011-03-31', Chronos::createFromDate(2012, 3, 31)->addYears(-1)->toDateString());
+        $this->assertSame('2011-01-31', Chronos::createFromDate(2012, 1, 31)->addYears(-1)->toDateString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthPassingArg($class)
+    public function testAddMonthPassingArg()
     {
-        $this->assertSame(7, $class::createFromDate(1975, 5, 1)->addMonths(2)->month);
+        $this->assertSame(7, Chronos::createFromDate(1975, 5, 1)->addMonths(2)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMonthNoOverflowPassingArg($class)
+    public function testAddMonthNoOverflowPassingArg()
     {
-        $dt = $class::createFromDate(2010, 12, 31)->addMonths(2);
+        $dt = Chronos::createFromDate(2010, 12, 31)->addMonths(2);
         $this->assertSame(2011, $dt->year);
         $this->assertSame(2, $dt->month);
         $this->assertSame(28, $dt->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddDayPassingArg($class)
+    public function testAddDayPassingArg()
     {
-        $this->assertSame(12, $class::createFromDate(1975, 5, 10)->addDays(2)->day);
+        $this->assertSame(12, Chronos::createFromDate(1975, 5, 10)->addDays(2)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddHourPassingArg($class)
+    public function testAddHourPassingArg()
     {
-        $this->assertSame(2, $class::createFromTime(0)->addHours(2)->hour);
+        $this->assertSame(2, Chronos::createFromTime(0)->addHours(2)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddMinutePassingArg($class)
+    public function testAddMinutePassingArg()
     {
-        $this->assertSame(2, $class::createFromTime(0)->addMinutes(2)->minute);
+        $this->assertSame(2, Chronos::createFromTime(0)->addMinutes(2)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAddSecondPassingArg($class)
+    public function testAddSecondPassingArg()
     {
-        $this->assertSame(2, $class::createFromTime(0)->addSeconds(2)->second);
+        $this->assertSame(2, Chronos::createFromTime(0)->addSeconds(2)->second);
     }
 }

--- a/tests/TestCase/DateTime/ComparisonTest.php
+++ b/tests/TestCase/DateTime/ComparisonTest.php
@@ -15,52 +15,37 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosInterface;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class ComparisonTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetSetWeekendDays($class)
+    public function testGetSetWeekendDays()
     {
         $expected = [ChronosInterface::SATURDAY, ChronosInterface::SUNDAY];
-        $this->assertSame($expected, $class::getWeekendDays());
+        $this->assertSame($expected, Chronos::getWeekendDays());
 
         $replace = [ChronosInterface::SUNDAY];
-        $class::setWeekendDays($replace);
-        $this->assertSame($replace, $class::getWeekendDays());
+        Chronos::setWeekendDays($replace);
+        $this->assertSame($replace, Chronos::getWeekendDays());
 
-        $class::setWeekendDays($expected);
+        Chronos::setWeekendDays($expected);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEqualToTrue($class)
+    public function testEqualToTrue()
     {
-        $this->assertTrue($class::create(2000, 1, 1, 0, 0, 0)->equals($class::create(2000, 1, 1, 0, 0, 0)));
+        $this->assertTrue(Chronos::create(2000, 1, 1, 0, 0, 0)->equals(Chronos::create(2000, 1, 1, 0, 0, 0)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEqualToFalse($class)
+    public function testEqualToFalse()
     {
-        $this->assertFalse($class::create(2000, 1, 1, 0, 0, 0)->equals($class::create(2000, 1, 2, 0, 0, 0)));
+        $this->assertFalse(Chronos::create(2000, 1, 1, 0, 0, 0)->equals(Chronos::create(2000, 1, 2, 0, 0, 0)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEqualWithTimezoneTrue($class)
+    public function testEqualWithTimezoneTrue()
     {
-        $this->assertTrue($class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto')->equals($class::create(
+        $this->assertTrue(Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto')->equals(Chronos::create(
             2000,
             1,
             1,
@@ -72,13 +57,9 @@ class ComparisonTest extends TestCase
         )));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEqualWithTimezoneFalse($class)
+    public function testEqualWithTimezoneFalse()
     {
-        $this->assertFalse($class::createFromDate(2000, 1, 1, 'America/Toronto')->equals($class::createFromDate(
+        $this->assertFalse(Chronos::createFromDate(2000, 1, 1, 'America/Toronto')->equals(Chronos::createFromDate(
             2000,
             1,
             1,
@@ -86,31 +67,19 @@ class ComparisonTest extends TestCase
         )));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNotEqualToTrue($class)
+    public function testNotEqualToTrue()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 1)->notEquals($class::createFromDate(2000, 1, 2)));
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->notEquals(Chronos::createFromDate(2000, 1, 2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNotEqualToFalse($class)
+    public function testNotEqualToFalse()
     {
-        $this->assertFalse($class::create(2000, 1, 1, 0, 0, 0)->notEquals($class::create(2000, 1, 1, 0, 0, 0)));
+        $this->assertFalse(Chronos::create(2000, 1, 1, 0, 0, 0)->notEquals(Chronos::create(2000, 1, 1, 0, 0, 0)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNotEqualWithTimezone($class)
+    public function testNotEqualWithTimezone()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 1, 'America/Toronto')->notEquals($class::createFromDate(
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 1, 'America/Toronto')->notEquals(Chronos::createFromDate(
             2000,
             1,
             1,
@@ -118,292 +87,184 @@ class ComparisonTest extends TestCase
         )));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGreaterThanTrue($class)
+    public function testGreaterThanTrue()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 1)->greaterThan($class::createFromDate(1999, 12, 31)));
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->greaterThan(Chronos::createFromDate(1999, 12, 31)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGreaterThanFalse($class)
+    public function testGreaterThanFalse()
     {
-        $this->assertFalse($class::createFromDate(2000, 1, 1)->greaterThan($class::createFromDate(2000, 1, 2)));
+        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->greaterThan(Chronos::createFromDate(2000, 1, 2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGreaterThanWithTimezoneTrue($class)
+    public function testGreaterThanWithTimezoneTrue()
     {
-        $dt1 = $class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
-        $dt2 = $class::create(2000, 1, 1, 8, 59, 59, 0, 'America/Vancouver');
+        $dt1 = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $dt2 = Chronos::create(2000, 1, 1, 8, 59, 59, 0, 'America/Vancouver');
         $this->assertTrue($dt1->greaterThan($dt2));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGreaterThanWithTimezoneFalse($class)
+    public function testGreaterThanWithTimezoneFalse()
     {
-        $dt1 = $class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
-        $dt2 = $class::create(2000, 1, 1, 9, 0, 1, 0, 'America/Vancouver');
+        $dt1 = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $dt2 = Chronos::create(2000, 1, 1, 9, 0, 1, 0, 'America/Vancouver');
         $this->assertFalse($dt1->greaterThan($dt2));
         $this->assertFalse($dt1->greaterThan($dt2));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGreaterThanOrEqualTrue($class)
+    public function testGreaterThanOrEqualTrue()
     {
-        $this->assertTrue($class::create(2000, 1, 1)->greaterThanOrEquals($class::createFromDate(1999, 12, 31)));
+        $this->assertTrue(Chronos::create(2000, 1, 1)->greaterThanOrEquals(Chronos::createFromDate(1999, 12, 31)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGreaterThanOrEqualTrueEqual($class)
+    public function testGreaterThanOrEqualTrueEqual()
     {
-        $this->assertTrue($class::create(2000, 1, 1, 0, 0, 0)->greaterThanOrEquals($class::create(2000, 1, 1, 0, 0, 0)));
+        $this->assertTrue(Chronos::create(2000, 1, 1, 0, 0, 0)->greaterThanOrEquals(Chronos::create(2000, 1, 1, 0, 0, 0)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGreaterThanOrEqualFalse($class)
+    public function testGreaterThanOrEqualFalse()
     {
-        $this->assertFalse($class::createFromDate(2000, 1, 1)->greaterThanOrEquals($class::createFromDate(2000, 1, 2)));
+        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->greaterThanOrEquals(Chronos::createFromDate(2000, 1, 2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLessThanTrue($class)
+    public function testLessThanTrue()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 1)->lessThan($class::createFromDate(2000, 1, 2)));
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->lessThan(Chronos::createFromDate(2000, 1, 2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLessThanFalse($class)
+    public function testLessThanFalse()
     {
-        $this->assertFalse($class::createFromDate(2000, 1, 1)->lessThanOrEquals($class::createFromDate(1999, 12, 31)));
+        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->lessThanOrEquals(Chronos::createFromDate(1999, 12, 31)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLessThanOrEqualTrue($class)
+    public function testLessThanOrEqualTrue()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 1)->lessThanOrEquals($class::createFromDate(2000, 1, 2)));
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->lessThanOrEquals(Chronos::createFromDate(2000, 1, 2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLessThanOrEqualTrueEqual($class)
+    public function testLessThanOrEqualTrueEqual()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 1)->lessThanOrEquals($class::createFromDate(2000, 1, 1)));
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->lessThanOrEquals(Chronos::createFromDate(2000, 1, 1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLessThanOrEqualFalse($class)
+    public function testLessThanOrEqualFalse()
     {
-        $this->assertFalse($class::createFromDate(2000, 1, 1)->lessThanOrEquals($class::createFromDate(1999, 12, 31)));
+        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->lessThanOrEquals(Chronos::createFromDate(1999, 12, 31)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBetweenEqualTrue($class)
+    public function testBetweenEqualTrue()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 15)->between(
-            $class::createFromDate(2000, 1, 1),
-            $class::createFromDate(2000, 1, 31),
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 15)->between(
+            Chronos::createFromDate(2000, 1, 1),
+            Chronos::createFromDate(2000, 1, 31),
             true
         ));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBetweenNotEqualTrue($class)
+    public function testBetweenNotEqualTrue()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 15)->between(
-            $class::createFromDate(2000, 1, 1),
-            $class::createFromDate(2000, 1, 31),
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 15)->between(
+            Chronos::createFromDate(2000, 1, 1),
+            Chronos::createFromDate(2000, 1, 31),
             false
         ));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBetweenEqualFalse($class)
+    public function testBetweenEqualFalse()
     {
-        $this->assertFalse($class::createFromDate(1999, 12, 31)->between(
-            $class::createFromDate(2000, 1, 1),
-            $class::createFromDate(2000, 1, 31),
+        $this->assertFalse(Chronos::createFromDate(1999, 12, 31)->between(
+            Chronos::createFromDate(2000, 1, 1),
+            Chronos::createFromDate(2000, 1, 31),
             true
         ));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBetweenNotEqualFalse($class)
+    public function testBetweenNotEqualFalse()
     {
-        $this->assertFalse($class::createFromDate(2000, 1, 1)->between(
-            $class::createFromDate(2000, 1, 1),
-            $class::createFromDate(2000, 1, 31),
+        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->between(
+            Chronos::createFromDate(2000, 1, 1),
+            Chronos::createFromDate(2000, 1, 31),
             false
         ));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBetweenEqualSwitchTrue($class)
+    public function testBetweenEqualSwitchTrue()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 15)->between(
-            $class::createFromDate(2000, 1, 31),
-            $class::createFromDate(2000, 1, 1),
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 15)->between(
+            Chronos::createFromDate(2000, 1, 31),
+            Chronos::createFromDate(2000, 1, 1),
             true
         ));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBetweenNotEqualSwitchTrue($class)
+    public function testBetweenNotEqualSwitchTrue()
     {
-        $this->assertTrue($class::createFromDate(2000, 1, 15)->between(
-            $class::createFromDate(2000, 1, 31),
-            $class::createFromDate(2000, 1, 1),
+        $this->assertTrue(Chronos::createFromDate(2000, 1, 15)->between(
+            Chronos::createFromDate(2000, 1, 31),
+            Chronos::createFromDate(2000, 1, 1),
             false
         ));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBetweenEqualSwitchFalse($class)
+    public function testBetweenEqualSwitchFalse()
     {
-        $this->assertFalse($class::createFromDate(1999, 12, 31)->between(
-            $class::createFromDate(2000, 1, 31),
-            $class::createFromDate(2000, 1, 1),
+        $this->assertFalse(Chronos::createFromDate(1999, 12, 31)->between(
+            Chronos::createFromDate(2000, 1, 31),
+            Chronos::createFromDate(2000, 1, 1),
             true
         ));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBetweenNotEqualSwitchFalse($class)
+    public function testBetweenNotEqualSwitchFalse()
     {
-        $this->assertFalse($class::createFromDate(2000, 1, 1)->between(
-            $class::createFromDate(2000, 1, 31),
-            $class::createFromDate(2000, 1, 1),
+        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->between(
+            Chronos::createFromDate(2000, 1, 31),
+            Chronos::createFromDate(2000, 1, 1),
             false
         ));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMinIsFluid($class)
+    public function testMinIsFluid()
     {
-        $dt = $class::now();
-        $this->assertTrue($dt->min() instanceof $class);
+        $dt = Chronos::now();
+        $this->assertTrue($dt->min() instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMinWithNow($class)
+    public function testMinWithNow()
     {
-        $dt = $class::create(2012, 1, 1, 0, 0, 0)->min();
+        $dt = Chronos::create(2012, 1, 1, 0, 0, 0)->min();
         $this->assertDateTime($dt, 2012, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMinWithInstance($class)
+    public function testMinWithInstance()
     {
-        $dt1 = $class::create(2013, 12, 31, 23, 59, 59);
-        $dt2 = $class::create(2012, 1, 1, 0, 0, 0)->min($dt1);
+        $dt1 = Chronos::create(2013, 12, 31, 23, 59, 59);
+        $dt2 = Chronos::create(2012, 1, 1, 0, 0, 0)->min($dt1);
         $this->assertDateTime($dt2, 2012, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMaxIsFluid($class)
+    public function testMaxIsFluid()
     {
-        $dt = $class::now();
-        $this->assertTrue($dt->max() instanceof $class);
+        $dt = Chronos::now();
+        $this->assertTrue($dt->max() instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMaxWithNow($class)
+    public function testMaxWithNow()
     {
-        $dt = $class::create(2099, 12, 31, 23, 59, 59)->max();
+        $dt = Chronos::create(2099, 12, 31, 23, 59, 59)->max();
         $this->assertDateTime($dt, 2099, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMaxWithInstance($class)
+    public function testMaxWithInstance()
     {
-        $dt1 = $class::create(2012, 1, 1, 0, 0, 0);
-        $dt2 = $class::create(2099, 12, 31, 23, 59, 59)->max($dt1);
+        $dt1 = Chronos::create(2012, 1, 1, 0, 0, 0);
+        $dt2 = Chronos::create(2099, 12, 31, 23, 59, 59)->max($dt1);
         $this->assertDateTime($dt2, 2099, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsBirthday($class)
+    public function testIsBirthday()
     {
-        $dt = $class::now();
+        $dt = Chronos::now();
         $aBirthday = $dt->subYears(1);
         $this->assertTrue($aBirthday->isBirthday());
         $notABirthday = $dt->subDays(1);
@@ -411,61 +272,45 @@ class ComparisonTest extends TestCase
         $alsoNotABirthday = $dt->addDays(2);
         $this->assertFalse($alsoNotABirthday->isBirthday());
 
-        $dt1 = $class::createFromDate(1987, 4, 23);
-        $dt2 = $class::createFromDate(2014, 9, 26);
-        $dt3 = $class::createFromDate(2014, 4, 23);
+        $dt1 = Chronos::createFromDate(1987, 4, 23);
+        $dt2 = Chronos::createFromDate(2014, 9, 26);
+        $dt3 = Chronos::createFromDate(2014, 4, 23);
         $this->assertFalse($dt2->isBirthday($dt1));
         $this->assertTrue($dt3->isBirthday($dt1));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testClosest($class)
+    public function testClosest()
     {
-        $instance = $class::create(2015, 5, 28, 12, 0, 0);
-        $dt1 = $class::create(2015, 5, 28, 11, 0, 0);
-        $dt2 = $class::create(2015, 5, 28, 14, 0, 0);
+        $instance = Chronos::create(2015, 5, 28, 12, 0, 0);
+        $dt1 = Chronos::create(2015, 5, 28, 11, 0, 0);
+        $dt2 = Chronos::create(2015, 5, 28, 14, 0, 0);
         $closest = $instance->closest($dt1, $dt2);
         $this->assertSame($dt1, $closest);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testClosestWithEquals($class)
+    public function testClosestWithEquals()
     {
-        $instance = $class::create(2015, 5, 28, 12, 0, 0);
-        $dt1 = $class::create(2015, 5, 28, 12, 0, 0);
-        $dt2 = $class::create(2015, 5, 28, 14, 0, 0);
+        $instance = Chronos::create(2015, 5, 28, 12, 0, 0);
+        $dt1 = Chronos::create(2015, 5, 28, 12, 0, 0);
+        $dt2 = Chronos::create(2015, 5, 28, 14, 0, 0);
         $closest = $instance->closest($dt1, $dt2);
         $this->assertSame($dt1, $closest);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFarthest($class)
+    public function testFarthest()
     {
-        $instance = $class::create(2015, 5, 28, 12, 0, 0);
-        $dt1 = $class::create(2015, 5, 28, 11, 0, 0);
-        $dt2 = $class::create(2015, 5, 28, 14, 0, 0);
+        $instance = Chronos::create(2015, 5, 28, 12, 0, 0);
+        $dt1 = Chronos::create(2015, 5, 28, 11, 0, 0);
+        $dt2 = Chronos::create(2015, 5, 28, 14, 0, 0);
         $Farthest = $instance->farthest($dt1, $dt2);
         $this->assertSame($dt2, $Farthest);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFarthestWithEquals($class)
+    public function testFarthestWithEquals()
     {
-        $instance = $class::create(2015, 5, 28, 12, 0, 0);
-        $dt1 = $class::create(2015, 5, 28, 12, 0, 0);
-        $dt2 = $class::create(2015, 5, 28, 14, 0, 0);
+        $instance = Chronos::create(2015, 5, 28, 12, 0, 0);
+        $dt1 = Chronos::create(2015, 5, 28, 12, 0, 0);
+        $dt2 = Chronos::create(2015, 5, 28, 14, 0, 0);
         $Farthest = $instance->farthest($dt1, $dt2);
         $this->assertSame($dt2, $Farthest);
     }

--- a/tests/TestCase/DateTime/ConstructTest.php
+++ b/tests/TestCase/DateTime/ConstructTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTime;
 use DateTimeImmutable;
@@ -22,191 +23,135 @@ use DateTimeZone;
 
 class ConstructTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimestamp($class)
+    public function testCreateFromTimestamp()
     {
         $ts = 1454284800;
 
-        $time = new $class($ts);
+        $time = new Chronos($ts);
         $this->assertSame('+00:00', $time->tzName);
         $this->assertSame('2016-02-01 00:00:00', $time->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreatesAnInstanceDefaultToNow($class)
+    public function testCreatesAnInstanceDefaultToNow()
     {
-        $c = new $class();
-        $now = $class::now();
-        $this->assertInstanceOf($class, $c);
+        $c = new Chronos();
+        $now = Chronos::now();
+        $this->assertInstanceOf(Chronos::class, $c);
         $this->assertSame($now->tzName, $c->tzName);
         $this->assertDateTime($c, $now->year, $now->month, $now->day, $now->hour, $now->minute, $now->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseCreatesAnInstanceDefaultToNow($class)
+    public function testParseCreatesAnInstanceDefaultToNow()
     {
-        $c = $class::parse();
-        $now = $class::now();
-        $this->assertInstanceOf($class, $c);
+        $c = Chronos::parse();
+        $now = Chronos::now();
+        $this->assertInstanceOf(Chronos::class, $c);
         $this->assertSame($now->tzName, $c->tzName);
         $this->assertDateTime($c, $now->year, $now->month, $now->day, $now->hour, $now->minute, $now->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testWithFancyString($class)
+    public function testWithFancyString()
     {
-        $c = new $class('first day of January 2008');
+        $c = new Chronos('first day of January 2008');
         $this->assertDateTime($c, 2008, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseWithFancyString($class)
+    public function testParseWithFancyString()
     {
-        $c = $class::parse('first day of January 2008');
+        $c = Chronos::parse('first day of January 2008');
         $this->assertDateTime($c, 2008, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDefaultTimezone($class)
+    public function testDefaultTimezone()
     {
-        $c = new $class('now');
+        $c = new Chronos('now');
         $this->assertSame('America/Toronto', $c->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testConstructWithMicrosecondsAndOffset($class)
+    public function testConstructWithMicrosecondsAndOffset()
     {
-        $c = new $class('2014-09-29 18:24:54.591767+02:00');
+        $c = new Chronos('2014-09-29 18:24:54.591767+02:00');
         $this->assertDateTime($c, 2014, 9, 29, 18, 24, 54);
         $this->assertSame(591767, $c->micro);
         $this->assertSame('+02:00', $c->getTimezone()->getName());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseWithDefaultTimezone($class)
+    public function testParseWithDefaultTimezone()
     {
-        $c = $class::parse('now');
+        $c = Chronos::parse('now');
         $this->assertSame('America/Toronto', $c->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSettingTimezone($class)
+    public function testSettingTimezone()
     {
         $timezone = 'Europe/London';
         $dtz = new DateTimeZone($timezone);
         $dt = new DateTime('now', $dtz);
         $dayLightSavingTimeOffset = (int)$dt->format('I');
 
-        $c = new $class('now', $dtz);
+        $c = new Chronos('now', $dtz);
         $this->assertSame($timezone, $c->tzName);
         $this->assertSame($dayLightSavingTimeOffset, $c->offsetHours);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseSettingTimezone($class)
+    public function testParseSettingTimezone()
     {
         $timezone = 'Europe/London';
         $dtz = new DateTimeZone($timezone);
         $dt = new DateTime('now', $dtz);
         $dayLightSavingTimeOffset = (int)$dt->format('I');
 
-        $c = $class::parse('now', $dtz);
+        $c = Chronos::parse('now', $dtz);
         $this->assertSame($timezone, $c->tzName);
         $this->assertSame($dayLightSavingTimeOffset, $c->offsetHours);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSettingTimezoneWithString($class)
+    public function testSettingTimezoneWithString()
     {
         $timezone = 'Asia/Tokyo';
         $dtz = new DateTimeZone($timezone);
         $dt = new DateTime('now', $dtz);
         $dayLightSavingTimeOffset = (int)$dt->format('I');
 
-        $c = new $class('now', $timezone);
+        $c = new Chronos('now', $timezone);
         $this->assertSame($timezone, $c->tzName);
         $this->assertSame(9 + $dayLightSavingTimeOffset, $c->offsetHours);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseSettingTimezoneWithString($class)
+    public function testParseSettingTimezoneWithString()
     {
         $timezone = 'Asia/Tokyo';
         $dtz = new DateTimeZone($timezone);
         $dt = new DateTime('now', $dtz);
         $dayLightSavingTimeOffset = (int)$dt->format('I');
 
-        $c = $class::parse('now', $timezone);
+        $c = Chronos::parse('now', $timezone);
         $this->assertSame($timezone, $c->tzName);
         $this->assertSame(9 + $dayLightSavingTimeOffset, $c->offsetHours);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromExistingInstance($class)
+    public function testCreateFromExistingInstance()
     {
-        $existingClass = new $class();
-        $this->assertInstanceOf($class, $existingClass);
+        $existingClass = new Chronos();
+        $this->assertInstanceOf(Chronos::class, $existingClass);
 
-        $newClass = new $class($existingClass);
-        $this->assertInstanceOf($class, $newClass);
+        $newClass = new Chronos($existingClass);
+        $this->assertInstanceOf(Chronos::class, $newClass);
         $this->assertSame((string)$existingClass, (string)$newClass);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDateTimeInterface($class)
+    public function testCreateFromDateTimeInterface()
     {
         $existingClass = new DateTimeImmutable();
-        $newClass = new $class($existingClass);
+        $newClass = new Chronos($existingClass);
         $this->assertSame($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
         $existingClass = new DateTime();
-        $newClass = new $class($existingClass);
+        $newClass = new Chronos($existingClass);
         $this->assertSame($existingClass->format('Y-m-d H:i:s.u'), $newClass->format('Y-m-d H:i:s.u'));
 
         $existingClass = new DateTime('2019-01-15 00:15:22.139302');
-        $newClass = new $class($existingClass);
+        $newClass = new Chronos($existingClass);
         $this->assertDateTime($newClass, 2019, 01, 15, 0, 15, 22);
         $this->assertSame(139302, $newClass->micro);
     }

--- a/tests/TestCase/DateTime/CreateFromDateTest.php
+++ b/tests/TestCase/DateTime/CreateFromDateTest.php
@@ -15,79 +15,52 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTimeZone;
 
 class CreateFromDateTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDateWithDefaults($class)
+    public function testCreateFromDateWithDefaults()
     {
-        $d = $class::createFromDate();
-        $this->assertSame($d->timestamp, $class::create(null, null, null, null, null, null, null)->timestamp);
+        $d = Chronos::createFromDate();
+        $this->assertSame($d->timestamp, Chronos::create(null, null, null, null, null, null, null)->timestamp);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDate($class)
+    public function testCreateFromDate()
     {
-        $d = $class::createFromDate(1975, 5, 21);
+        $d = Chronos::createFromDate(1975, 5, 21);
         $this->assertDateTime($d, 1975, 5, 21);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDateWithYear($class)
+    public function testCreateFromDateWithYear()
     {
-        $d = $class::createFromDate(1975);
+        $d = Chronos::createFromDate(1975);
         $this->assertSame(1975, $d->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDateWithMonth($class)
+    public function testCreateFromDateWithMonth()
     {
-        $d = $class::createFromDate(null, 5);
+        $d = Chronos::createFromDate(null, 5);
         $this->assertSame(5, $d->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDateWithDay($class)
+    public function testCreateFromDateWithDay()
     {
-        $d = $class::createFromDate(null, null, 21);
+        $d = Chronos::createFromDate(null, null, 21);
         $this->assertSame(21, $d->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDateWithTimezone($class)
+    public function testCreateFromDateWithTimezone()
     {
-        $d = $class::createFromDate(1975, 5, 21, 'Europe/London');
+        $d = Chronos::createFromDate(1975, 5, 21, 'Europe/London');
         $this->assertDateTime($d, 1975, 5, 21);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDateWithDateTimeZone($class)
+    public function testCreateFromDateWithDateTimeZone()
     {
-        $d = $class::createFromDate(1975, 5, 21, new DateTimeZone('Europe/London'));
+        $d = Chronos::createFromDate(1975, 5, 21, new DateTimeZone('Europe/London'));
         $this->assertDateTime($d, 1975, 5, 21);
         $this->assertSame('Europe/London', $d->tzName);
     }

--- a/tests/TestCase/DateTime/CreateFromFormatTest.php
+++ b/tests/TestCase/DateTime/CreateFromFormatTest.php
@@ -15,51 +15,36 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTimeZone;
 
 class CreateFromFormatTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromFormatReturnsInstance($class)
+    public function testCreateFromFormatReturnsInstance()
     {
-        $d = $class::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
+        $d = Chronos::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
         $this->assertDateTime($d, 1975, 5, 21, 22, 32, 11);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromFormatWithTimezoneString($class)
+    public function testCreateFromFormatWithTimezoneString()
     {
-        $d = $class::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11', 'Europe/London');
+        $d = Chronos::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11', 'Europe/London');
         $this->assertDateTime($d, 1975, 5, 21, 22, 32, 11);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromFormatWithTimezone($class)
+    public function testCreateFromFormatWithTimezone()
     {
-        $d = $class::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11', new DateTimeZone('Europe/London'));
+        $d = Chronos::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11', new DateTimeZone('Europe/London'));
         $this->assertDateTime($d, 1975, 5, 21, 22, 32, 11);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromFormatWithMillis($class)
+    public function testCreateFromFormatWithMillis()
     {
-        $d = $class::createFromFormat('Y-m-d H:i:s.u', '1975-05-21 22:32:11.254687');
+        $d = Chronos::createFromFormat('Y-m-d H:i:s.u', '1975-05-21 22:32:11.254687');
         $this->assertSame(254687, $d->micro);
     }
 }

--- a/tests/TestCase/DateTime/CreateFromTimeTest.php
+++ b/tests/TestCase/DateTime/CreateFromTimeTest.php
@@ -15,93 +15,62 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTimeZone;
 
 class CreateFromTimeTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDateWithDefaults($class)
+    public function testCreateFromDateWithDefaults()
     {
-        $d = $class::createFromTime();
-        $this->assertSame($d->timestamp, $class::create(null, null, null, null, null, null)->timestamp);
+        $d = Chronos::createFromTime();
+        $this->assertSame($d->timestamp, Chronos::create(null, null, null, null, null, null)->timestamp);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromDate($class)
+    public function testCreateFromDate()
     {
-        $d = $class::createFromTime(23, 5, 21);
-        $this->assertDateTime($d, $class::now()->year, $class::now()->month, $class::now()->day, 23, 5, 21);
+        $d = Chronos::createFromTime(23, 5, 21);
+        $this->assertDateTime($d, Chronos::now()->year, Chronos::now()->month, Chronos::now()->day, 23, 5, 21);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimeWithHour($class)
+    public function testCreateFromTimeWithHour()
     {
-        $d = $class::createFromTime(22);
+        $d = Chronos::createFromTime(22);
         $this->assertSame(22, $d->hour);
         $this->assertSame(0, $d->minute);
         $this->assertSame(0, $d->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimeWithMinute($class)
+    public function testCreateFromTimeWithMinute()
     {
-        $d = $class::createFromTime(null, 5);
+        $d = Chronos::createFromTime(null, 5);
         $this->assertSame(5, $d->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimeWithSecond($class)
+    public function testCreateFromTimeWithSecond()
     {
-        $d = $class::createFromTime(null, null, 21);
+        $d = Chronos::createFromTime(null, null, 21);
         $this->assertSame(21, $d->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimeWithMicrosecond($class)
+    public function testCreateFromTimeWithMicrosecond()
     {
-        $d = $class::createFromTime(null, null, null, 123456);
+        $d = Chronos::createFromTime(null, null, null, 123456);
         $this->assertSame(123456, $d->microsecond);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimeWithDateTimeZone($class)
+    public function testCreateFromTimeWithDateTimeZone()
     {
-        $now = $class::now();
-        $d = $class::createFromTime(12, 0, 0, 0, new DateTimeZone('Europe/London'));
+        $now = Chronos::now();
+        $d = Chronos::createFromTime(12, 0, 0, 0, new DateTimeZone('Europe/London'));
         $this->assertDateTime($d, $now->year, $now->month, $now->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimeWithTimeZoneString($class)
+    public function testCreateFromTimeWithTimeZoneString()
     {
-        $now = $class::now();
-        $d = $class::createFromTime(12, 0, 0, 0, 'Europe/London');
+        $now = Chronos::now();
+        $d = Chronos::createFromTime(12, 0, 0, 0, 'Europe/London');
         $this->assertDateTime($d, $now->year, $now->month, $now->day, 12, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }

--- a/tests/TestCase/DateTime/CreateFromTimestampTest.php
+++ b/tests/TestCase/DateTime/CreateFromTimestampTest.php
@@ -15,64 +15,45 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTimeZone;
 
 class CreateFromTimestampTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateReturnsDatingInstance($class)
+    public function testCreateReturnsDatingInstance()
     {
-        $d = $class::createFromTimestamp($class::create(1975, 5, 21, 22, 32, 5)->timestamp);
+        $d = Chronos::createFromTimestamp(Chronos::create(1975, 5, 21, 22, 32, 5)->timestamp);
         $this->assertDateTime($d, 1975, 5, 21, 22, 32, 5);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimestampUsesDefaultTimezone($class)
+    public function testCreateFromTimestampUsesDefaultTimezone()
     {
-        $d = $class::createFromTimestamp(0);
+        $d = Chronos::createFromTimestamp(0);
 
         // We know Toronto is -5 since no DST in Jan
         $this->assertSame(1969, $d->year);
         $this->assertSame(-5 * 3600, $d->offset);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimestampWithDateTimeZone($class)
+    public function testCreateFromTimestampWithDateTimeZone()
     {
-        $d = $class::createFromTimestamp(0, new DateTimeZone('UTC'));
+        $d = Chronos::createFromTimestamp(0, new DateTimeZone('UTC'));
         $this->assertSame('UTC', $d->tzName);
         $this->assertDateTime($d, 1970, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimestampWithString($class)
+    public function testCreateFromTimestampWithString()
     {
-        $d = $class::createFromTimestamp(0, 'UTC');
+        $d = Chronos::createFromTimestamp(0, 'UTC');
         $this->assertDateTime($d, 1970, 1, 1, 0, 0, 0);
         $this->assertSame(0, $d->offset);
         $this->assertSame('UTC', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromTimestampGMTDoesNotUseDefaultTimezone($class)
+    public function testCreateFromTimestampGMTDoesNotUseDefaultTimezone()
     {
-        $d = $class::createFromTimestampUTC(0);
+        $d = Chronos::createFromTimestampUTC(0);
         $this->assertDateTime($d, 1970, 1, 1, 0, 0, 0);
         $this->assertSame(0, $d->offset);
     }

--- a/tests/TestCase/DateTime/CreateTest.php
+++ b/tests/TestCase/DateTime/CreateTest.php
@@ -15,256 +15,161 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTimeZone;
 use InvalidArgumentException;
 
 class CreateTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateReturnsDatingInstance($class)
+    public function testCreateReturnsDatingInstance()
     {
-        $d = $class::create();
-        $this->assertTrue($d instanceof $class);
+        $d = Chronos::create();
+        $this->assertTrue($d instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithDefaults($class)
+    public function testCreateWithDefaults()
     {
-        $d = $class::create();
-        $this->assertSame($d->timestamp, $class::now()->timestamp);
+        $d = Chronos::create();
+        $this->assertSame($d->timestamp, Chronos::now()->timestamp);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithYear($class)
+    public function testCreateWithYear()
     {
-        $d = $class::create(2012);
+        $d = Chronos::create(2012);
         $this->assertSame(2012, $d->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateHandlesNegativeYear($class)
+    public function testCreateHandlesNegativeYear()
     {
-        $d = $class::create(-1, 10, 12, 1, 2, 3);
+        $d = Chronos::create(-1, 10, 12, 1, 2, 3);
         $this->assertDateTime($d, -1, 10, 12, 1, 2, 3);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateHandlesFiveDigitsPositiveYears($class)
+    public function testCreateHandlesFiveDigitsPositiveYears()
     {
-        $c = $class::create(999999999, 10, 12, 1, 2, 3);
+        $c = Chronos::create(999999999, 10, 12, 1, 2, 3);
         $this->assertDateTime($c, 999999999, 10, 12, 1, 2, 3);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateHandlesFiveDigitsNegativeYears($class)
+    public function testCreateHandlesFiveDigitsNegativeYears()
     {
-        $c = $class::create(-999999999, 10, 12, 1, 2, 3);
+        $c = Chronos::create(-999999999, 10, 12, 1, 2, 3);
         $this->assertDateTime($c, -999999999, 10, 12, 1, 2, 3);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithMonth($class)
+    public function testCreateWithMonth()
     {
-        $d = $class::create(null, 3);
+        $d = Chronos::create(null, 3);
         $this->assertSame(3, $d->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithInvalidMonth($class)
+    public function testCreateWithInvalidMonth()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $class::create(null, -5);
+        Chronos::create(null, -5);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateMonthWraps($class)
+    public function testCreateMonthWraps()
     {
-        $d = $class::create(2011, 0, 1, 0, 0, 0);
+        $d = Chronos::create(2011, 0, 1, 0, 0, 0);
         $this->assertDateTime($d, 2010, 12, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithDay($class)
+    public function testCreateWithDay()
     {
-        $d = $class::create(null, null, 21);
+        $d = Chronos::create(null, null, 21);
         $this->assertSame(21, $d->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithInvalidDay($class)
+    public function testCreateWithInvalidDay()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $class::create(null, null, -4);
+        Chronos::create(null, null, -4);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateDayWraps($class)
+    public function testCreateDayWraps()
     {
-        $d = $class::create(2011, 1, 40, 0, 0, 0);
+        $d = Chronos::create(2011, 1, 40, 0, 0, 0);
         $this->assertDateTime($d, 2011, 2, 9, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithHourAndDefaultMinSecToZero($class)
+    public function testCreateWithHourAndDefaultMinSecToZero()
     {
-        $d = $class::create(null, null, null, 14);
+        $d = Chronos::create(null, null, null, 14);
         $this->assertSame(14, $d->hour);
         $this->assertSame(0, $d->minute);
         $this->assertSame(0, $d->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithInvalidHour($class)
+    public function testCreateWithInvalidHour()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $class::create(null, null, null, -1);
+        Chronos::create(null, null, null, -1);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateHourWraps($class)
+    public function testCreateHourWraps()
     {
-        $d = $class::create(2011, 1, 1, 24, 0, 0);
+        $d = Chronos::create(2011, 1, 1, 24, 0, 0);
         $this->assertDateTime($d, 2011, 1, 2, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithMinute($class)
+    public function testCreateWithMinute()
     {
-        $d = $class::create(null, null, null, null, 58);
+        $d = Chronos::create(null, null, null, null, 58);
         $this->assertSame(58, $d->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithInvalidMinute($class)
+    public function testCreateWithInvalidMinute()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $class::create(2011, 1, 1, 0, -2, 0);
+        Chronos::create(2011, 1, 1, 0, -2, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateMinuteWraps($class)
+    public function testCreateMinuteWraps()
     {
-        $d = $class::create(2011, 1, 1, 0, 62, 0);
+        $d = Chronos::create(2011, 1, 1, 0, 62, 0);
         $this->assertDateTime($d, 2011, 1, 1, 1, 2, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithSecond($class)
+    public function testCreateWithSecond()
     {
-        $d = $class::create(null, null, null, null, null, 59);
+        $d = Chronos::create(null, null, null, null, null, 59);
         $this->assertSame(59, $d->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithInvalidSecond($class)
+    public function testCreateWithInvalidSecond()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $class::create(null, null, null, null, null, -2);
+        Chronos::create(null, null, null, null, null, -2);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateSecondsWrap($class)
+    public function testCreateSecondsWrap()
     {
-        $d = $class::create(2012, 1, 1, 0, 0, 61);
+        $d = Chronos::create(2012, 1, 1, 0, 0, 61);
         $this->assertDateTime($d, 2012, 1, 1, 0, 1, 1);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithDateTimeZone($class)
+    public function testCreateWithDateTimeZone()
     {
-        $d = $class::create(2012, 1, 1, 0, 0, 0, 0, new DateTimeZone('Europe/London'));
+        $d = Chronos::create(2012, 1, 1, 0, 0, 0, 0, new DateTimeZone('Europe/London'));
         $this->assertDateTime($d, 2012, 1, 1, 0, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateWithTimeZoneString($class)
+    public function testCreateWithTimeZoneString()
     {
-        $d = $class::create(2012, 1, 1, 0, 0, 0, 0, 'Europe/London');
+        $d = Chronos::create(2012, 1, 1, 0, 0, 0, 0, 'Europe/London');
         $this->assertDateTime($d, 2012, 1, 1, 0, 0, 0);
         $this->assertSame('Europe/London', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromArray($class)
+    public function testCreateFromArray()
     {
         $values = [
             'year' => 2012,
@@ -276,32 +181,24 @@ class CreateTest extends TestCase
             'microsecond' => 123456,
             'meridian' => 'am',
         ];
-        $d = $class::createFromArray($values);
+        $d = Chronos::createFromArray($values);
         $this->assertDateTime($d, 2012, 1, 1, 0, 13, 14, 123456);
         $this->assertSame('America/Toronto', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromArrayDateOnly($class)
+    public function testCreateFromArrayDateOnly()
     {
         $values = [
             'year' => 2012,
             'month' => '1',
             'day' => '1',
         ];
-        $d = $class::createFromArray($values);
+        $d = Chronos::createFromArray($values);
         $this->assertDateTime($d, 2012, 1, 1);
         $this->assertSame('America/Toronto', $d->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromArrayTimeOnly($class)
+    public function testCreateFromArrayTimeOnly()
     {
         $values = [
             'hour' => 12,
@@ -310,7 +207,7 @@ class CreateTest extends TestCase
             'microsecond' => 123456,
             'meridian' => 'am',
         ];
-        $d = $class::createFromArray($values);
+        $d = Chronos::createFromArray($values);
         $this->assertTime($d, 0, 13, 14, 123456);
         $this->assertSame('America/Toronto', $d->tzName);
     }

--- a/tests/TestCase/DateTime/DayOfWeekModifiersTest.php
+++ b/tests/TestCase/DateTime/DayOfWeekModifiersTest.php
@@ -15,484 +15,295 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class DayOfWeekModifiersTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfWeek($class)
+    public function testStartOfWeek()
     {
-        $d = $class::create(1980, 8, 7, 12, 11, 9)->startOfWeek();
+        $d = Chronos::create(1980, 8, 7, 12, 11, 9)->startOfWeek();
         $this->assertDateTime($d, 1980, 8, 4, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfWeekFromWeekStart($class)
+    public function testStartOfWeekFromWeekStart()
     {
-        $d = $class::createFromDate(1980, 8, 4)->startOfWeek();
+        $d = Chronos::createFromDate(1980, 8, 4)->startOfWeek();
         $this->assertDateTime($d, 1980, 8, 4, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfWeekCrossingYearBoundary($class)
+    public function testStartOfWeekCrossingYearBoundary()
     {
-        $d = $class::createFromDate(2013, 12, 31, 'GMT');
+        $d = Chronos::createFromDate(2013, 12, 31, 'GMT');
         $this->assertDateTime($d->startOfWeek(), 2013, 12, 30, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfWeek($class)
+    public function testEndOfWeek()
     {
-        $d = $class::create(1980, 8, 7, 11, 12, 13)->endOfWeek();
+        $d = Chronos::create(1980, 8, 7, 11, 12, 13)->endOfWeek();
         $this->assertDateTime($d, 1980, 8, 10, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfWeekFromWeekEnd($class)
+    public function testEndOfWeekFromWeekEnd()
     {
-        $d = $class::createFromDate(1980, 8, 9)->endOfWeek();
+        $d = Chronos::createFromDate(1980, 8, 9)->endOfWeek();
         $this->assertDateTime($d, 1980, 8, 10, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfWeekCrossingYearBoundary($class)
+    public function testEndOfWeekCrossingYearBoundary()
     {
-        $d = $class::createFromDate(2013, 12, 31, 'GMT');
+        $d = Chronos::createFromDate(2013, 12, 31, 'GMT');
         $this->assertDateTime($d->endOfWeek(), 2014, 1, 5, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNext($class)
+    public function testNext()
     {
-        $d = $class::createFromDate(1975, 5, 21)->next();
+        $d = Chronos::createFromDate(1975, 5, 21)->next();
         $this->assertDateTime($d, 1975, 5, 28, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     */
-    public function testStartOrEndOfWeekFromWeekWithUTC($class)
+    public function testStartOrEndOfWeekFromWeekWithUTC()
     {
-        $d = $class::create(2016, 7, 27, 17, 13, 7, 0, 'UTC');
+        $d = Chronos::create(2016, 7, 27, 17, 13, 7, 0, 'UTC');
         $this->assertDateTime($d->startOfWeek(), 2016, 7, 25, 0, 0, 0);
         $this->assertDateTime($d->endOfWeek(), 2016, 7, 31, 23, 59, 59);
         $this->assertDateTime($d->startOfWeek()->endOfWeek(), 2016, 7, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     */
-    public function testStartOrEndOfWeekFromWeekWithOtherTimezone($class)
+    public function testStartOrEndOfWeekFromWeekWithOtherTimezone()
     {
-        $d = $class::create(2016, 7, 27, 17, 13, 7, 0, 'America/New_York');
+        $d = Chronos::create(2016, 7, 27, 17, 13, 7, 0, 'America/New_York');
         $this->assertDateTime($d->startOfWeek(), 2016, 7, 25, 0, 0, 0);
         $this->assertDateTime($d->endOfWeek(), 2016, 7, 31, 23, 59, 59);
         $this->assertDateTime($d->startOfWeek()->endOfWeek(), 2016, 7, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNextMonday($class)
+    public function testNextMonday()
     {
-        $d = $class::createFromDate(1975, 5, 21)->next($class::MONDAY);
+        $d = Chronos::createFromDate(1975, 5, 21)->next(Chronos::MONDAY);
         $this->assertDateTime($d, 1975, 5, 26, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNextSaturday($class)
+    public function testNextSaturday()
     {
-        $d = $class::createFromDate(1975, 5, 21)->next(6);
+        $d = Chronos::createFromDate(1975, 5, 21)->next(6);
         $this->assertDateTime($d, 1975, 5, 24, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNextTimestamp($class)
+    public function testNextTimestamp()
     {
-        $d = $class::createFromDate(1975, 11, 14)->next();
+        $d = Chronos::createFromDate(1975, 11, 14)->next();
         $this->assertDateTime($d, 1975, 11, 21, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testPrevious($class)
+    public function testPrevious()
     {
-        $d = $class::createFromDate(1975, 5, 21)->previous();
+        $d = Chronos::createFromDate(1975, 5, 21)->previous();
         $this->assertDateTime($d, 1975, 5, 14, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testPreviousMonday($class)
+    public function testPreviousMonday()
     {
-        $d = $class::createFromDate(1975, 5, 21)->previous($class::MONDAY);
+        $d = Chronos::createFromDate(1975, 5, 21)->previous(Chronos::MONDAY);
         $this->assertDateTime($d, 1975, 5, 19, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testPreviousSaturday($class)
+    public function testPreviousSaturday()
     {
-        $d = $class::createFromDate(1975, 5, 21)->previous(6);
+        $d = Chronos::createFromDate(1975, 5, 21)->previous(6);
         $this->assertDateTime($d, 1975, 5, 17, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testPreviousTimestamp($class)
+    public function testPreviousTimestamp()
     {
-        $d = $class::createFromDate(1975, 11, 28)->previous();
+        $d = Chronos::createFromDate(1975, 11, 28)->previous();
         $this->assertDateTime($d, 1975, 11, 21, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstDayOfMonth($class)
+    public function testFirstDayOfMonth()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfMonth();
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfMonth();
         $this->assertDateTime($d, 1975, 11, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstWednesdayOfMonth($class)
+    public function testFirstWednesdayOfMonth()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfMonth($class::WEDNESDAY);
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfMonth(Chronos::WEDNESDAY);
         $this->assertDateTime($d, 1975, 11, 5, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstFridayOfMonth($class)
+    public function testFirstFridayOfMonth()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfMonth(5);
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfMonth(5);
         $this->assertDateTime($d, 1975, 11, 7, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastDayOfMonth($class)
+    public function testLastDayOfMonth()
     {
-        $d = $class::createFromDate(1975, 12, 5)->lastOfMonth();
+        $d = Chronos::createFromDate(1975, 12, 5)->lastOfMonth();
         $this->assertDateTime($d, 1975, 12, 31, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastTuesdayOfMonth($class)
+    public function testLastTuesdayOfMonth()
     {
-        $d = $class::createFromDate(1975, 12, 1)->lastOfMonth($class::TUESDAY);
+        $d = Chronos::createFromDate(1975, 12, 1)->lastOfMonth(Chronos::TUESDAY);
         $this->assertDateTime($d, 1975, 12, 30, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastFridayOfMonth($class)
+    public function testLastFridayOfMonth()
     {
-        $d = $class::createFromDate(1975, 12, 5)->lastOfMonth(5);
+        $d = Chronos::createFromDate(1975, 12, 5)->lastOfMonth(5);
         $this->assertDateTime($d, 1975, 12, 26, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNthOfMonthOutsideScope($class)
+    public function testNthOfMonthOutsideScope()
     {
-        $this->assertFalse($class::createFromDate(1975, 12, 5)->nthOfMonth(6, $class::MONDAY));
+        $this->assertFalse(Chronos::createFromDate(1975, 12, 5)->nthOfMonth(6, Chronos::MONDAY));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNthOfMonthOutsideYear($class)
+    public function testNthOfMonthOutsideYear()
     {
-        $this->assertFalse($class::createFromDate(1975, 12, 5)->nthOfMonth(55, $class::MONDAY));
+        $this->assertFalse(Chronos::createFromDate(1975, 12, 5)->nthOfMonth(55, Chronos::MONDAY));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function test2ndMondayOfMonth($class)
+    public function test2ndMondayOfMonth()
     {
-        $d = $class::createFromDate(1975, 12, 5)->nthOfMonth(2, $class::MONDAY);
+        $d = Chronos::createFromDate(1975, 12, 5)->nthOfMonth(2, Chronos::MONDAY);
         $this->assertDateTime($d, 1975, 12, 8, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function test3rdWednesdayOfMonth($class)
+    public function test3rdWednesdayOfMonth()
     {
-        $d = $class::createFromDate(1975, 12, 5)->nthOfMonth(3, 3);
+        $d = Chronos::createFromDate(1975, 12, 5)->nthOfMonth(3, 3);
         $this->assertDateTime($d, 1975, 12, 17, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstDayOfQuarter($class)
+    public function testFirstDayOfQuarter()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfQuarter();
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfQuarter();
         $this->assertDateTime($d, 1975, 10, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstWednesdayOfQuarter($class)
+    public function testFirstWednesdayOfQuarter()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfQuarter($class::WEDNESDAY);
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfQuarter(Chronos::WEDNESDAY);
         $this->assertDateTime($d, 1975, 10, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstFridayOfQuarter($class)
+    public function testFirstFridayOfQuarter()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfQuarter(5);
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfQuarter(5);
         $this->assertDateTime($d, 1975, 10, 3, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstOfQuarterFromADayThatWillNotExistIntheFirstMonth($class)
+    public function testFirstOfQuarterFromADayThatWillNotExistIntheFirstMonth()
     {
-        $d = $class::createFromDate(2014, 5, 31)->firstOfQuarter();
+        $d = Chronos::createFromDate(2014, 5, 31)->firstOfQuarter();
         $this->assertDateTime($d, 2014, 4, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastDayOfQuarter($class)
+    public function testLastDayOfQuarter()
     {
-        $d = $class::createFromDate(1975, 8, 5)->lastOfQuarter();
+        $d = Chronos::createFromDate(1975, 8, 5)->lastOfQuarter();
         $this->assertDateTime($d, 1975, 9, 30, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastTuesdayOfQuarter($class)
+    public function testLastTuesdayOfQuarter()
     {
-        $d = $class::createFromDate(1975, 8, 1)->lastOfQuarter($class::TUESDAY);
+        $d = Chronos::createFromDate(1975, 8, 1)->lastOfQuarter(Chronos::TUESDAY);
         $this->assertDateTime($d, 1975, 9, 30, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastFridayOfQuarter($class)
+    public function testLastFridayOfQuarter()
     {
-        $d = $class::createFromDate(1975, 7, 5)->lastOfQuarter(5);
+        $d = Chronos::createFromDate(1975, 7, 5)->lastOfQuarter(5);
         $this->assertDateTime($d, 1975, 9, 26, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastOfQuarterFromADayThatWillNotExistIntheLastMonth($class)
+    public function testLastOfQuarterFromADayThatWillNotExistIntheLastMonth()
     {
-        $d = $class::createFromDate(2014, 5, 31)->lastOfQuarter();
+        $d = Chronos::createFromDate(2014, 5, 31)->lastOfQuarter();
         $this->assertDateTime($d, 2014, 6, 30, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNthOfQuarterOutsideScope($class)
+    public function testNthOfQuarterOutsideScope()
     {
-        $this->assertFalse($class::createFromDate(1975, 1, 5)->nthOfQuarter(20, $class::MONDAY));
+        $this->assertFalse(Chronos::createFromDate(1975, 1, 5)->nthOfQuarter(20, Chronos::MONDAY));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNthOfQuarterOutsideYear($class)
+    public function testNthOfQuarterOutsideYear()
     {
-        $this->assertFalse($class::createFromDate(1975, 1, 5)->nthOfQuarter(55, $class::MONDAY));
+        $this->assertFalse(Chronos::createFromDate(1975, 1, 5)->nthOfQuarter(55, Chronos::MONDAY));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNthOfQuarterFromADayThatWillNotExistIntheFirstMonth($class)
+    public function testNthOfQuarterFromADayThatWillNotExistIntheFirstMonth()
     {
-        $d = $class::createFromDate(2014, 5, 31)->nthOfQuarter(2, $class::MONDAY);
+        $d = Chronos::createFromDate(2014, 5, 31)->nthOfQuarter(2, Chronos::MONDAY);
         $this->assertDateTime($d, 2014, 4, 14, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function test2ndMondayOfQuarter($class)
+    public function test2ndMondayOfQuarter()
     {
-        $d = $class::createFromDate(1975, 8, 5)->nthOfQuarter(2, $class::MONDAY);
+        $d = Chronos::createFromDate(1975, 8, 5)->nthOfQuarter(2, Chronos::MONDAY);
         $this->assertDateTime($d, 1975, 7, 14, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function test3rdWednesdayOfQuarter($class)
+    public function test3rdWednesdayOfQuarter()
     {
-        $d = $class::createFromDate(1975, 8, 5)->nthOfQuarter(3, 3);
+        $d = Chronos::createFromDate(1975, 8, 5)->nthOfQuarter(3, 3);
         $this->assertDateTime($d, 1975, 7, 16, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstDayOfYear($class)
+    public function testFirstDayOfYear()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfYear();
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfYear();
         $this->assertDateTime($d, 1975, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstWednesdayOfYear($class)
+    public function testFirstWednesdayOfYear()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfYear($class::WEDNESDAY);
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfYear(Chronos::WEDNESDAY);
         $this->assertDateTime($d, 1975, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFirstFridayOfYear($class)
+    public function testFirstFridayOfYear()
     {
-        $d = $class::createFromDate(1975, 11, 21)->firstOfYear(5);
+        $d = Chronos::createFromDate(1975, 11, 21)->firstOfYear(5);
         $this->assertDateTime($d, 1975, 1, 3, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastDayOfYear($class)
+    public function testLastDayOfYear()
     {
-        $d = $class::createFromDate(1975, 8, 5)->lastOfYear();
+        $d = Chronos::createFromDate(1975, 8, 5)->lastOfYear();
         $this->assertDateTime($d, 1975, 12, 31, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastTuesdayOfYear($class)
+    public function testLastTuesdayOfYear()
     {
-        $d = $class::createFromDate(1975, 8, 1)->lastOfYear($class::TUESDAY);
+        $d = Chronos::createFromDate(1975, 8, 1)->lastOfYear(Chronos::TUESDAY);
         $this->assertDateTime($d, 1975, 12, 30, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testLastFridayOfYear($class)
+    public function testLastFridayOfYear()
     {
-        $d = $class::createFromDate(1975, 7, 5)->lastOfYear(5);
+        $d = Chronos::createFromDate(1975, 7, 5)->lastOfYear(5);
         $this->assertDateTime($d, 1975, 12, 26, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNthOfYearOutsideScope($class)
+    public function testNthOfYearOutsideScope()
     {
-        $this->assertFalse($class::createFromDate(1975, 1, 5)->nthOfYear(55, $class::MONDAY));
+        $this->assertFalse(Chronos::createFromDate(1975, 1, 5)->nthOfYear(55, Chronos::MONDAY));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function test2ndMondayOfYear($class)
+    public function test2ndMondayOfYear()
     {
-        $d = $class::createFromDate(1975, 8, 5)->nthOfYear(2, $class::MONDAY);
+        $d = Chronos::createFromDate(1975, 8, 5)->nthOfYear(2, Chronos::MONDAY);
         $this->assertDateTime($d, 1975, 1, 13, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function test3rdWednesdayOfYear($class)
+    public function test3rdWednesdayOfYear()
     {
-        $d = $class::createFromDate(1975, 8, 5)->nthOfYear(3, 3);
+        $d = Chronos::createFromDate(1975, 8, 5)->nthOfYear(3, 3);
         $this->assertDateTime($d, 1975, 1, 15, 0, 0, 0);
     }
 }

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -29,296 +29,196 @@ class DiffTest extends TestCase
         parent::wrapWithTestNow($func, $dt ?? Chronos::createFromDate(2012, 1, 1));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInYearsPositive($class)
+    public function testDiffInYearsPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInYears($dt->addYears(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInYearsNegativeWithSign($class)
+    public function testDiffInYearsNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(-1, $dt->diffInYears($dt->subYears(1), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInYearsNegativeNoSign($class)
+    public function testDiffInYearsNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInYears($dt->subYears(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInYearsVsDefaultNow($class)
+    public function testDiffInYearsVsDefaultNow()
     {
-        $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(1, $class::now()->subYears(1)->diffInYears());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(1, Chronos::now()->subYears(1)->diffInYears());
         });
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInYearsEnsureIsTruncated($class)
+    public function testDiffInYearsEnsureIsTruncated()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInYears($dt->addYears(1)->addMonths(7)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMonthsPositive($class)
+    public function testDiffInMonthsPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(13, $dt->diffInMonths($dt->addYears(1)->addMonths(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMonthsNegativeWithSign($class)
+    public function testDiffInMonthsNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(-11, $dt->diffInMonths($dt->subYears(1)->addMonths(1), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMonthsNegativeNoSign($class)
+    public function testDiffInMonthsNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(11, $dt->diffInMonths($dt->subYears(1)->addMonths(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMonthsVsDefaultNow($class)
+    public function testDiffInMonthsVsDefaultNow()
     {
-        $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(12, $class::now()->subYears(1)->diffInMonths());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(12, Chronos::now()->subYears(1)->diffInMonths());
         });
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMonthsEnsureIsTruncated($class)
+    public function testDiffInMonthsEnsureIsTruncated()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInMonths($dt->addMonths(1)->addDays(16)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMonthsIgnoreTimezone($class)
+    public function testDiffInMonthsIgnoreTimezone()
     {
-        $tokyoStart = new $class('2019-06-01', new DateTimeZone('Asia/Tokyo'));
-        $utcStart = new $class('2019-06-01', new DateTimeZone('UTC'));
+        $tokyoStart = new Chronos('2019-06-01', new DateTimeZone('Asia/Tokyo'));
+        $utcStart = new Chronos('2019-06-01', new DateTimeZone('UTC'));
         foreach (range(1, 6) as $monthOffset) {
-            $end = new $class(sprintf('2019-%02d-01', 6 + $monthOffset), new DateTimeZone('Asia/Tokyo'));
+            $end = new Chronos(sprintf('2019-%02d-01', 6 + $monthOffset), new DateTimeZone('Asia/Tokyo'));
             $this->assertSame($monthOffset, $tokyoStart->diffInMonthsIgnoreTimezone($end));
             $this->assertSame($monthOffset, $utcStart->diffInMonthsIgnoreTimezone($end));
 
-            $end = new $class(sprintf('2020-%02d-01', 6 + $monthOffset), new DateTimeZone('Asia/Tokyo'));
+            $end = new Chronos(sprintf('2020-%02d-01', 6 + $monthOffset), new DateTimeZone('Asia/Tokyo'));
             $this->assertSame($monthOffset + 12, $tokyoStart->diffInMonthsIgnoreTimezone($end));
             $this->assertSame($monthOffset + 12, $utcStart->diffInMonthsIgnoreTimezone($end));
         }
 
-        $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(1, $class::now()->subMonths(1)->startOfMonth()->diffInMonthsIgnoreTimezone());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(1, Chronos::now()->subMonths(1)->startOfMonth()->diffInMonthsIgnoreTimezone());
         });
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysPositive($class)
+    public function testDiffInDaysPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(366, $dt->diffInDays($dt->addYears(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysNegativeWithSign($class)
+    public function testDiffInDaysNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(-365, $dt->diffInDays($dt->subYears(1), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysNegativeNoSign($class)
+    public function testDiffInDaysNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(365, $dt->diffInDays($dt->subYears(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysVsDefaultNow($class)
+    public function testDiffInDaysVsDefaultNow()
     {
-        $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(7, $class::now()->subWeeks(1)->diffInDays());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(7, Chronos::now()->subWeeks(1)->diffInDays());
         });
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysEnsureIsTruncated($class)
+    public function testDiffInDaysEnsureIsTruncated()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInDays($dt->addDays(1)->addHours(13)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysFilteredPositiveWithMutated($class)
+    public function testDiffInDaysFilteredPositiveWithMutated()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(5, $dt->diffInDaysFiltered(function ($date) {
             return $date->dayOfWeek === 1;
         }, $dt->endOfMonth()));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysFilteredPositiveWithSecondObject($class)
+    public function testDiffInDaysFilteredPositiveWithSecondObject()
     {
-        $dt1 = $class::createFromDate(2000, 1, 1);
-        $dt2 = $class::createFromDate(2000, 1, 31);
+        $dt1 = Chronos::createFromDate(2000, 1, 1);
+        $dt2 = Chronos::createFromDate(2000, 1, 31);
 
-        $this->assertSame(5, $dt1->diffInDaysFiltered(function ($date) use ($class) {
-            return $date->dayOfWeek === $class::SUNDAY;
+        $this->assertSame(5, $dt1->diffInDaysFiltered(function ($date) {
+            return $date->dayOfWeek === Chronos::SUNDAY;
         }, $dt2));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysFilteredNegativeNoSignWithMutated($class)
+    public function testDiffInDaysFilteredNegativeNoSignWithMutated()
     {
-        $dt = $class::createFromDate(2000, 1, 31);
-        $this->assertSame(5, $dt->diffInDaysFiltered(function ($date) use ($class) {
-            return $date->dayOfWeek === $class::SUNDAY;
+        $dt = Chronos::createFromDate(2000, 1, 31);
+        $this->assertSame(5, $dt->diffInDaysFiltered(function ($date) {
+            return $date->dayOfWeek === Chronos::SUNDAY;
         }, $dt->startOfMonth()));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysFilteredNegativeNoSignWithSecondObject($class)
+    public function testDiffInDaysFilteredNegativeNoSignWithSecondObject()
     {
-        $dt1 = $class::createFromDate(2000, 1, 31);
-        $dt2 = $class::createFromDate(2000, 1, 1);
+        $dt1 = Chronos::createFromDate(2000, 1, 31);
+        $dt2 = Chronos::createFromDate(2000, 1, 1);
 
-        $this->assertSame(5, $dt1->diffInDaysFiltered(function ($date) use ($class) {
-            return $date->dayOfWeek === $class::SUNDAY;
+        $this->assertSame(5, $dt1->diffInDaysFiltered(function ($date) {
+            return $date->dayOfWeek === Chronos::SUNDAY;
         }, $dt2));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysFilteredNegativeWithSignWithMutated($class)
+    public function testDiffInDaysFilteredNegativeWithSignWithMutated()
     {
-        $dt = $class::createFromDate(2000, 1, 31);
+        $dt = Chronos::createFromDate(2000, 1, 31);
         $this->assertSame(-5, $dt->diffInDaysFiltered(function ($date) {
             return $date->dayOfWeek === 1;
         }, $dt->startOfMonth(), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInDaysFilteredNegativeWithSignWithSecondObject($class)
+    public function testDiffInDaysFilteredNegativeWithSignWithSecondObject()
     {
-        $dt1 = $class::createFromDate(2000, 1, 31);
-        $dt2 = $class::createFromDate(2000, 1, 1);
+        $dt1 = Chronos::createFromDate(2000, 1, 31);
+        $dt2 = Chronos::createFromDate(2000, 1, 1);
 
-        $this->assertSame(-5, $dt1->diffInDaysFiltered(function ($date) use ($class) {
-            return $date->dayOfWeek === $class::SUNDAY;
+        $this->assertSame(-5, $dt1->diffInDaysFiltered(function ($date) {
+            return $date->dayOfWeek === Chronos::SUNDAY;
         }, $dt2, false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInHoursFiltered($class)
+    public function testDiffInHoursFiltered()
     {
-        $dt1 = $class::createFromDate(2000, 1, 31)->endOfDay();
-        $dt2 = $class::createFromDate(2000, 1, 1)->startOfDay();
+        $dt1 = Chronos::createFromDate(2000, 1, 31)->endOfDay();
+        $dt2 = Chronos::createFromDate(2000, 1, 1)->startOfDay();
 
         $this->assertSame(31, $dt1->diffInHoursFiltered(function ($date) {
             return $date->hour === 9;
         }, $dt2));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInHoursFilteredNegative($class)
+    public function testDiffInHoursFilteredNegative()
     {
-        $dt1 = $class::createFromDate(2000, 1, 31)->endOfDay();
-        $dt2 = $class::createFromDate(2000, 1, 1)->startOfDay();
+        $dt1 = Chronos::createFromDate(2000, 1, 31)->endOfDay();
+        $dt2 = Chronos::createFromDate(2000, 1, 1)->startOfDay();
 
         $this->assertSame(-31, $dt1->diffInHoursFiltered(function ($date) {
             return $date->hour === 9;
         }, $dt2, false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInHoursFilteredWorkHoursPerWeek($class)
+    public function testDiffInHoursFilteredWorkHoursPerWeek()
     {
-        $dt1 = $class::createFromDate(2000, 1, 5)->endOfDay();
-        $dt2 = $class::createFromDate(2000, 1, 1)->startOfDay();
+        $dt1 = Chronos::createFromDate(2000, 1, 5)->endOfDay();
+        $dt2 = Chronos::createFromDate(2000, 1, 1)->startOfDay();
 
         $this->assertSame(40, $dt1->diffInHoursFiltered(function ($date) {
             return $date->hour > 8 && $date->hour < 17;
@@ -440,353 +340,221 @@ class DiffTest extends TestCase
         }, $dt2, false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBug188DiffWithSameDates($class)
+    public function testBug188DiffWithSameDates()
     {
-        $start = $class::create(2014, 10, 8, 15, 20, 0);
+        $start = Chronos::create(2014, 10, 8, 15, 20, 0);
         $end = clone $start;
 
         $this->assertSame(0, $start->diffInDays($end));
         $this->assertSame(0, $start->diffInWeekdays($end));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBug188DiffWithDatesOnlyHoursApart($class)
+    public function testBug188DiffWithDatesOnlyHoursApart()
     {
-        $start = $class::create(2014, 10, 8, 15, 20, 0);
+        $start = Chronos::create(2014, 10, 8, 15, 20, 0);
         $end = clone $start;
 
         $this->assertSame(0, $start->diffInDays($end));
         $this->assertSame(0, $start->diffInWeekdays($end));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBug188DiffWithSameDates1DayApart($class)
+    public function testBug188DiffWithSameDates1DayApart()
     {
-        $start = $class::create(2014, 10, 8, 15, 20, 0);
+        $start = Chronos::create(2014, 10, 8, 15, 20, 0);
         $end = $start->addDays(1);
 
         $this->assertSame(1, $start->diffInDays($end));
         $this->assertSame(1, $start->diffInWeekdays($end));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testBug188DiffWithDatesOnTheWeekend($class)
+    public function testBug188DiffWithDatesOnTheWeekend()
     {
-        $start = $class::create(2014, 1, 1, 0, 0, 0);
-        $start = $start->next($class::SATURDAY);
+        $start = Chronos::create(2014, 1, 1, 0, 0, 0);
+        $start = $start->next(Chronos::SATURDAY);
         $end = $start->addDays(1);
 
         $this->assertSame(1, $start->diffInDays($end));
         $this->assertSame(0, $start->diffInWeekdays($end));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeekdaysPositive($class)
+    public function testDiffInWeekdaysPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(21, $dt->diffInWeekdays($dt->endOfMonth()));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeekdaysNegativeNoSign($class)
+    public function testDiffInWeekdaysNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 31);
+        $dt = Chronos::createFromDate(2000, 1, 31);
         $this->assertSame(21, $dt->diffInWeekdays($dt->startOfMonth()));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeekdaysNegativeWithSign($class)
+    public function testDiffInWeekdaysNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 31);
+        $dt = Chronos::createFromDate(2000, 1, 31);
         $this->assertSame(-21, $dt->diffInWeekdays($dt->startOfMonth(), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeekendDaysPositive($class)
+    public function testDiffInWeekendDaysPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(10, $dt->diffInWeekendDays($dt->endOfMonth()));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeekendDaysNegativeNoSign($class)
+    public function testDiffInWeekendDaysNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 31);
+        $dt = Chronos::createFromDate(2000, 1, 31);
         $this->assertSame(10, $dt->diffInWeekendDays($dt->startOfMonth()));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeekendDaysNegativeWithSign($class)
+    public function testDiffInWeekendDaysNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 31);
+        $dt = Chronos::createFromDate(2000, 1, 31);
         $this->assertSame(-10, $dt->diffInWeekendDays($dt->startOfMonth(), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeeksPositive($class)
+    public function testDiffInWeeksPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(52, $dt->diffInWeeks($dt->addYears(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeeksNegativeWithSign($class)
+    public function testDiffInWeeksNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(-52, $dt->diffInWeeks($dt->subYears(1), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeeksNegativeNoSign($class)
+    public function testDiffInWeeksNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(52, $dt->diffInWeeks($dt->subYears(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeeksVsDefaultNow($class)
+    public function testDiffInWeeksVsDefaultNow()
     {
-        $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(1, $class::now()->subWeeks(1)->diffInWeeks());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(1, Chronos::now()->subWeeks(1)->diffInWeeks());
         });
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInWeeksEnsureIsTruncated($class)
+    public function testDiffInWeeksEnsureIsTruncated()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(0, $dt->diffInWeeks($dt->addWeeks(1)->subDays(1)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInHoursPositive($class)
+    public function testDiffInHoursPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(26, $dt->diffInHours($dt->addDays(1)->addHours(2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInHoursNegativeWithSign($class)
+    public function testDiffInHoursNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(-22, $dt->diffInHours($dt->subDays(1)->addHours(2), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInHoursNegativeNoSign($class)
+    public function testDiffInHoursNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(22, $dt->diffInHours($dt->subDays(1)->addHours(2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInHoursVsDefaultNow($class)
+    public function testDiffInHoursVsDefaultNow()
     {
         date_default_timezone_set('UTC');
-        $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(48, $class::now()->subDays(2)->diffInHours());
-        }, $class::create(2012, 1, 15));
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(48, Chronos::now()->subDays(2)->diffInHours());
+        }, Chronos::create(2012, 1, 15));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInHoursEnsureIsTruncated($class)
+    public function testDiffInHoursEnsureIsTruncated()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInHours($dt->addHours(1)->addMinutes(31)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMinutesPositive($class)
+    public function testDiffInMinutesPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(62, $dt->diffInMinutes($dt->addHours(1)->addMinutes(2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMinutesPositiveAlot($class)
+    public function testDiffInMinutesPositiveAlot()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(1502, $dt->diffInMinutes($dt->addHours(25)->addMinutes(2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMinutesNegativeWithSign($class)
+    public function testDiffInMinutesNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(-58, $dt->diffInMinutes($dt->subHours(1)->addMinutes(2), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMinutesNegativeNoSign($class)
+    public function testDiffInMinutesNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(58, $dt->diffInMinutes($dt->subHours(1)->addMinutes(2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMinutesVsDefaultNow($class)
+    public function testDiffInMinutesVsDefaultNow()
     {
-        $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(60, $class::now()->subHours(1)->diffInMinutes());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(60, Chronos::now()->subHours(1)->diffInMinutes());
         });
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInMinutesEnsureIsTruncated($class)
+    public function testDiffInMinutesEnsureIsTruncated()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(1, $dt->diffInMinutes($dt->addMinutes(1)->addSeconds(31)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInSecondsPositive($class)
+    public function testDiffInSecondsPositive()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(62, $dt->diffInSeconds($dt->addMinutes(1)->addSeconds(2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInSecondsPositiveAlot($class)
+    public function testDiffInSecondsPositiveAlot()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(7202, $dt->diffInSeconds($dt->addHours(2)->addSeconds(2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInSecondsNegativeWithSign($class)
+    public function testDiffInSecondsNegativeWithSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(-58, $dt->diffInSeconds($dt->subMinutes(1)->addSeconds(2), false));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInSecondsNegativeNoSign($class)
+    public function testDiffInSecondsNegativeNoSign()
     {
-        $dt = $class::createFromDate(2000, 1, 1);
+        $dt = Chronos::createFromDate(2000, 1, 1);
         $this->assertSame(58, $dt->diffInSeconds($dt->subMinutes(1)->addSeconds(2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInSecondsVsDefaultNow($class)
+    public function testDiffInSecondsVsDefaultNow()
     {
-        $this->wrapWithTestNow(function () use ($class) {
-            $this->assertSame(3600, $class::now()->subHours(1)->diffInSeconds());
+        $this->wrapWithTestNow(function () {
+            $this->assertSame(3600, Chronos::now()->subHours(1)->diffInSeconds());
         });
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInSecondsWithTimezones($class)
+    public function testDiffInSecondsWithTimezones()
     {
-        $dtOttawa = $class::createFromDate(2000, 1, 1, 'America/Toronto');
-        $dtVancouver = $class::createFromDate(2000, 1, 1, 'America/Vancouver');
+        $dtOttawa = Chronos::createFromDate(2000, 1, 1, 'America/Toronto');
+        $dtVancouver = Chronos::createFromDate(2000, 1, 1, 'America/Vancouver');
         $this->assertSame(3 * 60 * 60, $dtOttawa->diffInSeconds($dtVancouver));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDiffInSecondsWithTimezonesAndVsDefaulessThan($class)
+    public function testDiffInSecondsWithTimezonesAndVsDefaulessThan()
     {
-        $vanNow = $class::now('America/Vancouver');
-        $hereNow = $vanNow->setTimezone($class::now()->tz);
+        $vanNow = Chronos::now('America/Vancouver');
+        $hereNow = $vanNow->setTimezone(Chronos::now()->tz);
 
         $this->wrapWithTestNow(function () use ($vanNow) {
             $this->assertSame(0, $vanNow->diffInSeconds());
@@ -795,17 +563,14 @@ class DiffTest extends TestCase
 
     /**
      * Tests the "from now" time calculation.
-     *
-     * @dataProvider classNameProvider
-     * @return void
      */
-    public function testFromNow($class)
+    public function testFromNow()
     {
-        $date = $class::now();
+        $date = Chronos::now();
         $date = $date->modify('-1 year')
             ->modify('-6 days')
             ->modify('-51 seconds');
-        $interval = $class::fromNow($date);
+        $interval = Chronos::fromNow($date);
         $result = $interval->format('%y %m %d %H %i %s');
         $this->assertSame($result, '1 0 6 00 0 51');
     }

--- a/tests/TestCase/DateTime/FluidSettersTest.php
+++ b/tests/TestCase/DateTime/FluidSettersTest.php
@@ -15,189 +15,130 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class FluidSettersTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidYearSetter($class)
+    public function testFluidYearSetter()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->year(1995);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(1995, $d->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidMonthSetter($class)
+    public function testFluidMonthSetter()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->month(3);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(3, $d->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidMonthSetterWithWrap($class)
+    public function testFluidMonthSetterWithWrap()
     {
-        $d = $class::createFromDate(2012, 8, 21);
+        $d = Chronos::createFromDate(2012, 8, 21);
         $d = $d->month(13);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(1, $d->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidDaySetter($class)
+    public function testFluidDaySetter()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->day(2);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(2, $d->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidDaySetterWithWrap($class)
+    public function testFluidDaySetterWithWrap()
     {
-        $d = $class::createFromDate(2000, 1, 1);
+        $d = Chronos::createFromDate(2000, 1, 1);
         $d = $d->day(32);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(1, $d->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidSetDate($class)
+    public function testFluidSetDate()
     {
-        $d = $class::createFromDate(2000, 1, 1);
+        $d = Chronos::createFromDate(2000, 1, 1);
         $d = $d->setDate(1995, 13, 32);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertDateTime($d, 1996, 2, 1);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidHourSetter($class)
+    public function testFluidHourSetter()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->hour(2);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(2, $d->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidHourSetterWithWrap($class)
+    public function testFluidHourSetterWithWrap()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->hour(25);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(1, $d->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidMinuteSetter($class)
+    public function testFluidMinuteSetter()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->minute(2);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(2, $d->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidMinuteSetterWithWrap($class)
+    public function testFluidMinuteSetterWithWrap()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->minute(61);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(1, $d->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidSecondSetter($class)
+    public function testFluidSecondSetter()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->second(2);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(2, $d->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidSecondSetterWithWrap($class)
+    public function testFluidSecondSetterWithWrap()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->second(62);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(2, $d->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidMicroecondSetter($class)
+    public function testFluidMicroecondSetter()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $second = $d->second;
         $d = $d->microsecond(2);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(2, $d->microsecond);
         $this->assertSame($second, $d->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidSetTime($class)
+    public function testFluidSetTime()
     {
-        $d = $class::createFromDate(2000, 1, 1);
+        $d = Chronos::createFromDate(2000, 1, 1);
         $d = $d->setTime(25, 61, 61);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertDateTime($d, 2000, 1, 2, 2, 2, 1);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testFluidTimestampSetter($class)
+    public function testFluidTimestampSetter()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $d = $d->timestamp(10);
-        $this->assertTrue($d instanceof $class);
+        $this->assertTrue($d instanceof Chronos);
         $this->assertSame(10, $d->timestamp);
     }
 }

--- a/tests/TestCase/DateTime/GettersTest.php
+++ b/tests/TestCase/DateTime/GettersTest.php
@@ -15,172 +15,109 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosInterface;
 use Cake\Chronos\Test\TestCase\TestCase;
 use InvalidArgumentException;
 
 class GettersTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGettersThrowExceptionOnUnknownGetter($class)
+    public function testGettersThrowExceptionOnUnknownGetter()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $class::create(1234, 5, 6, 7, 8, 9)->sdfsdfss;
+        Chronos::create(1234, 5, 6, 7, 8, 9)->sdfsdfss;
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testYearGetter($class)
+    public function testYearGetter()
     {
-        $d = $class::create(1234, 5, 6, 7, 8, 9);
+        $d = Chronos::create(1234, 5, 6, 7, 8, 9);
         $this->assertSame(1234, $d->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testYearIsoGetter($class)
+    public function testYearIsoGetter()
     {
-        $d = $class::createFromDate(2012, 12, 31);
+        $d = Chronos::createFromDate(2012, 12, 31);
         $this->assertSame(2013, $d->yearIso);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMonthGetter($class)
+    public function testMonthGetter()
     {
-        $d = $class::create(1234, 5, 6, 7, 8, 9);
+        $d = Chronos::create(1234, 5, 6, 7, 8, 9);
         $this->assertSame(5, $d->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDayGetter($class)
+    public function testDayGetter()
     {
-        $d = $class::create(1234, 5, 6, 7, 8, 9);
+        $d = Chronos::create(1234, 5, 6, 7, 8, 9);
         $this->assertSame(6, $d->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testHourGetter($class)
+    public function testHourGetter()
     {
-        $d = $class::create(1234, 5, 6, 7, 8, 9);
+        $d = Chronos::create(1234, 5, 6, 7, 8, 9);
         $this->assertSame(7, $d->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMinuteGetter($class)
+    public function testMinuteGetter()
     {
-        $d = $class::create(1234, 5, 6, 7, 8, 9);
+        $d = Chronos::create(1234, 5, 6, 7, 8, 9);
         $this->assertSame(8, $d->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSecondGetter($class)
+    public function testSecondGetter()
     {
-        $d = $class::create(1234, 5, 6, 7, 8, 9);
+        $d = Chronos::create(1234, 5, 6, 7, 8, 9);
         $this->assertSame(9, $d->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMicroGetter($class)
+    public function testMicroGetter()
     {
         $micro = 345678;
-        $d = $class::parse('2014-01-05 12:34:11.' . $micro);
+        $d = Chronos::parse('2014-01-05 12:34:11.' . $micro);
         $this->assertSame($micro, $d->micro);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDayOfWeekGetter($class)
+    public function testDayOfWeekGetter()
     {
-        $d = $class::create(2012, 5, 7, 7, 8, 9);
-        $this->assertSame($class::MONDAY, $d->dayOfWeek);
+        $d = Chronos::create(2012, 5, 7, 7, 8, 9);
+        $this->assertSame(Chronos::MONDAY, $d->dayOfWeek);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDayOfWeekNameGetter($class)
+    public function testDayOfWeekNameGetter()
     {
-        $d = $class::create(2012, 5, 7, 7, 8, 9);
+        $d = Chronos::create(2012, 5, 7, 7, 8, 9);
         $this->assertSame('Monday', $d->dayOfWeekName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDayOfYearGetter($class)
+    public function testDayOfYearGetter()
     {
-        $d = $class::createFromDate(2012, 5, 7);
+        $d = Chronos::createFromDate(2012, 5, 7);
         $this->assertSame(127, $d->dayOfYear);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testDaysInMonthGetter($class)
+    public function testDaysInMonthGetter()
     {
-        $d = $class::createFromDate(2012, 5, 7);
+        $d = Chronos::createFromDate(2012, 5, 7);
         $this->assertSame(31, $d->daysInMonth);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testTimestampGetter($class)
+    public function testTimestampGetter()
     {
-        $d = $class::create();
+        $d = Chronos::create();
         $d = $d->setTimezone('GMT')->setDateTime(1970, 1, 1, 0, 0, 0);
         $this->assertSame(0, $d->timestamp);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetAge($class)
+    public function testGetAge()
     {
-        $d = $class::now();
+        $d = Chronos::now();
         $this->assertSame(0, $d->age);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetAgeWithRealAge($class)
+    public function testGetAgeWithRealAge()
     {
-        $d = $class::createFromDate(1975, 5, 21);
+        $d = Chronos::createFromDate(1975, 5, 21);
         $age = intval(substr(
             (string)(date('Ymd') - date('Ymd', $d->timestamp)),
             0,
@@ -190,312 +127,192 @@ class GettersTest extends TestCase
         $this->assertSame($age, $d->age);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetQuarterFirst($class)
+    public function testGetQuarterFirst()
     {
-        $d = $class::createFromDate(2012, 1, 1);
+        $d = Chronos::createFromDate(2012, 1, 1);
         $this->assertSame(1, $d->quarter);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetQuarterFirstEnd($class)
+    public function testGetQuarterFirstEnd()
     {
-        $d = $class::createFromDate(2012, 3, 31);
+        $d = Chronos::createFromDate(2012, 3, 31);
         $this->assertSame(1, $d->quarter);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetQuarterSecond($class)
+    public function testGetQuarterSecond()
     {
-        $d = $class::createFromDate(2012, 4, 1);
+        $d = Chronos::createFromDate(2012, 4, 1);
         $this->assertSame(2, $d->quarter);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetQuarterThird($class)
+    public function testGetQuarterThird()
     {
-        $d = $class::createFromDate(2012, 7, 1);
+        $d = Chronos::createFromDate(2012, 7, 1);
         $this->assertSame(3, $d->quarter);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetQuarterFourth($class)
+    public function testGetQuarterFourth()
     {
-        $d = $class::createFromDate(2012, 10, 1);
+        $d = Chronos::createFromDate(2012, 10, 1);
         $this->assertSame(4, $d->quarter);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetQuarterFirstLast($class)
+    public function testGetQuarterFirstLast()
     {
-        $d = $class::createFromDate(2012, 12, 31);
+        $d = Chronos::createFromDate(2012, 12, 31);
         $this->assertSame(4, $d->quarter);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetLocalTrue($class)
+    public function testGetLocalTrue()
     {
         // Default timezone has been set to America/Toronto in TestCase.php
         // @see : http://en.wikipedia.org/wiki/List_of_UTC_time_offsets
-        $this->assertTrue($class::createFromDate(2012, 1, 1, 'America/Toronto')->local);
-        $this->assertTrue($class::createFromDate(2012, 1, 1, 'America/New_York')->local);
+        $this->assertTrue(Chronos::createFromDate(2012, 1, 1, 'America/Toronto')->local);
+        $this->assertTrue(Chronos::createFromDate(2012, 1, 1, 'America/New_York')->local);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetLocalFalse($class)
+    public function testGetLocalFalse()
     {
-        $this->assertFalse($class::createFromDate(2012, 7, 1, 'UTC')->local);
-        $this->assertFalse($class::createFromDate(2012, 7, 1, 'Europe/London')->local);
+        $this->assertFalse(Chronos::createFromDate(2012, 7, 1, 'UTC')->local);
+        $this->assertFalse(Chronos::createFromDate(2012, 7, 1, 'Europe/London')->local);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetUtcFalse($class)
+    public function testGetUtcFalse()
     {
-        $this->assertFalse($class::createFromDate(2013, 1, 1, 'America/Toronto')->utc);
-        $this->assertFalse($class::createFromDate(2013, 1, 1, 'Europe/Paris')->utc);
+        $this->assertFalse(Chronos::createFromDate(2013, 1, 1, 'America/Toronto')->utc);
+        $this->assertFalse(Chronos::createFromDate(2013, 1, 1, 'Europe/Paris')->utc);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetUtcTrue($class)
+    public function testGetUtcTrue()
     {
-        $this->assertTrue($class::createFromDate(2013, 1, 1, 'Atlantic/Reykjavik')->utc);
-        $this->assertTrue($class::createFromDate(2013, 1, 1, 'Europe/Lisbon')->utc);
-        $this->assertTrue($class::createFromDate(2013, 1, 1, 'Africa/Casablanca')->utc);
-        $this->assertTrue($class::createFromDate(2013, 1, 1, 'Africa/Dakar')->utc);
-        $this->assertTrue($class::createFromDate(2013, 1, 1, 'Europe/Dublin')->utc);
-        $this->assertTrue($class::createFromDate(2013, 1, 1, 'Europe/London')->utc);
-        $this->assertTrue($class::createFromDate(2013, 1, 1, 'UTC')->utc);
-        $this->assertTrue($class::createFromDate(2013, 1, 1, 'GMT')->utc);
+        $this->assertTrue(Chronos::createFromDate(2013, 1, 1, 'Atlantic/Reykjavik')->utc);
+        $this->assertTrue(Chronos::createFromDate(2013, 1, 1, 'Europe/Lisbon')->utc);
+        $this->assertTrue(Chronos::createFromDate(2013, 1, 1, 'Africa/Casablanca')->utc);
+        $this->assertTrue(Chronos::createFromDate(2013, 1, 1, 'Africa/Dakar')->utc);
+        $this->assertTrue(Chronos::createFromDate(2013, 1, 1, 'Europe/Dublin')->utc);
+        $this->assertTrue(Chronos::createFromDate(2013, 1, 1, 'Europe/London')->utc);
+        $this->assertTrue(Chronos::createFromDate(2013, 1, 1, 'UTC')->utc);
+        $this->assertTrue(Chronos::createFromDate(2013, 1, 1, 'GMT')->utc);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetDstFalse($class)
+    public function testGetDstFalse()
     {
-        $this->assertFalse($class::createFromDate(2012, 1, 1, 'America/Toronto')->dst);
+        $this->assertFalse(Chronos::createFromDate(2012, 1, 1, 'America/Toronto')->dst);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetDstTrue($class)
+    public function testGetDstTrue()
     {
-        $this->assertTrue($class::createFromDate(2012, 7, 1, 'America/Toronto')->dst);
+        $this->assertTrue(Chronos::createFromDate(2012, 7, 1, 'America/Toronto')->dst);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testOffsetForTorontoWithDST($class)
+    public function testOffsetForTorontoWithDST()
     {
-        $this->assertSame(-18000, $class::createFromDate(2012, 1, 1, 'America/Toronto')->offset);
+        $this->assertSame(-18000, Chronos::createFromDate(2012, 1, 1, 'America/Toronto')->offset);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testOffsetForTorontoNoDST($class)
+    public function testOffsetForTorontoNoDST()
     {
-        $this->assertSame(-14400, $class::createFromDate(2012, 6, 1, 'America/Toronto')->offset);
+        $this->assertSame(-14400, Chronos::createFromDate(2012, 6, 1, 'America/Toronto')->offset);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testOffsetForGMT($class)
+    public function testOffsetForGMT()
     {
-        $this->assertSame(0, $class::createFromDate(2012, 6, 1, 'GMT')->offset);
+        $this->assertSame(0, Chronos::createFromDate(2012, 6, 1, 'GMT')->offset);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testOffsetHoursForTorontoWithDST($class)
+    public function testOffsetHoursForTorontoWithDST()
     {
-        $this->assertSame(-5, $class::createFromDate(2012, 1, 1, 'America/Toronto')->offsetHours);
+        $this->assertSame(-5, Chronos::createFromDate(2012, 1, 1, 'America/Toronto')->offsetHours);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testOffsetHoursForTorontoNoDST($class)
+    public function testOffsetHoursForTorontoNoDST()
     {
-        $this->assertSame(-4, $class::createFromDate(2012, 6, 1, 'America/Toronto')->offsetHours);
+        $this->assertSame(-4, Chronos::createFromDate(2012, 6, 1, 'America/Toronto')->offsetHours);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testOffsetHoursForGMT($class)
+    public function testOffsetHoursForGMT()
     {
-        $this->assertSame(0, $class::createFromDate(2012, 6, 1, 'GMT')->offsetHours);
+        $this->assertSame(0, Chronos::createFromDate(2012, 6, 1, 'GMT')->offsetHours);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLeapYearTrue($class)
+    public function testIsLeapYearTrue()
     {
-        $this->assertTrue($class::createFromDate(2012, 1, 1)->isLeapYear());
+        $this->assertTrue(Chronos::createFromDate(2012, 1, 1)->isLeapYear());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLeapYearFalse($class)
+    public function testIsLeapYearFalse()
     {
-        $this->assertFalse($class::createFromDate(2011, 1, 1)->isLeapYear());
+        $this->assertFalse(Chronos::createFromDate(2011, 1, 1)->isLeapYear());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testWeekOfMonth($class)
+    public function testWeekOfMonth()
     {
-        $this->assertSame(5, $class::createFromDate(2012, 9, 30)->weekOfMonth);
-        $this->assertSame(4, $class::createFromDate(2012, 9, 28)->weekOfMonth);
-        $this->assertSame(3, $class::createFromDate(2012, 9, 20)->weekOfMonth);
-        $this->assertSame(2, $class::createFromDate(2012, 9, 8)->weekOfMonth);
-        $this->assertSame(1, $class::createFromDate(2012, 9, 1)->weekOfMonth);
+        $this->assertSame(5, Chronos::createFromDate(2012, 9, 30)->weekOfMonth);
+        $this->assertSame(4, Chronos::createFromDate(2012, 9, 28)->weekOfMonth);
+        $this->assertSame(3, Chronos::createFromDate(2012, 9, 20)->weekOfMonth);
+        $this->assertSame(2, Chronos::createFromDate(2012, 9, 8)->weekOfMonth);
+        $this->assertSame(1, Chronos::createFromDate(2012, 9, 1)->weekOfMonth);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testWeekOfYearFirstWeek($class)
+    public function testWeekOfYearFirstWeek()
     {
-        $this->assertSame(52, $class::createFromDate(2012, 1, 1)->weekOfYear);
-        $this->assertSame(1, $class::createFromDate(2012, 1, 2)->weekOfYear);
+        $this->assertSame(52, Chronos::createFromDate(2012, 1, 1)->weekOfYear);
+        $this->assertSame(1, Chronos::createFromDate(2012, 1, 2)->weekOfYear);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testWeekOfYearLastWeek($class)
+    public function testWeekOfYearLastWeek()
     {
-        $this->assertSame(52, $class::createFromDate(2012, 12, 30)->weekOfYear);
-        $this->assertSame(1, $class::createFromDate(2012, 12, 31)->weekOfYear);
+        $this->assertSame(52, Chronos::createFromDate(2012, 12, 30)->weekOfYear);
+        $this->assertSame(1, Chronos::createFromDate(2012, 12, 31)->weekOfYear);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetWeekStartsAt($class)
+    public function testGetWeekStartsAt()
     {
-        $d = $class::createFromDate(2012, 12, 31);
+        $d = Chronos::createFromDate(2012, 12, 31);
         $this->assertSame(ChronosInterface::MONDAY, $d->getWeekStartsAt());
 
         $d::setWeekStartsAt(ChronosInterface::SUNDAY);
         $this->assertSame(ChronosInterface::SUNDAY, $d->getWeekStartsAt());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetWeekEndsAt($class)
+    public function testGetWeekEndsAt()
     {
-        $d = $class::createFromDate(2012, 12, 31);
+        $d = Chronos::createFromDate(2012, 12, 31);
         $this->assertSame(ChronosInterface::SUNDAY, $d->getWeekEndsAt());
 
         $d::setWeekEndsAt(ChronosInterface::SATURDAY);
         $this->assertSame(ChronosInterface::SATURDAY, $d->getWeekEndsAt());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetTimezone($class)
+    public function testGetTimezone()
     {
-        $dt = $class::createFromDate(2000, 1, 1, 'America/Toronto');
+        $dt = Chronos::createFromDate(2000, 1, 1, 'America/Toronto');
         $this->assertSame('America/Toronto', $dt->timezone->getName());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetTz($class)
+    public function testGetTz()
     {
-        $dt = $class::createFromDate(2000, 1, 1, 'America/Toronto');
+        $dt = Chronos::createFromDate(2000, 1, 1, 'America/Toronto');
         $this->assertSame('America/Toronto', $dt->tz->getName());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetTimezoneName($class)
+    public function testGetTimezoneName()
     {
-        $dt = $class::createFromDate(2000, 1, 1, 'America/Toronto');
+        $dt = Chronos::createFromDate(2000, 1, 1, 'America/Toronto');
         $this->assertSame('America/Toronto', $dt->timezoneName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testGetTzName($class)
+    public function testGetTzName()
     {
-        $dt = $class::createFromDate(2000, 1, 1, 'America/Toronto');
+        $dt = Chronos::createFromDate(2000, 1, 1, 'America/Toronto');
         $this->assertSame('America/Toronto', $dt->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testInvalidGetter($class)
+    public function testInvalidGetter()
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $d = $class::now();
+        $d = Chronos::now();
         $bb = $d->doesNotExit;
     }
 }

--- a/tests/TestCase/DateTime/InstanceTest.php
+++ b/tests/TestCase/DateTime/InstanceTest.php
@@ -15,55 +15,40 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTime;
 use DateTimeZone;
 
 class InstanceTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testInstanceFromDateTime($class)
+    public function testInstanceFromDateTime()
     {
-        $dating = $class::instance(DateTime::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11'));
+        $dating = Chronos::instance(DateTime::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11'));
         $this->assertDateTime($dating, 1975, 5, 21, 22, 32, 11);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testInstanceFromDateTimeKeepsTimezoneName($class)
+    public function testInstanceFromDateTimeKeepsTimezoneName()
     {
-        $dating = $class::instance(DateTime::createFromFormat(
+        $dating = Chronos::instance(DateTime::createFromFormat(
             'Y-m-d H:i:s',
             '1975-05-21 22:32:11'
         )->setTimezone(new DateTimeZone('America/Vancouver')));
         $this->assertSame('America/Vancouver', $dating->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testInstanceFromDateTimeKeepsMicros($class)
+    public function testInstanceFromDateTimeKeepsMicros()
     {
         $micro = 254687;
         $datetime = DateTime::createFromFormat('Y-m-d H:i:s.u', '2014-02-01 03:45:27.' . $micro);
-        $carbon = $class::instance($datetime);
+        $carbon = Chronos::instance($datetime);
         $this->assertSame($micro, $carbon->micro);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testCreateFromFormatErrors($class)
+    public function testCreateFromFormatErrors()
     {
-        $class::createFromFormat('d/m/Y', '41/02/1900');
-        $errors = $class::getLastErrors();
+        Chronos::createFromFormat('d/m/Y', '41/02/1900');
+        $errors = Chronos::getLastErrors();
         $expected = [
             'warning_count' => 1,
             'warnings' => [

--- a/tests/TestCase/DateTime/IsTest.php
+++ b/tests/TestCase/DateTime/IsTest.php
@@ -15,514 +15,341 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class IsTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsWeekdayTrue($class)
+    public function testIsWeekdayTrue()
     {
-        $this->assertTrue($class::createFromDate(2012, 1, 2)->isWeekday());
+        $this->assertTrue(Chronos::createFromDate(2012, 1, 2)->isWeekday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsWeekdayFalse($class)
+    public function testIsWeekdayFalse()
     {
-        $this->assertFalse($class::createFromDate(2012, 1, 1)->isWeekday());
+        $this->assertFalse(Chronos::createFromDate(2012, 1, 1)->isWeekday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsWeekendTrue($class)
+    public function testIsWeekendTrue()
     {
-        $this->assertTrue($class::createFromDate(2012, 1, 1)->isWeekend());
+        $this->assertTrue(Chronos::createFromDate(2012, 1, 1)->isWeekend());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsWeekendFalse($class)
+    public function testIsWeekendFalse()
     {
-        $this->assertFalse($class::createFromDate(2012, 1, 2)->isWeekend());
+        $this->assertFalse(Chronos::createFromDate(2012, 1, 2)->isWeekend());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsYesterdayTrue($class)
+    public function testIsYesterdayTrue()
     {
-        $this->assertTrue($class::now()->subDays(1)->isYesterday());
+        $this->assertTrue(Chronos::now()->subDays(1)->isYesterday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsYesterdayFalseWithToday($class)
+    public function testIsYesterdayFalseWithToday()
     {
-        $this->assertFalse($class::now()->endOfDay()->isYesterday());
+        $this->assertFalse(Chronos::now()->endOfDay()->isYesterday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsYesterdayFalseWith2Days($class)
+    public function testIsYesterdayFalseWith2Days()
     {
-        $this->assertFalse($class::now()->subDays(2)->startOfDay()->isYesterday());
+        $this->assertFalse(Chronos::now()->subDays(2)->startOfDay()->isYesterday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsTodayTrue($class)
+    public function testIsTodayTrue()
     {
-        $this->assertTrue($class::now()->isToday());
+        $this->assertTrue(Chronos::now()->isToday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsTodayFalseWithYesterday($class)
+    public function testIsTodayFalseWithYesterday()
     {
-        $this->assertFalse($class::now()->subDays(1)->endOfDay()->isToday());
+        $this->assertFalse(Chronos::now()->subDays(1)->endOfDay()->isToday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsTodayFalseWithTomorrow($class)
+    public function testIsTodayFalseWithTomorrow()
     {
-        $this->assertFalse($class::now()->addDays(1)->startOfDay()->isToday());
+        $this->assertFalse(Chronos::now()->addDays(1)->startOfDay()->isToday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsTodayWithTimezone($class)
+    public function testIsTodayWithTimezone()
     {
-        $this->assertTrue($class::now('Asia/Tokyo')->isToday());
+        $this->assertTrue(Chronos::now('Asia/Tokyo')->isToday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsTomorrowTrue($class)
+    public function testIsTomorrowTrue()
     {
-        $this->assertTrue($class::now()->addDays(1)->isTomorrow());
+        $this->assertTrue(Chronos::now()->addDays(1)->isTomorrow());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsTomorrowFalseWithToday($class)
+    public function testIsTomorrowFalseWithToday()
     {
-        $this->assertFalse($class::now()->endOfDay()->isTomorrow());
+        $this->assertFalse(Chronos::now()->endOfDay()->isTomorrow());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsTomorrowFalseWith2Days($class)
+    public function testIsTomorrowFalseWith2Days()
     {
-        $this->assertFalse($class::now()->addDays(2)->startOfDay()->isTomorrow());
+        $this->assertFalse(Chronos::now()->addDays(2)->startOfDay()->isTomorrow());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsNextWeekTrue($class)
+    public function testIsNextWeekTrue()
     {
-        $this->assertTrue($class::now()->addWeeks(1)->isNextWeek());
+        $this->assertTrue(Chronos::now()->addWeeks(1)->isNextWeek());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLastWeekTrue($class)
+    public function testIsLastWeekTrue()
     {
-        $this->assertTrue($class::now()->subWeeks(1)->isLastWeek());
+        $this->assertTrue(Chronos::now()->subWeeks(1)->isLastWeek());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsNextWeekFalse($class)
+    public function testIsNextWeekFalse()
     {
-        $this->assertFalse($class::now()->addWeeks(2)->isNextWeek());
+        $this->assertFalse(Chronos::now()->addWeeks(2)->isNextWeek());
 
-        $class::setTestNow('2017-W01');
-        $time = new $class('2018-W02');
+        Chronos::setTestNow('2017-W01');
+        $time = new Chronos('2018-W02');
         $this->assertFalse($time->isNextWeek());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLastWeekFalse($class)
+    public function testIsLastWeekFalse()
     {
-        $this->assertFalse($class::now()->subWeeks(2)->isLastWeek());
+        $this->assertFalse(Chronos::now()->subWeeks(2)->isLastWeek());
 
-        $class::setTestNow('2018-W02');
-        $time = new $class('2017-W01');
+        Chronos::setTestNow('2018-W02');
+        $time = new Chronos('2017-W01');
         $this->assertFalse($time->isLastWeek());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsNextMonthTrue($class)
+    public function testIsNextMonthTrue()
     {
-        $this->assertTrue($class::now()->addMonths(1)->isNextMonth());
+        $this->assertTrue(Chronos::now()->addMonths(1)->isNextMonth());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLastMonthTrue($class)
+    public function testIsLastMonthTrue()
     {
-        $this->assertTrue($class::now()->subMonths(1)->isLastMonth());
+        $this->assertTrue(Chronos::now()->subMonths(1)->isLastMonth());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsNextMonthFalse($class)
+    public function testIsNextMonthFalse()
     {
-        $this->assertFalse($class::now()->addMonths(2)->isNextMonth());
+        $this->assertFalse(Chronos::now()->addMonths(2)->isNextMonth());
 
-        $class::setTestNow('2017-12-31');
-        $time = new $class('2017-01-01');
+        Chronos::setTestNow('2017-12-31');
+        $time = new Chronos('2017-01-01');
         $this->assertFalse($time->isNextMonth());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLastMonthFalse($class)
+    public function testIsLastMonthFalse()
     {
-        $this->assertFalse($class::now()->subMonths(2)->isLastMonth());
+        $this->assertFalse(Chronos::now()->subMonths(2)->isLastMonth());
 
-        $class::setTestNow('2017-01-01');
-        $time = new $class('2017-12-31');
+        Chronos::setTestNow('2017-01-01');
+        $time = new Chronos('2017-12-31');
         $this->assertFalse($time->isLastMonth());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsNextYearTrue($class)
+    public function testIsNextYearTrue()
     {
-        $this->assertTrue($class::now()->addYears(1)->isNextYear());
+        $this->assertTrue(Chronos::now()->addYears(1)->isNextYear());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLastYearTrue($class)
+    public function testIsLastYearTrue()
     {
-        $this->assertTrue($class::now()->subYears(1)->isLastYear());
+        $this->assertTrue(Chronos::now()->subYears(1)->isLastYear());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsNextYearFalse($class)
+    public function testIsNextYearFalse()
     {
-        $this->assertFalse($class::now()->addYears(2)->isNextYear());
+        $this->assertFalse(Chronos::now()->addYears(2)->isNextYear());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLastYearFalse($class)
+    public function testIsLastYearFalse()
     {
-        $this->assertFalse($class::now()->subYears(2)->isLastYear());
+        $this->assertFalse(Chronos::now()->subYears(2)->isLastYear());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsFutureTrue($class)
+    public function testIsFutureTrue()
     {
-        $this->assertTrue($class::now()->addSeconds(1)->isFuture());
+        $this->assertTrue(Chronos::now()->addSeconds(1)->isFuture());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsFutureFalse($class)
+    public function testIsFutureFalse()
     {
-        $this->assertFalse($class::now()->isFuture());
+        $this->assertFalse(Chronos::now()->isFuture());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsFutureFalseInThePast($class)
+    public function testIsFutureFalseInThePast()
     {
-        $this->assertFalse($class::now()->subSeconds(1)->isFuture());
+        $this->assertFalse(Chronos::now()->subSeconds(1)->isFuture());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsPastTrue($class)
+    public function testIsPastTrue()
     {
-        $this->assertTrue($class::now()->subSeconds(1)->isPast());
+        $this->assertTrue(Chronos::now()->subSeconds(1)->isPast());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsPastFalse($class)
+    public function testIsPastFalse()
     {
-        $this->assertFalse($class::now()->addSeconds(1)->isPast());
+        $this->assertFalse(Chronos::now()->addSeconds(1)->isPast());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLeapYearTrue($class)
+    public function testIsLeapYearTrue()
     {
-        $this->assertTrue($class::createFromDate(2016, 1, 1)->isLeapYear());
+        $this->assertTrue(Chronos::createFromDate(2016, 1, 1)->isLeapYear());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsLeapYearFalse($class)
+    public function testIsLeapYearFalse()
     {
-        $this->assertFalse($class::createFromDate(2014, 1, 1)->isLeapYear());
+        $this->assertFalse(Chronos::createFromDate(2014, 1, 1)->isLeapYear());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsSameDayTrue($class)
+    public function testIsSameDayTrue()
     {
-        $current = $class::createFromDate(2012, 1, 2);
-        $this->assertTrue($current->isSameDay($class::createFromDate(2012, 1, 2)));
+        $current = Chronos::createFromDate(2012, 1, 2);
+        $this->assertTrue($current->isSameDay(Chronos::createFromDate(2012, 1, 2)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsSameDayFalse($class)
+    public function testIsSameDayFalse()
     {
-        $current = $class::createFromDate(2012, 1, 2);
-        $this->assertFalse($current->isSameDay($class::createFromDate(2012, 1, 3)));
+        $current = Chronos::createFromDate(2012, 1, 2);
+        $this->assertFalse($current->isSameDay(Chronos::createFromDate(2012, 1, 3)));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsSunday($class)
+    public function testIsSunday()
     {
         // True in the past past
-        $this->assertTrue($class::createFromDate(2015, 5, 31)->isSunday());
-        $this->assertTrue($class::createFromDate(2015, 6, 21)->isSunday());
-        $this->assertTrue($class::now()->subWeeks(1)->previous($class::SUNDAY)->isSunday());
+        $this->assertTrue(Chronos::createFromDate(2015, 5, 31)->isSunday());
+        $this->assertTrue(Chronos::createFromDate(2015, 6, 21)->isSunday());
+        $this->assertTrue(Chronos::now()->subWeeks(1)->previous(Chronos::SUNDAY)->isSunday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeeks(1)->previous($class::SUNDAY)->isSunday());
-        $this->assertTrue($class::now()->addMonths(1)->previous($class::SUNDAY)->isSunday());
+        $this->assertTrue(Chronos::now()->addWeeks(1)->previous(Chronos::SUNDAY)->isSunday());
+        $this->assertTrue(Chronos::now()->addMonths(1)->previous(Chronos::SUNDAY)->isSunday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeeks(1)->previous($class::MONDAY)->isSunday());
-        $this->assertFalse($class::now()->subMonths(1)->previous($class::MONDAY)->isSunday());
+        $this->assertFalse(Chronos::now()->subWeeks(1)->previous(Chronos::MONDAY)->isSunday());
+        $this->assertFalse(Chronos::now()->subMonths(1)->previous(Chronos::MONDAY)->isSunday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeeks(1)->previous($class::MONDAY)->isSunday());
-        $this->assertFalse($class::now()->addMonths(1)->previous($class::MONDAY)->isSunday());
+        $this->assertFalse(Chronos::now()->addWeeks(1)->previous(Chronos::MONDAY)->isSunday());
+        $this->assertFalse(Chronos::now()->addMonths(1)->previous(Chronos::MONDAY)->isSunday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsMonday($class)
+    public function testIsMonday()
     {
         // True in the past past
-        $this->assertTrue($class::createFromDate(2015, 6, 1)->isMonday());
-        $this->assertTrue($class::now()->subWeeks(1)->previous($class::MONDAY)->isMonday());
+        $this->assertTrue(Chronos::createFromDate(2015, 6, 1)->isMonday());
+        $this->assertTrue(Chronos::now()->subWeeks(1)->previous(Chronos::MONDAY)->isMonday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeeks(1)->previous($class::MONDAY)->isMonday());
-        $this->assertTrue($class::now()->addMonths(1)->previous($class::MONDAY)->isMonday());
+        $this->assertTrue(Chronos::now()->addWeeks(1)->previous(Chronos::MONDAY)->isMonday());
+        $this->assertTrue(Chronos::now()->addMonths(1)->previous(Chronos::MONDAY)->isMonday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeeks(1)->previous($class::TUESDAY)->isMonday());
-        $this->assertFalse($class::now()->subMonths(1)->previous($class::TUESDAY)->isMonday());
+        $this->assertFalse(Chronos::now()->subWeeks(1)->previous(Chronos::TUESDAY)->isMonday());
+        $this->assertFalse(Chronos::now()->subMonths(1)->previous(Chronos::TUESDAY)->isMonday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeeks(1)->previous($class::TUESDAY)->isMonday());
-        $this->assertFalse($class::now()->addMonths(1)->previous($class::TUESDAY)->isMonday());
+        $this->assertFalse(Chronos::now()->addWeeks(1)->previous(Chronos::TUESDAY)->isMonday());
+        $this->assertFalse(Chronos::now()->addMonths(1)->previous(Chronos::TUESDAY)->isMonday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsTuesday($class)
+    public function testIsTuesday()
     {
         // True in the past past
-        $this->assertTrue($class::createFromDate(2015, 6, 2)->isTuesday());
-        $this->assertTrue($class::now()->subWeeks(1)->previous($class::TUESDAY)->isTuesday());
+        $this->assertTrue(Chronos::createFromDate(2015, 6, 2)->isTuesday());
+        $this->assertTrue(Chronos::now()->subWeeks(1)->previous(Chronos::TUESDAY)->isTuesday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeeks(1)->previous($class::TUESDAY)->isTuesday());
-        $this->assertTrue($class::now()->addMonths(1)->previous($class::TUESDAY)->isTuesday());
+        $this->assertTrue(Chronos::now()->addWeeks(1)->previous(Chronos::TUESDAY)->isTuesday());
+        $this->assertTrue(Chronos::now()->addMonths(1)->previous(Chronos::TUESDAY)->isTuesday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeeks(1)->previous($class::WEDNESDAY)->isTuesday());
-        $this->assertFalse($class::now()->subMonths(1)->previous($class::WEDNESDAY)->isTuesday());
+        $this->assertFalse(Chronos::now()->subWeeks(1)->previous(Chronos::WEDNESDAY)->isTuesday());
+        $this->assertFalse(Chronos::now()->subMonths(1)->previous(Chronos::WEDNESDAY)->isTuesday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeeks(1)->previous($class::WEDNESDAY)->isTuesday());
-        $this->assertFalse($class::now()->addMonths(1)->previous($class::WEDNESDAY)->isTuesday());
+        $this->assertFalse(Chronos::now()->addWeeks(1)->previous(Chronos::WEDNESDAY)->isTuesday());
+        $this->assertFalse(Chronos::now()->addMonths(1)->previous(Chronos::WEDNESDAY)->isTuesday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsWednesday($class)
+    public function testIsWednesday()
     {
         // True in the past past
-        $this->assertTrue($class::createFromDate(2015, 6, 3)->isWednesday());
-        $this->assertTrue($class::now()->subWeeks(1)->previous($class::WEDNESDAY)->isWednesday());
+        $this->assertTrue(Chronos::createFromDate(2015, 6, 3)->isWednesday());
+        $this->assertTrue(Chronos::now()->subWeeks(1)->previous(Chronos::WEDNESDAY)->isWednesday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeeks(1)->previous($class::WEDNESDAY)->isWednesday());
-        $this->assertTrue($class::now()->addMonths(1)->previous($class::WEDNESDAY)->isWednesday());
+        $this->assertTrue(Chronos::now()->addWeeks(1)->previous(Chronos::WEDNESDAY)->isWednesday());
+        $this->assertTrue(Chronos::now()->addMonths(1)->previous(Chronos::WEDNESDAY)->isWednesday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeeks(1)->previous($class::THURSDAY)->isWednesday());
-        $this->assertFalse($class::now()->subMonths(1)->previous($class::THURSDAY)->isWednesday());
+        $this->assertFalse(Chronos::now()->subWeeks(1)->previous(Chronos::THURSDAY)->isWednesday());
+        $this->assertFalse(Chronos::now()->subMonths(1)->previous(Chronos::THURSDAY)->isWednesday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeeks(1)->previous($class::THURSDAY)->isWednesday());
-        $this->assertFalse($class::now()->addMonths(1)->previous($class::THURSDAY)->isWednesday());
+        $this->assertFalse(Chronos::now()->addWeeks(1)->previous(Chronos::THURSDAY)->isWednesday());
+        $this->assertFalse(Chronos::now()->addMonths(1)->previous(Chronos::THURSDAY)->isWednesday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsThursday($class)
+    public function testIsThursday()
     {
         // True in the past past
-        $this->assertTrue($class::createFromDate(2015, 6, 4)->isThursday());
-        $this->assertTrue($class::now()->subWeeks(1)->previous($class::THURSDAY)->isThursday());
+        $this->assertTrue(Chronos::createFromDate(2015, 6, 4)->isThursday());
+        $this->assertTrue(Chronos::now()->subWeeks(1)->previous(Chronos::THURSDAY)->isThursday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeeks(1)->previous($class::THURSDAY)->isThursday());
-        $this->assertTrue($class::now()->addMonths(1)->previous($class::THURSDAY)->isThursday());
+        $this->assertTrue(Chronos::now()->addWeeks(1)->previous(Chronos::THURSDAY)->isThursday());
+        $this->assertTrue(Chronos::now()->addMonths(1)->previous(Chronos::THURSDAY)->isThursday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeeks(1)->previous($class::FRIDAY)->isThursday());
-        $this->assertFalse($class::now()->subMonths(1)->previous($class::FRIDAY)->isThursday());
+        $this->assertFalse(Chronos::now()->subWeeks(1)->previous(Chronos::FRIDAY)->isThursday());
+        $this->assertFalse(Chronos::now()->subMonths(1)->previous(Chronos::FRIDAY)->isThursday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeeks(1)->previous($class::FRIDAY)->isThursday());
-        $this->assertFalse($class::now()->addMonths(1)->previous($class::FRIDAY)->isThursday());
+        $this->assertFalse(Chronos::now()->addWeeks(1)->previous(Chronos::FRIDAY)->isThursday());
+        $this->assertFalse(Chronos::now()->addMonths(1)->previous(Chronos::FRIDAY)->isThursday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsFriday($class)
+    public function testIsFriday()
     {
         // True in the past past
-        $this->assertTrue($class::createFromDate(2015, 6, 5)->isFriday());
-        $this->assertTrue($class::now()->subWeeks(1)->previous($class::FRIDAY)->isFriday());
+        $this->assertTrue(Chronos::createFromDate(2015, 6, 5)->isFriday());
+        $this->assertTrue(Chronos::now()->subWeeks(1)->previous(Chronos::FRIDAY)->isFriday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeeks(1)->previous($class::FRIDAY)->isFriday());
-        $this->assertTrue($class::now()->addMonths(1)->previous($class::FRIDAY)->isFriday());
+        $this->assertTrue(Chronos::now()->addWeeks(1)->previous(Chronos::FRIDAY)->isFriday());
+        $this->assertTrue(Chronos::now()->addMonths(1)->previous(Chronos::FRIDAY)->isFriday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeeks(1)->previous($class::SATURDAY)->isFriday());
-        $this->assertFalse($class::now()->subMonths(1)->previous($class::SATURDAY)->isFriday());
+        $this->assertFalse(Chronos::now()->subWeeks(1)->previous(Chronos::SATURDAY)->isFriday());
+        $this->assertFalse(Chronos::now()->subMonths(1)->previous(Chronos::SATURDAY)->isFriday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeeks(1)->previous($class::SATURDAY)->isFriday());
-        $this->assertFalse($class::now()->addMonths(1)->previous($class::SATURDAY)->isFriday());
+        $this->assertFalse(Chronos::now()->addWeeks(1)->previous(Chronos::SATURDAY)->isFriday());
+        $this->assertFalse(Chronos::now()->addMonths(1)->previous(Chronos::SATURDAY)->isFriday());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsSaturday($class)
+    public function testIsSaturday()
     {
         // True in the past past
-        $this->assertTrue($class::createFromDate(2015, 6, 6)->isSaturday());
-        $this->assertTrue($class::now()->subWeeks(1)->previous($class::SATURDAY)->isSaturday());
+        $this->assertTrue(Chronos::createFromDate(2015, 6, 6)->isSaturday());
+        $this->assertTrue(Chronos::now()->subWeeks(1)->previous(Chronos::SATURDAY)->isSaturday());
 
         // True in the future
-        $this->assertTrue($class::now()->addWeeks(1)->previous($class::SATURDAY)->isSaturday());
-        $this->assertTrue($class::now()->addMonths(1)->previous($class::SATURDAY)->isSaturday());
+        $this->assertTrue(Chronos::now()->addWeeks(1)->previous(Chronos::SATURDAY)->isSaturday());
+        $this->assertTrue(Chronos::now()->addMonths(1)->previous(Chronos::SATURDAY)->isSaturday());
 
         // False in the past
-        $this->assertFalse($class::now()->subWeeks(1)->previous($class::SUNDAY)->isSaturday());
-        $this->assertFalse($class::now()->subMonths(1)->previous($class::SUNDAY)->isSaturday());
+        $this->assertFalse(Chronos::now()->subWeeks(1)->previous(Chronos::SUNDAY)->isSaturday());
+        $this->assertFalse(Chronos::now()->subMonths(1)->previous(Chronos::SUNDAY)->isSaturday());
 
         // False in the future
-        $this->assertFalse($class::now()->addWeeks(1)->previous($class::SUNDAY)->isSaturday());
-        $this->assertFalse($class::now()->addMonths(1)->previous($class::SUNDAY)->isSaturday());
+        $this->assertFalse(Chronos::now()->addWeeks(1)->previous(Chronos::SUNDAY)->isSaturday());
+        $this->assertFalse(Chronos::now()->addMonths(1)->previous(Chronos::SUNDAY)->isSaturday());
     }
 
-    /**
-     * testIsThisWeek method
-     *
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsThisWeek($class)
+    public function testIsThisWeek()
     {
-        $time = new $class('this sunday');
+        $time = new Chronos('this sunday');
         $this->assertTrue($time->isThisWeek());
 
         $time = $time->modify('-1 day');
@@ -531,86 +358,62 @@ class IsTest extends TestCase
         $time = $time->modify('-6 days');
         $this->assertFalse($time->isThisWeek());
 
-        $time = new $class();
+        $time = new Chronos();
         $time = $time->year($time->year - 1);
         $this->assertFalse($time->isThisWeek());
     }
 
-    /**
-     * testIsThisMonth method
-     *
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsThisMonth($class)
+    public function testIsThisMonth()
     {
-        $time = new $class();
+        $time = new Chronos();
         $this->assertTrue($time->isThisMonth());
 
         $time = $time->year($time->year + 1);
         $this->assertFalse($time->isThisMonth());
 
-        $time = new $class();
+        $time = new Chronos();
         $this->assertFalse($time->modify('next month')->isThisMonth());
     }
 
-    /**
-     * testIsThisYear method
-     *
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsThisYear($class)
+    public function testIsThisYear()
     {
-        $time = new $class();
+        $time = new Chronos();
         $this->assertTrue($time->isThisYear());
 
         $time = $time->year($time->year + 1);
         $this->assertFalse($time->isThisYear());
     }
 
-    /**
-     * testWasWithinLast method
-     *
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testWasWithinLast($class)
+    public function testWasWithinLast()
     {
-        $this->assertTrue((new $class('-1 day'))->wasWithinLast('1 day'));
-        $this->assertTrue((new $class('-1 week'))->wasWithinLast('1 week'));
-        $this->assertTrue((new $class('-1 year'))->wasWithinLast('1 year'));
-        $this->assertTrue((new $class('-1 second'))->wasWithinLast('1 second'));
-        $this->assertTrue((new $class('-1 day'))->wasWithinLast('1 week'));
-        $this->assertTrue((new $class('-1 week'))->wasWithinLast('2 week'));
-        $this->assertTrue((new $class('-1 second'))->wasWithinLast('10 minutes'));
-        $this->assertTrue((new $class('-1 month'))->wasWithinLast('13 month'));
-        $this->assertTrue((new $class('-1 seconds'))->wasWithinLast('1 hour'));
-        $this->assertFalse((new $class('-1 year'))->wasWithinLast('1 second'));
-        $this->assertFalse((new $class('-1 year'))->wasWithinLast('0 year'));
-        $this->assertFalse((new $class('-1 weeks'))->wasWithinLast('1 day'));
+        $this->assertTrue((new Chronos('-1 day'))->wasWithinLast('1 day'));
+        $this->assertTrue((new Chronos('-1 week'))->wasWithinLast('1 week'));
+        $this->assertTrue((new Chronos('-1 year'))->wasWithinLast('1 year'));
+        $this->assertTrue((new Chronos('-1 second'))->wasWithinLast('1 second'));
+        $this->assertTrue((new Chronos('-1 day'))->wasWithinLast('1 week'));
+        $this->assertTrue((new Chronos('-1 week'))->wasWithinLast('2 week'));
+        $this->assertTrue((new Chronos('-1 second'))->wasWithinLast('10 minutes'));
+        $this->assertTrue((new Chronos('-1 month'))->wasWithinLast('13 month'));
+        $this->assertTrue((new Chronos('-1 seconds'))->wasWithinLast('1 hour'));
+        $this->assertFalse((new Chronos('-1 year'))->wasWithinLast('1 second'));
+        $this->assertFalse((new Chronos('-1 year'))->wasWithinLast('0 year'));
+        $this->assertFalse((new Chronos('-1 weeks'))->wasWithinLast('1 day'));
     }
 
-    /**
-     * testWasWithinLast method
-     *
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIsWithinNext($class)
+    public function testIsWithinNext()
     {
-        $this->assertFalse((new $class('-1 day'))->isWithinNext('1 day'));
-        $this->assertFalse((new $class('-1 week'))->isWithinNext('1 week'));
-        $this->assertFalse((new $class('-1 year'))->isWithinNext('1 year'));
-        $this->assertFalse((new $class('-1 second'))->isWithinNext('1 second'));
-        $this->assertFalse((new $class('-1 day'))->isWithinNext('1 week'));
-        $this->assertFalse((new $class('-1 week'))->isWithinNext('2 week'));
-        $this->assertFalse((new $class('-1 second'))->isWithinNext('10 minutes'));
-        $this->assertFalse((new $class('-1 month'))->isWithinNext('13 month'));
-        $this->assertFalse((new $class('-1 seconds'))->isWithinNext('1 hour'));
-        $this->assertTrue((new $class('+1 day'))->isWithinNext('1 day'));
-        $this->assertTrue((new $class('+1 week'))->isWithinNext('7 day'));
-        $this->assertTrue((new $class('+1 second'))->isWithinNext('1 minute'));
-        $this->assertTrue((new $class('+1 month'))->isWithinNext('1 month'));
+        $this->assertFalse((new Chronos('-1 day'))->isWithinNext('1 day'));
+        $this->assertFalse((new Chronos('-1 week'))->isWithinNext('1 week'));
+        $this->assertFalse((new Chronos('-1 year'))->isWithinNext('1 year'));
+        $this->assertFalse((new Chronos('-1 second'))->isWithinNext('1 second'));
+        $this->assertFalse((new Chronos('-1 day'))->isWithinNext('1 week'));
+        $this->assertFalse((new Chronos('-1 week'))->isWithinNext('2 week'));
+        $this->assertFalse((new Chronos('-1 second'))->isWithinNext('10 minutes'));
+        $this->assertFalse((new Chronos('-1 month'))->isWithinNext('13 month'));
+        $this->assertFalse((new Chronos('-1 seconds'))->isWithinNext('1 hour'));
+        $this->assertTrue((new Chronos('+1 day'))->isWithinNext('1 day'));
+        $this->assertTrue((new Chronos('+1 week'))->isWithinNext('7 day'));
+        $this->assertTrue((new Chronos('+1 second'))->isWithinNext('1 minute'));
+        $this->assertTrue((new Chronos('+1 month'))->isWithinNext('1 month'));
     }
 }

--- a/tests/TestCase/DateTime/IssetTest.php
+++ b/tests/TestCase/DateTime/IssetTest.php
@@ -15,24 +15,17 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class IssetTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIssetReturnFalseForUnknownProperty($class)
+    public function testIssetReturnFalseForUnknownProperty()
     {
-        $this->assertFalse(isset($class::create(1234, 5, 6, 7, 8, 9)->sdfsdfss));
+        $this->assertFalse(isset(Chronos::create(1234, 5, 6, 7, 8, 9)->sdfsdfss));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testIssetReturnTrueForProperties($class)
+    public function testIssetReturnTrueForProperties()
     {
         $properties = [
             'year',
@@ -57,7 +50,7 @@ class IssetTest extends TestCase
         ];
 
         foreach ($properties as $property) {
-            $this->assertTrue(isset($class::create(1234, 5, 6, 7, 8, 9)->$property));
+            $this->assertTrue(isset(Chronos::create(1234, 5, 6, 7, 8, 9)->$property));
         }
     }
 }

--- a/tests/TestCase/DateTime/NowAndOtherStaticHelpersTest.php
+++ b/tests/TestCase/DateTime/NowAndOtherStaticHelpersTest.php
@@ -15,137 +15,90 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTime;
 use DateTimeZone;
 
 class NowAndOtherStaticHelpersTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNow($class)
+    public function testNow()
     {
-        $dt = $class::now();
+        $dt = Chronos::now();
         $this->assertSame(time(), $dt->timestamp);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNowWithTimezone($class)
+    public function testNowWithTimezone()
     {
-        $dt = $class::now('Europe/London');
+        $dt = Chronos::now('Europe/London');
         $this->assertSame(time(), $dt->timestamp);
         $this->assertSame('Europe/London', $dt->tzName);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToday($class)
+    public function testToday()
     {
-        $dt = $class::today();
+        $dt = Chronos::today();
         $this->assertSame(date('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testTodayWithTimezone($class)
+    public function testTodayWithTimezone()
     {
-        $dt = $class::today('Europe/London');
+        $dt = Chronos::today('Europe/London');
         $dt2 = new DateTime('now', new DateTimeZone('Europe/London'));
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testTomorrow($class)
+    public function testTomorrow()
     {
-        $dt = $class::tomorrow();
+        $dt = Chronos::tomorrow();
         $dt2 = new DateTime('tomorrow');
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testTomorrowWithTimezone($class)
+    public function testTomorrowWithTimezone()
     {
-        $dt = $class::tomorrow('Europe/London');
+        $dt = Chronos::tomorrow('Europe/London');
         $dt2 = new DateTime('tomorrow', new DateTimeZone('Europe/London'));
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testYesterday($class)
+    public function testYesterday()
     {
-        $dt = $class::yesterday();
+        $dt = Chronos::yesterday();
         $dt2 = new DateTime('yesterday');
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testYesterdayWithTimezone($class)
+    public function testYesterdayWithTimezone()
     {
-        $dt = $class::yesterday('Europe/London');
+        $dt = Chronos::yesterday('Europe/London');
         $dt2 = new DateTime('yesterday', new DateTimeZone('Europe/London'));
         $this->assertSame($dt2->format('Y-m-d 00:00:00'), $dt->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMinValue($class)
+    public function testMinValue()
     {
-        $this->assertLessThanOrEqual(-2147483647, $class::minValue()->getTimestamp());
+        $this->assertLessThanOrEqual(-2147483647, Chronos::minValue()->getTimestamp());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMinValueNonUtcTimezone($class)
+    public function testMinValueNonUtcTimezone()
     {
         date_default_timezone_set('Europe/Amsterdam');
 
-        $this->assertLessThanOrEqual(-2147483647, $class::minValue()->getTimestamp());
-        $this->assertTrue($class::now()->greaterThan($class::minValue()));
+        $this->assertLessThanOrEqual(-2147483647, Chronos::minValue()->getTimestamp());
+        $this->assertTrue(Chronos::now()->greaterThan(Chronos::minValue()));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMaxValue($class)
+    public function testMaxValue()
     {
-        $this->assertGreaterThanOrEqual(2147483647, $class::maxValue()->getTimestamp());
+        $this->assertGreaterThanOrEqual(2147483647, Chronos::maxValue()->getTimestamp());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testMaxValueNonUtcTimezone($class)
+    public function testMaxValueNonUtcTimezone()
     {
         date_default_timezone_set('Europe/Amsterdam');
 
-        $this->assertGreaterThanOrEqual(2147483647, $class::maxValue()->getTimestamp());
-        $this->assertTrue($class::now()->lessThan($class::maxValue()));
+        $this->assertGreaterThanOrEqual(2147483647, Chronos::maxValue()->getTimestamp());
+        $this->assertTrue(Chronos::now()->lessThan(Chronos::maxValue()));
     }
 }

--- a/tests/TestCase/DateTime/PhpBug72338Test.php
+++ b/tests/TestCase/DateTime/PhpBug72338Test.php
@@ -15,44 +15,36 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class PhpBug72338Test extends TestCase
 {
     /**
      * Ensures that $date->format('U') returns unchanged timestamp
-     *
-     * @dataProvider classNameProvider
-     * @return void
      */
-    public function testTimestamp($class)
+    public function testTimestamp()
     {
-        $date = $class::createFromTimestamp(0)->setTimezone('+02:00');
+        $date = Chronos::createFromTimestamp(0)->setTimezone('+02:00');
         $this->assertSame('0', $date->format('U'));
     }
 
     /**
      * Ensures that date created from string with timezone and with same timezone set by setTimezone() is equal
-     *
-     * @dataProvider classNameProvider
-     * @return void
      */
-    public function testEqualSetAndCreate($class)
+    public function testEqualSetAndCreate()
     {
-        $date = $class::createFromTimestamp(0)->setTimezone('+02:00');
-        $date1 = new $class('1970-01-01T02:00:00+02:00');
+        $date = Chronos::createFromTimestamp(0)->setTimezone('+02:00');
+        $date1 = new Chronos('1970-01-01T02:00:00+02:00');
         $this->assertSame($date->format('U'), $date1->format('U'));
     }
 
     /**
      * Ensures that second call to setTimezone() dont changing timestamp
-     *
-     * @dataProvider classNameProvider
-     * @return void
      */
-    public function testSecondSetTimezone($class)
+    public function testSecondSetTimezone()
     {
-        $date = $class::createFromTimestamp(0)->setTimezone('+02:00')->setTimezone('Europe/Moscow');
+        $date = Chronos::createFromTimestamp(0)->setTimezone('+02:00')->setTimezone('Europe/Moscow');
         $this->assertSame('0', $date->format('U'));
     }
 }

--- a/tests/TestCase/DateTime/RelativeTest.php
+++ b/tests/TestCase/DateTime/RelativeTest.php
@@ -15,45 +15,38 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class RelativeTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSecondsSinceMidnight($class)
+    public function testSecondsSinceMidnight()
     {
-        $d = $class::today()->addSeconds(30);
+        $d = Chronos::today()->addSeconds(30);
         $this->assertSame(30, $d->secondsSinceMidnight());
 
-        $d = $class::today()->addDays(1);
+        $d = Chronos::today()->addDays(1);
         $this->assertSame(0, $d->secondsSinceMidnight());
 
-        $d = $class::today()->addDays(1)->addSeconds(120);
+        $d = Chronos::today()->addDays(1)->addSeconds(120);
         $this->assertSame(120, $d->secondsSinceMidnight());
 
-        $d = $class::today()->addMonths(3)->addSeconds(42);
+        $d = Chronos::today()->addMonths(3)->addSeconds(42);
         $this->assertSame(42, $d->secondsSinceMidnight());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSecondsUntilEndOfDay($class)
+    public function testSecondsUntilEndOfDay()
     {
-        $d = $class::today()->endOfDay();
+        $d = Chronos::today()->endOfDay();
         $this->assertSame(0, $d->secondsUntilEndOfDay());
 
-        $d = $class::today()->endOfDay()->subSeconds(60);
+        $d = Chronos::today()->endOfDay()->subSeconds(60);
         $this->assertSame(60, $d->secondsUntilEndOfDay());
 
-        $d = $class::create(2014, 10, 24, 12, 34, 56);
+        $d = Chronos::create(2014, 10, 24, 12, 34, 56);
         $this->assertSame(41103, $d->secondsUntilEndOfDay());
 
-        $d = $class::create(2014, 10, 24, 0, 0, 0);
+        $d = Chronos::create(2014, 10, 24, 0, 0, 0);
         $this->assertSame(86399, $d->secondsUntilEndOfDay());
     }
 }

--- a/tests/TestCase/DateTime/StartEndOfTest.php
+++ b/tests/TestCase/DateTime/StartEndOfTest.php
@@ -15,384 +15,241 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class StartEndOfTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfDay($class)
+    public function testStartOfDay()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->startOfDay();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
         $this->assertDateTime($dt, $dt->year, $dt->month, $dt->day, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfDay($class)
+    public function testEndOfDay()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->endOfDay();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
         $this->assertDateTime($dt, $dt->year, $dt->month, $dt->day, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfMonthIsFluid($class)
+    public function testStartOfMonthIsFluid()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->startOfMonth();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfMonthFromNow($class)
+    public function testStartOfMonthFromNow()
     {
-        $dt = $class::now()->startOfMonth();
+        $dt = Chronos::now()->startOfMonth();
         $this->assertDateTime($dt, $dt->year, $dt->month, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfMonthFromLastDay($class)
+    public function testStartOfMonthFromLastDay()
     {
-        $dt = $class::create(2000, 1, 31, 2, 3, 4)->startOfMonth();
+        $dt = Chronos::create(2000, 1, 31, 2, 3, 4)->startOfMonth();
         $this->assertDateTime($dt, 2000, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfYearIsFluid($class)
+    public function testStartOfYearIsFluid()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->startOfYear();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfYearFromNow($class)
+    public function testStartOfYearFromNow()
     {
-        $dt = $class::now()->startOfYear();
+        $dt = Chronos::now()->startOfYear();
         $this->assertDateTime($dt, $dt->year, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfYearFromFirstDay($class)
+    public function testStartOfYearFromFirstDay()
     {
-        $dt = $class::create(2000, 1, 1, 1, 1, 1)->startOfYear();
+        $dt = Chronos::create(2000, 1, 1, 1, 1, 1)->startOfYear();
         $this->assertDateTime($dt, 2000, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfYearFromLastDay($class)
+    public function testStartOfYearFromLastDay()
     {
-        $dt = $class::create(2000, 12, 31, 23, 59, 59)->startOfYear();
+        $dt = Chronos::create(2000, 12, 31, 23, 59, 59)->startOfYear();
         $this->assertDateTime($dt, 2000, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfMonthIsFluid($class)
+    public function testEndOfMonthIsFluid()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->endOfMonth();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfMonth($class)
+    public function testEndOfMonth()
     {
-        $dt = $class::create(2000, 1, 1, 2, 3, 4)->endOfMonth();
+        $dt = Chronos::create(2000, 1, 1, 2, 3, 4)->endOfMonth();
         $this->assertDateTime($dt, 2000, 1, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfMonthFromLastDay($class)
+    public function testEndOfMonthFromLastDay()
     {
-        $dt = $class::create(2000, 1, 31, 2, 3, 4)->endOfMonth();
+        $dt = Chronos::create(2000, 1, 31, 2, 3, 4)->endOfMonth();
         $this->assertDateTime($dt, 2000, 1, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfYearIsFluid($class)
+    public function testEndOfYearIsFluid()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->endOfYear();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfYearFromNow($class)
+    public function testEndOfYearFromNow()
     {
-        $dt = $class::now()->endOfYear();
+        $dt = Chronos::now()->endOfYear();
         $this->assertDateTime($dt, $dt->year, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfYearFromFirstDay($class)
+    public function testEndOfYearFromFirstDay()
     {
-        $dt = $class::create(2000, 1, 1, 1, 1, 1)->endOfYear();
+        $dt = Chronos::create(2000, 1, 1, 1, 1, 1)->endOfYear();
         $this->assertDateTime($dt, 2000, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfYearFromLastDay($class)
+    public function testEndOfYearFromLastDay()
     {
-        $dt = $class::create(2000, 12, 31, 23, 59, 59)->endOfYear();
+        $dt = Chronos::create(2000, 12, 31, 23, 59, 59)->endOfYear();
         $this->assertDateTime($dt, 2000, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfDecadeIsFluid($class)
+    public function testStartOfDecadeIsFluid()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->startOfDecade();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfDecadeFromNow($class)
+    public function testStartOfDecadeFromNow()
     {
-        $dt = $class::now()->startOfDecade();
+        $dt = Chronos::now()->startOfDecade();
         $this->assertDateTime($dt, $dt->year - $dt->year % 10, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfDecadeFromFirstDay($class)
+    public function testStartOfDecadeFromFirstDay()
     {
-        $dt = $class::create(2000, 1, 1, 1, 1, 1)->startOfDecade();
+        $dt = Chronos::create(2000, 1, 1, 1, 1, 1)->startOfDecade();
         $this->assertDateTime($dt, 2000, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfDecadeFromLastDay($class)
+    public function testStartOfDecadeFromLastDay()
     {
-        $dt = $class::create(2009, 12, 31, 23, 59, 59)->startOfDecade();
+        $dt = Chronos::create(2009, 12, 31, 23, 59, 59)->startOfDecade();
         $this->assertDateTime($dt, 2000, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfDecadeIsFluid($class)
+    public function testEndOfDecadeIsFluid()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->endOfDecade();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfDecadeFromNow($class)
+    public function testEndOfDecadeFromNow()
     {
-        $dt = $class::now()->endOfDecade();
+        $dt = Chronos::now()->endOfDecade();
         $this->assertDateTime($dt, $dt->year - $dt->year % 10 + 9, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfDecadeFromFirstDay($class)
+    public function testEndOfDecadeFromFirstDay()
     {
-        $dt = $class::create(2000, 1, 1, 1, 1, 1)->endOfDecade();
+        $dt = Chronos::create(2000, 1, 1, 1, 1, 1)->endOfDecade();
         $this->assertDateTime($dt, 2009, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfDecadeFromLastDay($class)
+    public function testEndOfDecadeFromLastDay()
     {
-        $dt = $class::create(2009, 12, 31, 23, 59, 59)->endOfDecade();
+        $dt = Chronos::create(2009, 12, 31, 23, 59, 59)->endOfDecade();
         $this->assertDateTime($dt, 2009, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfCenturyIsFluid($class)
+    public function testStartOfCenturyIsFluid()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->startOfCentury();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfCenturyFromNow($class)
+    public function testStartOfCenturyFromNow()
     {
-        $now = $class::now();
-        $dt = $class::now()->startOfCentury();
+        $now = Chronos::now();
+        $dt = Chronos::now()->startOfCentury();
         $this->assertDateTime($dt, $now->year - $now->year % 100 + 1, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfCenturyFromFirstDay($class)
+    public function testStartOfCenturyFromFirstDay()
     {
-        $dt = $class::create(2001, 1, 1, 1, 1, 1)->startOfCentury();
+        $dt = Chronos::create(2001, 1, 1, 1, 1, 1)->startOfCentury();
         $this->assertDateTime($dt, 2001, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testStartOfCenturyFromLastDay($class)
+    public function testStartOfCenturyFromLastDay()
     {
-        $dt = $class::create(2100, 12, 31, 23, 59, 59)->startOfCentury();
+        $dt = Chronos::create(2100, 12, 31, 23, 59, 59)->startOfCentury();
         $this->assertDateTime($dt, 2001, 1, 1, 0, 0, 0);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfCenturyIsFluid($class)
+    public function testEndOfCenturyIsFluid()
     {
-        $now = $class::now();
+        $now = Chronos::now();
         $dt = $now->endOfCentury();
-        $this->assertTrue($dt instanceof $class);
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfCenturyFromNow($class)
+    public function testEndOfCenturyFromNow()
     {
-        $now = $class::now();
-        $dt = $class::now()->endOfCentury();
+        $now = Chronos::now();
+        $dt = Chronos::now()->endOfCentury();
         $this->assertDateTime($dt, $now->year - $now->year % 100 + 100, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfCenturyFromFirstDay($class)
+    public function testEndOfCenturyFromFirstDay()
     {
-        $dt = $class::create(2001, 1, 1, 1, 1, 1)->endOfCentury();
+        $dt = Chronos::create(2001, 1, 1, 1, 1, 1)->endOfCentury();
         $this->assertDateTime($dt, 2100, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testEndOfCenturyFromLastDay($class)
+    public function testEndOfCenturyFromLastDay()
     {
-        $dt = $class::create(2100, 12, 31, 23, 59, 59)->endOfCentury();
+        $dt = Chronos::create(2100, 12, 31, 23, 59, 59)->endOfCentury();
         $this->assertDateTime($dt, 2100, 12, 31, 23, 59, 59);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAverageIsFluid($class)
+    public function testAverageIsFluid()
     {
-        $dt = $class::now()->average();
-        $this->assertTrue($dt instanceof $class);
+        $dt = Chronos::now()->average();
+        $this->assertTrue($dt instanceof Chronos);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAverageFromSame($class)
+    public function testAverageFromSame()
     {
-        $dt1 = $class::create(2000, 1, 31, 2, 3, 4);
-        $dt2 = $class::create(2000, 1, 31, 2, 3, 4)->average($dt1);
+        $dt1 = Chronos::create(2000, 1, 31, 2, 3, 4);
+        $dt2 = Chronos::create(2000, 1, 31, 2, 3, 4)->average($dt1);
         $this->assertDateTime($dt2, 2000, 1, 31, 2, 3, 4);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAverageFromGreater($class)
+    public function testAverageFromGreater()
     {
-        $dt1 = $class::create(2000, 1, 1, 1, 1, 1);
-        $dt2 = $class::create(2009, 12, 31, 23, 59, 59)->average($dt1);
+        $dt1 = Chronos::create(2000, 1, 1, 1, 1, 1);
+        $dt2 = Chronos::create(2009, 12, 31, 23, 59, 59)->average($dt1);
         $this->assertDateTime($dt2, 2004, 12, 31, 12, 30, 30);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testAverageFromLower($class)
+    public function testAverageFromLower()
     {
-        $dt1 = $class::create(2009, 12, 31, 23, 59, 59);
-        $dt2 = $class::create(2000, 1, 1, 1, 1, 1)->average($dt1);
+        $dt1 = Chronos::create(2009, 12, 31, 23, 59, 59);
+        $dt2 = Chronos::create(2000, 1, 1, 1, 1, 1)->average($dt1);
         $this->assertDateTime($dt2, 2004, 12, 31, 12, 30, 30);
     }
 }

--- a/tests/TestCase/DateTime/StringsTest.php
+++ b/tests/TestCase/DateTime/StringsTest.php
@@ -21,116 +21,72 @@ use DateTime;
 
 class StringsTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToString($class)
+    public function testToString()
     {
-        $d = $class::now();
-        $this->assertSame($class::now()->toDateTimeString(), '' . $d);
+        $d = Chronos::now();
+        $this->assertSame(Chronos::now()->toDateTimeString(), '' . $d);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSetToStringFormat($class)
+    public function testSetToStringFormat()
     {
-        $class::setToStringFormat('jS \o\f F, Y g:i:s a');
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        Chronos::setToStringFormat('jS \o\f F, Y g:i:s a');
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('25th of December, 1975 2:15:16 pm', '' . $d);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testResetToStringFormat($class)
+    public function testResetToStringFormat()
     {
-        $d = $class::now();
-        $class::setToStringFormat('123');
-        $class::resetToStringFormat();
+        $d = Chronos::now();
+        Chronos::setToStringFormat('123');
+        Chronos::resetToStringFormat();
         $this->assertSame($d->toDateTimeString(), '' . $d);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToDateString($class)
+    public function testToDateString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25', $d->toDateString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToFormattedDateString($class)
+    public function testToFormattedDateString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Dec 25, 1975', $d->toFormattedDateString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToTimeString($class)
+    public function testToTimeString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('14:15:16', $d->toTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToDateTimeString($class)
+    public function testToDateTimeString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25 14:15:16', $d->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToDateTimeStringWithPaddedZeroes($class)
+    public function testToDateTimeStringWithPaddedZeroes()
     {
-        $d = $class::create(2000, 5, 2, 4, 3, 4);
+        $d = Chronos::create(2000, 5, 2, 4, 3, 4);
         $this->assertSame('2000-05-02 04:03:04', $d->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToDayDateTimeString($class)
+    public function testToDayDateTimeString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, Dec 25, 1975 2:15 PM', $d->toDayDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToAtomString($class)
+    public function testToAtomString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T14:15:16-05:00', $d->toAtomString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToCOOKIEString($class)
+    public function testToCOOKIEString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         if (DateTime::COOKIE === 'l, d-M-y H:i:s T') {
             $cookieString = 'Thursday, 25-Dec-75 14:15:16 EST';
         } else {
@@ -140,106 +96,66 @@ class StringsTest extends TestCase
         $this->assertSame($cookieString, $d->toCOOKIEString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToIso8601String($class)
+    public function testToIso8601String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T14:15:16-05:00', $d->toIso8601String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToRC822String($class)
+    public function testToRC822String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 75 14:15:16 -0500', $d->toRfc822String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToRfc850String($class)
+    public function testToRfc850String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thursday, 25-Dec-75 14:15:16 EST', $d->toRfc850String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToRfc1036String($class)
+    public function testToRfc1036String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 75 14:15:16 -0500', $d->toRfc1036String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToRfc1123String($class)
+    public function testToRfc1123String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 1975 14:15:16 -0500', $d->toRfc1123String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToRfc2822String($class)
+    public function testToRfc2822String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 1975 14:15:16 -0500', $d->toRfc2822String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToRfc3339String($class)
+    public function testToRfc3339String()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T14:15:16-05:00', $d->toRfc3339String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToRssString($class)
+    public function testToRssString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('Thu, 25 Dec 1975 14:15:16 -0500', $d->toRssString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToW3cString($class)
+    public function testToW3cString()
     {
-        $d = $class::create(1975, 12, 25, 14, 15, 16);
+        $d = Chronos::create(1975, 12, 25, 14, 15, 16);
         $this->assertSame('1975-12-25T14:15:16-05:00', $d->toW3cString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testToUnixString($class)
+    public function testToUnixString()
     {
-        $time = $class::parse('2014-04-20 08:00:00');
+        $time = Chronos::parse('2014-04-20 08:00:00');
         $this->assertSame('1397995200', $time->toUnixString());
 
-        $time = $class::parse('2021-12-11 07:00:01');
+        $time = Chronos::parse('2021-12-11 07:00:01');
         $this->assertSame('1639224001', $time->toUnixString());
     }
 

--- a/tests/TestCase/DateTime/SubTest.php
+++ b/tests/TestCase/DateTime/SubTest.php
@@ -15,167 +15,100 @@ declare(strict_types=1);
 
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 
 class SubTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubYearsPositive($class)
+    public function testSubYearsPositive()
     {
-        $this->assertSame(1974, $class::createFromDate(1975)->subYears(1)->year);
+        $this->assertSame(1974, Chronos::createFromDate(1975)->subYears(1)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubYearsZero($class)
+    public function testSubYearsZero()
     {
-        $this->assertSame(1975, $class::createFromDate(1975)->subYears(0)->year);
+        $this->assertSame(1975, Chronos::createFromDate(1975)->subYears(0)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubYearsNegative($class)
+    public function testSubYearsNegative()
     {
-        $this->assertSame(1976, $class::createFromDate(1975)->subYears(-1)->year);
+        $this->assertSame(1976, Chronos::createFromDate(1975)->subYears(-1)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubYear($class)
+    public function testSubYear()
     {
-        $this->assertSame(1974, $class::createFromDate(1975)->subYears(1)->year);
+        $this->assertSame(1974, Chronos::createFromDate(1975)->subYears(1)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubYearNoOverflowPassingArg($class)
+    public function testSubYearNoOverflowPassingArg()
     {
-        $dt = $class::createFromDate(2013, 2, 28)->subYears(1);
+        $dt = Chronos::createFromDate(2013, 2, 28)->subYears(1);
         $this->assertSame(2, $dt->month);
         $this->assertSame(28, $dt->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubYearsWithOverflowPassingArg($class)
+    public function testSubYearsWithOverflowPassingArg()
     {
-        $dt = $class::createFromDate(2014, 2, 29)->subYearsWithOverflow(2);
+        $dt = Chronos::createFromDate(2014, 2, 29)->subYearsWithOverflow(2);
         $this->assertSame(2, $dt->month);
         $this->assertSame(28, $dt->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubYearWithOverflowPassingArg($class)
+    public function testSubYearWithOverflowPassingArg()
     {
-        $dt = $class::createFromDate(2013, 2, 28)->subYearsWithOverflow(1);
+        $dt = Chronos::createFromDate(2013, 2, 28)->subYearsWithOverflow(1);
         $this->assertSame(2, $dt->month);
         $this->assertSame(28, $dt->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMonthsPositive($class)
+    public function testSubMonthsPositive()
     {
-        $this->assertSame(12, $class::createFromDate(1975, 1, 1)->subMonths(1)->month);
+        $this->assertSame(12, Chronos::createFromDate(1975, 1, 1)->subMonths(1)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMonthsZero($class)
+    public function testSubMonthsZero()
     {
-        $this->assertSame(1, $class::createFromDate(1975, 1, 1)->subMonths(0)->month);
+        $this->assertSame(1, Chronos::createFromDate(1975, 1, 1)->subMonths(0)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMonthsNegative($class)
+    public function testSubMonthsNegative()
     {
-        $this->assertSame(2, $class::createFromDate(1975, 1, 1)->subMonths(-1)->month);
+        $this->assertSame(2, Chronos::createFromDate(1975, 1, 1)->subMonths(-1)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMonth($class)
+    public function testSubMonth()
     {
-        $this->assertSame(12, $class::createFromDate(1975, 1, 1)->subMonths(1)->month);
+        $this->assertSame(12, Chronos::createFromDate(1975, 1, 1)->subMonths(1)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubDaysPositive($class)
+    public function testSubDaysPositive()
     {
-        $this->assertSame(30, $class::createFromDate(1975, 5, 1)->subDays(1)->day);
+        $this->assertSame(30, Chronos::createFromDate(1975, 5, 1)->subDays(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubDaysZero($class)
+    public function testSubDaysZero()
     {
-        $this->assertSame(1, $class::createFromDate(1975, 5, 1)->subDays(0)->day);
+        $this->assertSame(1, Chronos::createFromDate(1975, 5, 1)->subDays(0)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubDaysNegative($class)
+    public function testSubDaysNegative()
     {
-        $this->assertSame(2, $class::createFromDate(1975, 5, 1)->subDays(-1)->day);
+        $this->assertSame(2, Chronos::createFromDate(1975, 5, 1)->subDays(-1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubDay($class)
+    public function testSubDay()
     {
-        $this->assertSame(30, $class::createFromDate(1975, 5, 1)->subDays(1)->day);
+        $this->assertSame(30, Chronos::createFromDate(1975, 5, 1)->subDays(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeekdayDuringWeekend($class)
+    public function testSubWeekdayDuringWeekend()
     {
-        $this->assertSame(6, $class::createFromDate(2012, 1, 8)->subWeekdays(1)->day);
+        $this->assertSame(6, Chronos::createFromDate(2012, 1, 8)->subWeekdays(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeekdaysPositive($class)
+    public function testSubWeekdaysPositive()
     {
-        $dt = $class::create(2012, 1, 4, 13, 2, 1)->subWeekdays(9);
+        $dt = Chronos::create(2012, 1, 4, 13, 2, 1)->subWeekdays(9);
         $this->assertSame(22, $dt->day);
 
         // Test for https://bugs.php.net/bug.php?id=54909
@@ -184,263 +117,151 @@ class SubTest extends TestCase
         $this->assertSame(1, $dt->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeekdaysZero($class)
+    public function testSubWeekdaysZero()
     {
-        $this->assertSame(4, $class::createFromDate(2012, 1, 4)->subWeekdays(0)->day);
+        $this->assertSame(4, Chronos::createFromDate(2012, 1, 4)->subWeekdays(0)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeekdaysNegative($class)
+    public function testSubWeekdaysNegative()
     {
-        $this->assertSame(13, $class::createFromDate(2012, 1, 31)->subWeekdays(-9)->day);
+        $this->assertSame(13, Chronos::createFromDate(2012, 1, 31)->subWeekdays(-9)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeekday($class)
+    public function testSubWeekday()
     {
-        $this->assertSame(6, $class::createFromDate(2012, 1, 9)->subWeekdays(1)->day);
+        $this->assertSame(6, Chronos::createFromDate(2012, 1, 9)->subWeekdays(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeeksPositive($class)
+    public function testSubWeeksPositive()
     {
-        $this->assertSame(14, $class::createFromDate(1975, 5, 21)->subWeeks(1)->day);
+        $this->assertSame(14, Chronos::createFromDate(1975, 5, 21)->subWeeks(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeeksZero($class)
+    public function testSubWeeksZero()
     {
-        $this->assertSame(21, $class::createFromDate(1975, 5, 21)->subWeeks(0)->day);
+        $this->assertSame(21, Chronos::createFromDate(1975, 5, 21)->subWeeks(0)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeeksNegative($class)
+    public function testSubWeeksNegative()
     {
-        $this->assertSame(28, $class::createFromDate(1975, 5, 21)->subWeeks(-1)->day);
+        $this->assertSame(28, Chronos::createFromDate(1975, 5, 21)->subWeeks(-1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubWeek($class)
+    public function testSubWeek()
     {
-        $this->assertSame(14, $class::createFromDate(1975, 5, 21)->subWeeks(1)->day);
+        $this->assertSame(14, Chronos::createFromDate(1975, 5, 21)->subWeeks(1)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubHoursPositive($class)
+    public function testSubHoursPositive()
     {
-        $this->assertSame(23, $class::createFromTime(0)->subHours(1)->hour);
+        $this->assertSame(23, Chronos::createFromTime(0)->subHours(1)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubHoursZero($class)
+    public function testSubHoursZero()
     {
-        $this->assertSame(0, $class::createFromTime(0)->subHours(0)->hour);
+        $this->assertSame(0, Chronos::createFromTime(0)->subHours(0)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubHoursNegative($class)
+    public function testSubHoursNegative()
     {
-        $this->assertSame(1, $class::createFromTime(0)->subHours(-1)->hour);
+        $this->assertSame(1, Chronos::createFromTime(0)->subHours(-1)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubHour($class)
+    public function testSubHour()
     {
-        $this->assertSame(23, $class::createFromTime(0)->subHours(1)->hour);
+        $this->assertSame(23, Chronos::createFromTime(0)->subHours(1)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMinutesPositive($class)
+    public function testSubMinutesPositive()
     {
-        $this->assertSame(59, $class::createFromTime(0, 0)->subMinutes(1)->minute);
+        $this->assertSame(59, Chronos::createFromTime(0, 0)->subMinutes(1)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMinutesZero($class)
+    public function testSubMinutesZero()
     {
-        $this->assertSame(0, $class::createFromTime(0, 0)->subMinutes(0)->minute);
+        $this->assertSame(0, Chronos::createFromTime(0, 0)->subMinutes(0)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMinutesNegative($class)
+    public function testSubMinutesNegative()
     {
-        $this->assertSame(1, $class::createFromTime(0, 0)->subMinutes(-1)->minute);
+        $this->assertSame(1, Chronos::createFromTime(0, 0)->subMinutes(-1)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMinute($class)
+    public function testSubMinute()
     {
-        $this->assertSame(59, $class::createFromTime(0, 0)->subMinutes(1)->minute);
+        $this->assertSame(59, Chronos::createFromTime(0, 0)->subMinutes(1)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubSecondsPositive($class)
+    public function testSubSecondsPositive()
     {
-        $this->assertSame(59, $class::createFromTime(0, 0, 0)->subSeconds(1)->second);
+        $this->assertSame(59, Chronos::createFromTime(0, 0, 0)->subSeconds(1)->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubSecondsZero($class)
+    public function testSubSecondsZero()
     {
-        $this->assertSame(0, $class::createFromTime(0, 0, 0)->subSeconds(0)->second);
+        $this->assertSame(0, Chronos::createFromTime(0, 0, 0)->subSeconds(0)->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubSecondsNegative($class)
+    public function testSubSecondsNegative()
     {
-        $this->assertSame(1, $class::createFromTime(0, 0, 0)->subSeconds(-1)->second);
+        $this->assertSame(1, Chronos::createFromTime(0, 0, 0)->subSeconds(-1)->second);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubSecond($class)
+    public function testSubSecond()
     {
-        $this->assertSame(59, $class::createFromTime(0, 0, 0)->subSeconds(1)->second);
+        $this->assertSame(59, Chronos::createFromTime(0, 0, 0)->subSeconds(1)->second);
     }
 
     /***** Test non plural methods with non default args *****/
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubYearPassingArg($class)
+    public function testSubYearPassingArg()
     {
-        $this->assertSame(1973, $class::createFromDate(1975)->subYears(2)->year);
+        $this->assertSame(1973, Chronos::createFromDate(1975)->subYears(2)->year);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMonthPassingArg($class)
+    public function testSubMonthPassingArg()
     {
-        $this->assertSame(3, $class::createFromDate(1975, 5, 1)->subMonths(2)->month);
+        $this->assertSame(3, Chronos::createFromDate(1975, 5, 1)->subMonths(2)->month);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMonthNoOverflowPassingArg($class)
+    public function testSubMonthNoOverflowPassingArg()
     {
-        $dt = $class::createFromDate(2011, 4, 30)->subMonths(2);
+        $dt = Chronos::createFromDate(2011, 4, 30)->subMonths(2);
         $this->assertSame(2, $dt->month);
         $this->assertSame(28, $dt->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMonthsWithOverflowPassingArg($class)
+    public function testSubMonthsWithOverflowPassingArg()
     {
-        $dt = $class::createFromDate(2011, 4, 30)->subMonthsWithOverflow(2);
+        $dt = Chronos::createFromDate(2011, 4, 30)->subMonthsWithOverflow(2);
         $this->assertSame(3, $dt->month);
         $this->assertSame(2, $dt->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMonthWithOverflowPassingArg($class)
+    public function testSubMonthWithOverflowPassingArg()
     {
-        $dt = $class::createFromDate(2011, 3, 30)->subMonthsWithOverflow(1);
+        $dt = Chronos::createFromDate(2011, 3, 30)->subMonthsWithOverflow(1);
         $this->assertSame(3, $dt->month);
         $this->assertSame(2, $dt->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubDayPassingArg($class)
+    public function testSubDayPassingArg()
     {
-        $this->assertSame(8, $class::createFromDate(1975, 5, 10)->subDays(2)->day);
+        $this->assertSame(8, Chronos::createFromDate(1975, 5, 10)->subDays(2)->day);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubHourPassingArg($class)
+    public function testSubHourPassingArg()
     {
-        $this->assertSame(22, $class::createFromTime(0)->subHours(2)->hour);
+        $this->assertSame(22, Chronos::createFromTime(0)->subHours(2)->hour);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubMinutePassingArg($class)
+    public function testSubMinutePassingArg()
     {
-        $this->assertSame(58, $class::createFromTime(0)->subMinutes(2)->minute);
+        $this->assertSame(58, Chronos::createFromTime(0)->subMinutes(2)->minute);
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testSubSecondPassingArg($class)
+    public function testSubSecondPassingArg()
     {
-        $this->assertSame(58, $class::createFromTime(0)->subSeconds(2)->second);
+        $this->assertSame(58, Chronos::createFromTime(0)->subSeconds(2)->second);
     }
 }

--- a/tests/TestCase/DateTime/TestingAidsTest.php
+++ b/tests/TestCase/DateTime/TestingAidsTest.php
@@ -106,23 +106,20 @@ class TestingAidsTest extends TestCase
 
     /**
      * Ensure that using test now doesn't mutate test now.
-     *
-     * @dataProvider dateClassProvider
-     * @return void
      */
-    public function testNowNoMutateDate($class)
+    public function testNowNoMutateDate()
     {
         $value = '2018-06-21 10:11:12';
         $notNow = new Chronos($value);
-        $class::setTestNow($notNow);
+        Date::setTestNow($notNow);
 
-        $instance = new $class('-1 day');
+        $instance = new Date('-1 day');
         $this->assertSame('2018-06-20 00:00:00', $instance->format('Y-m-d H:i:s'));
 
-        $instance = new $class('-1 day');
+        $instance = new Date('-1 day');
         $this->assertSame('2018-06-20 00:00:00', $instance->format('Y-m-d H:i:s'));
 
-        $instance = new $class('-23 hours');
+        $instance = new Date('-23 hours');
         $this->assertSame('2018-06-20 00:00:00', $instance->format('Y-m-d H:i:s'));
     }
 

--- a/tests/TestCase/DateTime/TestingAidsTest.php
+++ b/tests/TestCase/DateTime/TestingAidsTest.php
@@ -22,85 +22,62 @@ use DateTimeZone;
 
 class TestingAidsTest extends TestCase
 {
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testTestingAidsWithTestNowNotSet($class)
+    public function testTestingAidsWithTestNowNotSet()
     {
-        $class::setTestNow();
+        Chronos::setTestNow();
 
-        $this->assertFalse($class::hasTestNow());
-        $this->assertNull($class::getTestNow());
+        $this->assertFalse(Chronos::hasTestNow());
+        $this->assertNull(Chronos::getTestNow());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testTestingAidsWithTestNowSet($class)
+    public function testTestingAidsWithTestNowSet()
     {
-        $notNow = $class::yesterday();
-        $class::setTestNow($notNow);
+        $notNow = Chronos::yesterday();
+        Chronos::setTestNow($notNow);
 
-        $this->assertTrue($class::hasTestNow());
-        $this->assertSame($notNow, $class::getTestNow());
+        $this->assertTrue(Chronos::hasTestNow());
+        $this->assertSame($notNow, Chronos::getTestNow());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testTestingAidsWithTestNowSetToString($class)
+    public function testTestingAidsWithTestNowSetToString()
     {
-        $class::setTestNow('2016-11-23');
-        $this->assertTrue($class::hasTestNow());
-        $this->assertSame((string)$class::getTestNow(), (string)$class::parse('2016-11-23'));
+        Chronos::setTestNow('2016-11-23');
+        $this->assertTrue(Chronos::hasTestNow());
+        $this->assertSame((string)Chronos::getTestNow(), (string)Chronos::parse('2016-11-23'));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testConstructorWithTestValueSet($class)
+    public function testConstructorWithTestValueSet()
     {
-        $notNow = $class::yesterday();
-        $class::setTestNow($notNow);
+        $notNow = Chronos::yesterday();
+        Chronos::setTestNow($notNow);
 
-        $this->assertSame((string)$notNow, (string)new $class());
-        $this->assertSame((string)$notNow, (string)new $class(null));
-        $this->assertSame((string)$notNow, (string)new $class(''));
-        $this->assertSame((string)$notNow, (string)new $class('now'));
+        $this->assertSame((string)$notNow, (string)new Chronos());
+        $this->assertSame((string)$notNow, (string)new Chronos(null));
+        $this->assertSame((string)$notNow, (string)new Chronos(''));
+        $this->assertSame((string)$notNow, (string)new Chronos('now'));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNowWithTestValueSet($class)
+    public function testNowWithTestValueSet()
     {
-        $notNow = $class::yesterday();
-        $class::setTestNow($notNow);
+        $notNow = Chronos::yesterday();
+        Chronos::setTestNow($notNow);
 
-        $this->assertSame((string)$notNow, (string)$class::now());
+        $this->assertSame((string)$notNow, (string)Chronos::now());
     }
 
     /**
      * Ensure that using test now doesn't mutate test now.
-     *
-     * @dataProvider classNameProvider
-     * @return void
      */
-    public function testNowNoMutateDateTime($class)
+    public function testNowNoMutateDateTime()
     {
         $value = '2018-06-21 10:11:12';
         $notNow = new Chronos($value);
-        $class::setTestNow($notNow);
+        Chronos::setTestNow($notNow);
 
-        $instance = new $class('-10 minutes');
+        $instance = new Chronos('-10 minutes');
         $this->assertSame('10:01:12', $instance->format('H:i:s'));
 
-        $instance = new $class('-10 minutes');
+        $instance = new Chronos('-10 minutes');
         $this->assertSame('10:01:12', $instance->format('H:i:s'));
     }
 
@@ -123,164 +100,134 @@ class TestingAidsTest extends TestCase
         $this->assertSame('2018-06-20 00:00:00', $instance->format('Y-m-d H:i:s'));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseWithTestValueSet($class)
+    public function testParseWithTestValueSet()
     {
-        $notNow = $class::yesterday();
-        $class::setTestNow($notNow);
+        $notNow = Chronos::yesterday();
+        Chronos::setTestNow($notNow);
 
-        $this->assertSame((string)$notNow, (string)$class::parse());
-        $this->assertSame((string)$notNow, (string)$class::parse(null));
-        $this->assertSame((string)$notNow, (string)$class::parse(''));
-        $this->assertSame((string)$notNow, (string)$class::parse('now'));
+        $this->assertSame((string)$notNow, (string)Chronos::parse());
+        $this->assertSame((string)$notNow, (string)Chronos::parse(null));
+        $this->assertSame((string)$notNow, (string)Chronos::parse(''));
+        $this->assertSame((string)$notNow, (string)Chronos::parse('now'));
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseRelativeWithTestValueSet($class)
+    public function testParseRelativeWithTestValueSet()
     {
-        $notNow = $class::parse('2013-09-01 05:15:05');
-        $class::setTestNow($notNow);
+        $notNow = Chronos::parse('2013-09-01 05:15:05');
+        Chronos::setTestNow($notNow);
 
-        $this->assertSame('2013-09-01 06:30:00', $class::parse('6:30')->toDateTimeString());
-        $this->assertSame('2013-09-01 06:30:00', $class::parse('6:30:00')->toDateTimeString());
-        $this->assertSame('2013-09-01 06:30:00', $class::parse('06:30:00')->toDateTimeString());
+        $this->assertSame('2013-09-01 06:30:00', Chronos::parse('6:30')->toDateTimeString());
+        $this->assertSame('2013-09-01 06:30:00', Chronos::parse('6:30:00')->toDateTimeString());
+        $this->assertSame('2013-09-01 06:30:00', Chronos::parse('06:30:00')->toDateTimeString());
 
-        $this->assertSame('2013-09-01 05:10:05', $class::parse('5 minutes ago')->toDateTimeString());
+        $this->assertSame('2013-09-01 05:10:05', Chronos::parse('5 minutes ago')->toDateTimeString());
 
-        $this->assertSame('2013-08-25 05:15:05', $class::parse('1 week ago')->toDateTimeString());
+        $this->assertSame('2013-08-25 05:15:05', Chronos::parse('1 week ago')->toDateTimeString());
 
-        $this->assertSame('2013-09-02 00:00:00', $class::parse('tomorrow')->toDateTimeString());
-        $this->assertSame('2013-09-01 00:00:00', $class::parse('today')->toDateTimeString());
-        $this->assertSame('2013-09-01 00:00:00', $class::parse('midnight')->toDateTimeString());
-        $this->assertSame('2013-08-31 00:00:00', $class::parse('yesterday')->toDateTimeString());
+        $this->assertSame('2013-09-02 00:00:00', Chronos::parse('tomorrow')->toDateTimeString());
+        $this->assertSame('2013-09-01 00:00:00', Chronos::parse('today')->toDateTimeString());
+        $this->assertSame('2013-09-01 00:00:00', Chronos::parse('midnight')->toDateTimeString());
+        $this->assertSame('2013-08-31 00:00:00', Chronos::parse('yesterday')->toDateTimeString());
 
-        $this->assertSame('2013-09-02 05:15:05', $class::parse('+1 day')->toDateTimeString());
-        $this->assertSame('2013-08-31 05:15:05', $class::parse('-1 day')->toDateTimeString());
+        $this->assertSame('2013-09-02 05:15:05', Chronos::parse('+1 day')->toDateTimeString());
+        $this->assertSame('2013-08-31 05:15:05', Chronos::parse('-1 day')->toDateTimeString());
 
-        $this->assertSame('2013-09-02 00:00:00', $class::parse('next monday')->toDateTimeString());
-        $this->assertSame('2013-09-03 00:00:00', $class::parse('next tuesday')->toDateTimeString());
-        $this->assertSame('2013-09-04 00:00:00', $class::parse('next wednesday')->toDateTimeString());
-        $this->assertSame('2013-09-05 00:00:00', $class::parse('next thursday')->toDateTimeString());
-        $this->assertSame('2013-09-06 00:00:00', $class::parse('next friday')->toDateTimeString());
-        $this->assertSame('2013-09-07 00:00:00', $class::parse('next saturday')->toDateTimeString());
-        $this->assertSame('2013-09-08 00:00:00', $class::parse('next sunday')->toDateTimeString());
+        $this->assertSame('2013-09-02 00:00:00', Chronos::parse('next monday')->toDateTimeString());
+        $this->assertSame('2013-09-03 00:00:00', Chronos::parse('next tuesday')->toDateTimeString());
+        $this->assertSame('2013-09-04 00:00:00', Chronos::parse('next wednesday')->toDateTimeString());
+        $this->assertSame('2013-09-05 00:00:00', Chronos::parse('next thursday')->toDateTimeString());
+        $this->assertSame('2013-09-06 00:00:00', Chronos::parse('next friday')->toDateTimeString());
+        $this->assertSame('2013-09-07 00:00:00', Chronos::parse('next saturday')->toDateTimeString());
+        $this->assertSame('2013-09-08 00:00:00', Chronos::parse('next sunday')->toDateTimeString());
 
-        $this->assertSame('2013-08-26 00:00:00', $class::parse('last monday')->toDateTimeString());
-        $this->assertSame('2013-08-27 00:00:00', $class::parse('last tuesday')->toDateTimeString());
-        $this->assertSame('2013-08-28 00:00:00', $class::parse('last wednesday')->toDateTimeString());
-        $this->assertSame('2013-08-29 00:00:00', $class::parse('last thursday')->toDateTimeString());
-        $this->assertSame('2013-08-30 00:00:00', $class::parse('last friday')->toDateTimeString());
-        $this->assertSame('2013-08-31 00:00:00', $class::parse('last saturday')->toDateTimeString());
-        $this->assertSame('2013-08-25 00:00:00', $class::parse('last sunday')->toDateTimeString());
+        $this->assertSame('2013-08-26 00:00:00', Chronos::parse('last monday')->toDateTimeString());
+        $this->assertSame('2013-08-27 00:00:00', Chronos::parse('last tuesday')->toDateTimeString());
+        $this->assertSame('2013-08-28 00:00:00', Chronos::parse('last wednesday')->toDateTimeString());
+        $this->assertSame('2013-08-29 00:00:00', Chronos::parse('last thursday')->toDateTimeString());
+        $this->assertSame('2013-08-30 00:00:00', Chronos::parse('last friday')->toDateTimeString());
+        $this->assertSame('2013-08-31 00:00:00', Chronos::parse('last saturday')->toDateTimeString());
+        $this->assertSame('2013-08-25 00:00:00', Chronos::parse('last sunday')->toDateTimeString());
 
-        $this->assertSame('2013-09-02 00:00:00', $class::parse('this monday')->toDateTimeString());
-        $this->assertSame('2013-09-03 00:00:00', $class::parse('this tuesday')->toDateTimeString());
-        $this->assertSame('2013-09-04 00:00:00', $class::parse('this wednesday')->toDateTimeString());
-        $this->assertSame('2013-09-05 00:00:00', $class::parse('this thursday')->toDateTimeString());
-        $this->assertSame('2013-09-06 00:00:00', $class::parse('this friday')->toDateTimeString());
-        $this->assertSame('2013-09-07 00:00:00', $class::parse('this saturday')->toDateTimeString());
-        $this->assertSame('2013-09-01 00:00:00', $class::parse('this sunday')->toDateTimeString());
+        $this->assertSame('2013-09-02 00:00:00', Chronos::parse('this monday')->toDateTimeString());
+        $this->assertSame('2013-09-03 00:00:00', Chronos::parse('this tuesday')->toDateTimeString());
+        $this->assertSame('2013-09-04 00:00:00', Chronos::parse('this wednesday')->toDateTimeString());
+        $this->assertSame('2013-09-05 00:00:00', Chronos::parse('this thursday')->toDateTimeString());
+        $this->assertSame('2013-09-06 00:00:00', Chronos::parse('this friday')->toDateTimeString());
+        $this->assertSame('2013-09-07 00:00:00', Chronos::parse('this saturday')->toDateTimeString());
+        $this->assertSame('2013-09-01 00:00:00', Chronos::parse('this sunday')->toDateTimeString());
 
-        $this->assertSame('2013-10-01 05:15:05', $class::parse('first day of next month')->toDateTimeString());
-        $this->assertSame('2013-09-30 05:15:05', $class::parse('last day of this month')->toDateTimeString());
+        $this->assertSame('2013-10-01 05:15:05', Chronos::parse('first day of next month')->toDateTimeString());
+        $this->assertSame('2013-09-30 05:15:05', Chronos::parse('last day of this month')->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseRelativeWithMinusSignsInDate($class)
+    public function testParseRelativeWithMinusSignsInDate()
     {
-        $notNow = $class::parse('2013-09-01 05:15:05');
-        $class::setTestNow($notNow);
+        $notNow = Chronos::parse('2013-09-01 05:15:05');
+        Chronos::setTestNow($notNow);
 
-        $this->assertSame('2000-01-03 00:00:00', $class::parse('2000-1-3')->toDateTimeString());
-        $this->assertSame('2000-10-10 00:00:00', $class::parse('2000-10-10')->toDateTimeString());
+        $this->assertSame('2000-01-03 00:00:00', Chronos::parse('2000-1-3')->toDateTimeString());
+        $this->assertSame('2000-10-10 00:00:00', Chronos::parse('2000-10-10')->toDateTimeString());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseWithTimeZone($class)
+    public function testParseWithTimeZone()
     {
-        $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
-        $class::setTestNow($notNow);
+        $notNow = Chronos::parse('2013-07-01 12:00:00', 'America/New_York');
+        Chronos::setTestNow($notNow);
 
-        $this->assertSame('2013-07-01T12:00:00-04:00', $class::parse('now')->toIso8601String());
-        $this->assertSame('2013-07-01T11:00:00-05:00', $class::parse('now', 'America/Mexico_City')->toIso8601String());
-        $this->assertSame('2013-07-01T09:00:00-07:00', $class::parse('now', 'America/Vancouver')->toIso8601String());
+        $this->assertSame('2013-07-01T12:00:00-04:00', Chronos::parse('now')->toIso8601String());
+        $this->assertSame('2013-07-01T11:00:00-05:00', Chronos::parse('now', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T09:00:00-07:00', Chronos::parse('now', 'America/Vancouver')->toIso8601String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testParseRelativeWithTimeZone($class)
+    public function testParseRelativeWithTimeZone()
     {
-        $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
-        $class::setTestNow($notNow);
+        $notNow = Chronos::parse('2013-07-01 12:00:00', 'America/New_York');
+        Chronos::setTestNow($notNow);
 
-        $this->assertSame('2013-07-01T10:55:00-05:00', $class::parse('5 minutes ago', 'America/Mexico_City')->toIso8601String());
-        $this->assertSame('2013-07-01 10:55:00', $class::parse('5 minutes ago', 'America/Mexico_City')->toDateTimeString());
+        $this->assertSame('2013-07-01T10:55:00-05:00', Chronos::parse('5 minutes ago', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01 10:55:00', Chronos::parse('5 minutes ago', 'America/Mexico_City')->toDateTimeString());
     }
 
     /**
      * Test parse() with relative values and timezones
-     *
-     * @dataProvider classNameProvider
-     * @return void
      */
-    public function testParseRelativeWithTimezoneAndTestValueSet($class)
+    public function testParseRelativeWithTimezoneAndTestValueSet()
     {
-        $notNow = $class::parse('2013-07-01 12:00:00', 'America/New_York');
-        $class::setTestNow($notNow);
+        $notNow = Chronos::parse('2013-07-01 12:00:00', 'America/New_York');
+        Chronos::setTestNow($notNow);
 
-        $this->assertSame('06:30:00', $class::parse('2013-07-01 06:30:00', 'America/Mexico_City')->toTimeString());
-        $this->assertSame('06:30:00', $class::parse('6:30', 'America/Mexico_City')->toTimeString());
+        $this->assertSame('06:30:00', Chronos::parse('2013-07-01 06:30:00', 'America/Mexico_City')->toTimeString());
+        $this->assertSame('06:30:00', Chronos::parse('6:30', 'America/Mexico_City')->toTimeString());
 
-        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('2013-07-01 06:30:00')->toIso8601String());
-        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('2013-07-01 06:30:00', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-04:00', Chronos::parse('2013-07-01 06:30:00')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', Chronos::parse('2013-07-01 06:30:00', 'America/Mexico_City')->toIso8601String());
 
-        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('06:30')->toIso8601String());
-        $this->assertSame('2013-07-01T06:30:00-04:00', $class::parse('6:30')->toIso8601String());
-        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('6:30', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-04:00', Chronos::parse('06:30')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-04:00', Chronos::parse('6:30')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', Chronos::parse('6:30', 'America/Mexico_City')->toIso8601String());
 
-        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('6:30:00', 'America/Mexico_City')->toIso8601String());
-        $this->assertSame('2013-07-01T06:30:00-05:00', $class::parse('06:30:00', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', Chronos::parse('6:30:00', 'America/Mexico_City')->toIso8601String());
+        $this->assertSame('2013-07-01T06:30:00-05:00', Chronos::parse('06:30:00', 'America/Mexico_City')->toIso8601String());
     }
 
-    /**
-     * @dataProvider classNameProvider
-     * @return void
-     */
-    public function testNullTimezone($class)
+    public function testNullTimezone()
     {
-        $c = new $class('2016-01-01 00:00:00', 'Europe/Copenhagen');
-        $class::setTestNow($c);
+        $c = new Chronos('2016-01-01 00:00:00', 'Europe/Copenhagen');
+        Chronos::setTestNow($c);
 
-        $result = new $class('now', null);
+        $result = new Chronos('now', null);
         $this->assertSame((new DateTimeZone('America/Toronto'))->getName(), $result->tz->getName());
         $this->assertSame('2015-12-31 18:00:00', $result->format('Y-m-d H:i:s'));
-        $this->assertSame((new DateTimeZone('Europe/Copenhagen'))->getName(), $class::getTestNow()->tz->getName());
+        $this->assertSame((new DateTimeZone('Europe/Copenhagen'))->getName(), Chronos::getTestNow()->tz->getName());
     }
 
     /**
      * Test that setting testNow() on one class sets it on all of the chronos classes.
-     *
-     * @dataProvider classNameProvider
-     * @return void
      */
-    public function testSetTestNowSingular($class)
+    public function testSetTestNowSingular()
     {
-        $c = new $class('2016-01-03 00:00:00', 'Europe/Copenhagen');
-        $class::setTestNow($c);
+        $c = new Chronos('2016-01-03 00:00:00', 'Europe/Copenhagen');
+        Chronos::setTestNow($c);
 
         $this->assertSame($c, Date::getTestNow());
         $this->assertSame($c, Chronos::getTestNow());

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -46,13 +46,6 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
-    public function dateClassProvider()
-    {
-        return [
-            'immutable' => [Date::class],
-        ];
-    }
-
     protected function assertTime($d, $hour, $minute, $second = null, $microsecond = null)
     {
         $this->assertSame($hour, $d->hour, 'Chronos->hour');

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -39,13 +39,6 @@ abstract class TestCase extends BaseTestCase
         Date::setTestNow(null);
     }
 
-    public function classNameProvider()
-    {
-        return [
-            'immutable' => [Chronos::class],
-        ];
-    }
-
     protected function assertTime($d, $hour, $minute, $second = null, $microsecond = null)
     {
         $this->assertSame($hour, $d->hour, 'Chronos->hour');


### PR DESCRIPTION
After mutable classes removal, `classNameProvider()` and `dateClassProvider()` return only one classname each, so unnecessary now.

This also helps IDE and static analyzers to see usage of methods in these classes, and will help in 3.x API refactoring.