### PR TITLE
2.next Backport createInterval()

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ want to migrate, we could use the following to update files:
 
 ```
 # Replace imports
-find ./src -type f -name '*.php' -exec sed -i '' 's/use Carbon\\CarbonInterval/use Cake\\Chronos\\ChronosInterval/g' {} \;
 find ./src -type f -name '*.php' -exec sed -i '' 's/use Carbon\\CarbonImmutable/use Cake\\Chronos\\Chronos/g' {} \;
 find ./src -type f -name '*.php' -exec sed -i '' 's/use Carbon\\Carbon/use Cake\\Chronos\\Chronos/g' {} \;
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -29,8 +29,6 @@ and extensions to ``DateInterval``.
 * ``Cake\Chronos\Date`` is a immutable *date* object.
 * ``Cake\Chronos\MutableDateTime`` is a mutable *date and time* object.
 * ``Cake\Chronos\MutableDate`` is a mutable *date* object.
-* ``Cake\Chronos\ChronosInterval`` is an extension to the ``DateInterval``
-  object.
 
 Lastly, if you want to typehint against Chronos-provided date/time objects you
 should use ``Cake\Chronos\ChronosInterface``. All of the date and time objects

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -30,8 +30,6 @@ immutables de date/time et les extensions de ``DateInterval``.
 * ``Cake\Chronos\Date`` est un objet de *date* immutable.
 * ``Cake\Chronos\MutableDateTime`` est un objet de *date et heure* mutable.
 * ``Cake\Chronos\MutableDate`` est un objet de *date* mutable.
-* ``Cake\Chronos\ChronosInterval`` est une extension pour l'objet
-  ``DateInterval``.
 
 Enfin si vous voulez typer selon les objets date/time fournis par Chronos,
 vous devez utiliser ``Cake\Chronos\ChronosInterface``. Tous les objets date et

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.php" colors="true" convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Chronos Test Suite">
             <directory>tests</directory>

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -219,7 +219,7 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
         ?int $hours = null,
         ?int $minutes = null,
         ?int $seconds = null,
-        ?int $microseconds = null,
+        ?int $microseconds = null
     ): DateInterval {
         $spec = 'P';
 

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos;
 
+use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
 
@@ -195,6 +196,70 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
     public static function hasTestNow(): bool
     {
         return static::$testNow !== null;
+    }
+
+    /**
+     * Create a new DateInterval instance from specified values.
+     *
+     * @param int|null $years The year to use.
+     * @param int|null $months The month to use.
+     * @param int|null $weeks The week to use.
+     * @param int|null $days The day to use.
+     * @param int|null $hours The hours to use.
+     * @param int|null $minutes The minutes to use.
+     * @param int|null $seconds The seconds to use.
+     * @param int|null $microseconds The microseconds to use.
+     * @return \DateInterval
+     */
+    public static function createInterval(
+        ?int $years = null,
+        ?int $months = null,
+        ?int $weeks = null,
+        ?int $days = null,
+        ?int $hours = null,
+        ?int $minutes = null,
+        ?int $seconds = null,
+        ?int $microseconds = null,
+    ): DateInterval {
+        $spec = 'P';
+
+        if ($years) {
+            $spec .= $years . 'Y';
+        }
+        if ($months) {
+            $spec .= $months . 'M';
+        }
+        if ($weeks) {
+            $spec .= $weeks . 'W';
+        }
+        if ($days) {
+            $spec .= $days . 'D';
+        }
+
+        if ($hours || $minutes || $seconds) {
+            $spec .= 'T';
+            if ($hours) {
+                $spec .= $hours . 'H';
+            }
+            if ($minutes) {
+                $spec .= $minutes . 'M';
+            }
+            if ($seconds) {
+                $spec .= $seconds . 'S';
+            }
+        }
+
+        if ($microseconds && $spec === 'P') {
+            $spec .= 'T0S';
+        }
+
+        $instance = new DateInterval($spec);
+
+        if ($microseconds) {
+            $instance->f = $microseconds / 1000000;
+        }
+
+        return $instance;
     }
 
     /**

--- a/src/ChronosInterval.php
+++ b/src/ChronosInterval.php
@@ -146,6 +146,10 @@ class ChronosInterval extends DateInterval
         if ($microseconds > 0) {
             $this->f = $microseconds / 1000000;
         }
+        trigger_error(
+            'Since 2.4 ChronosInterval is deprecated. Use `Chronos::createInterval() instead.`',
+            E_USER_DEPRECATED
+        );
     }
 
     /**

--- a/src/Traits/DifferenceTrait.php
+++ b/src/Traits/DifferenceTrait.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterface;
 use Cake\Chronos\ChronosInterval;
+use Cake\Chronos\Chronos;
+use Cake\Chronos\ChronosInterface;
 use Cake\Chronos\DifferenceFormatter;
 use Cake\Chronos\DifferenceFormatterInterface;
 use DatePeriod;
@@ -128,7 +129,9 @@ trait DifferenceTrait
      */
     public function diffInDaysFiltered(callable $callback, ?ChronosInterface $dt = null, bool $abs = true): int
     {
-        return $this->diffFiltered(ChronosInterval::day(), $callback, $dt, $abs);
+        $interval = Chronos::createInterval(0, 0, 0, 1);
+
+        return $this->diffFiltered($interval, $callback, $dt, $abs);
     }
 
     /**
@@ -141,20 +144,22 @@ trait DifferenceTrait
      */
     public function diffInHoursFiltered(callable $callback, ?ChronosInterface $dt = null, bool $abs = true): int
     {
-        return $this->diffFiltered(ChronosInterval::hour(), $callback, $dt, $abs);
+        $interval = Chronos::createInterval(0, 0, 0, 0, 1);
+
+        return $this->diffFiltered($interval, $callback, $dt, $abs);
     }
 
     /**
      * Get the difference by the given interval using a filter callable
      *
-     * @param \Cake\Chronos\ChronosInterval $ci An interval to traverse by
+     * @param \Cake\Chronos\ChronosInterval|\DateInterval $ci An interval to traverse by
      * @param callable $callback The callback to use for filtering.
      * @param \Cake\Chronos\ChronosInterface|null $dt The instance to difference from.
      * @param bool $abs Get the absolute of the difference
      * @return int
      */
     public function diffFiltered(
-        ChronosInterval $ci,
+        $ci,
         callable $callback,
         ?ChronosInterface $dt = null,
         bool $abs = true

--- a/src/Traits/DifferenceTrait.php
+++ b/src/Traits/DifferenceTrait.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
-use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosInterface;
 use Cake\Chronos\DifferenceFormatter;

--- a/tests/TestCase/DateTime/CreateIntervalTest.php
+++ b/tests/TestCase/DateTime/CreateIntervalTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Chronos\Test\TestCase\DateTime;
+
+use Cake\Chronos\Chronos;
+use Cake\Chronos\Test\TestCase\TestCase;
+
+class CreateIntervalTest extends TestCase
+{
+    public function testCreateInterval(): void
+    {
+        $interval = Chronos::createInterval(0, 0, 0, 0, 2);
+        $this->assertDateInterval($interval, null, null, null, 2);
+
+        $interval = Chronos::createInterval(0, 0, 0, 0, 0, 0, 0, 2);
+        $this->assertDateInterval($interval, 0, 0, 0, 0, 0, 0, 0.000002);
+    }
+}

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -18,6 +18,7 @@ use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\Test\TestCase\TestCase;
 use Closure;
+use DateInterval;
 use DateTimeZone;
 
 class DiffTest extends TestCase
@@ -330,7 +331,8 @@ class DiffTest extends TestCase
     public function testDiffFilteredUsingMinutesPositiveWithMutated($class)
     {
         $dt = $class::createFromDate(2000, 1, 1)->startOfDay();
-        $this->assertSame(60, $dt->diffFiltered(ChronosInterval::minute(), function ($date) {
+        $interval = Chronos::createInterval(0, 0, 0, 0, 0, 1);
+        $this->assertSame(60, $dt->diffFiltered($interval, function ($date) {
             return $date->hour === 12;
         }, $class::createFromDate(2000, 1, 1)->endOfDay()));
     }
@@ -344,7 +346,8 @@ class DiffTest extends TestCase
         $dt1 = $class::create(2000, 1, 1);
         $dt2 = $dt1->copy()->addSeconds(80);
 
-        $this->assertSame(40, $dt1->diffFiltered(ChronosInterval::second(), function ($date) {
+        $interval = Chronos::createInterval(0, 0, 0, 0, 0, 0, 1);
+        $this->assertSame(40, $dt1->diffFiltered($interval, function ($date) {
             return $date->second % 2 === 0;
         }, $dt2));
     }
@@ -356,8 +359,8 @@ class DiffTest extends TestCase
     public function testDiffFilteredNegativeNoSignWithMutated($class)
     {
         $dt = $class::createFromDate(2000, 1, 31);
-
-        $this->assertSame(2, $dt->diffFiltered(ChronosInterval::days(2), function ($date) use ($class) {
+        $interval = Chronos::createInterval(0, 0, 0, 2);
+        $this->assertSame(2, $dt->diffFiltered($interval, function ($date) use ($class) {
             return $date->dayOfWeek === $class::SUNDAY;
         }, $dt->copy()->startOfMonth()));
     }
@@ -371,7 +374,8 @@ class DiffTest extends TestCase
         $dt1 = $class::createFromDate(2006, 1, 31);
         $dt2 = $class::createFromDate(2000, 1, 1);
 
-        $this->assertSame(7, $dt1->diffFiltered(ChronosInterval::year(), function ($date) {
+        $interval = Chronos::createInterval(1);
+        $this->assertSame(7, $dt1->diffFiltered($interval, function ($date) {
             return $date->month === 1;
         }, $dt2));
     }
@@ -383,7 +387,8 @@ class DiffTest extends TestCase
     public function testDiffFilteredNegativeWithSignWithMutated($class)
     {
         $dt = $class::createFromDate(2000, 1, 31);
-        $this->assertSame(-4, $dt->diffFiltered(ChronosInterval::week(), function ($date) {
+        $interval = Chronos::createInterval(0, 0, 1);
+        $this->assertSame(-4, $dt->diffFiltered($interval, function ($date) {
             return $date->month === 12;
         }, $dt->copy()->subMonths(3), false));
     }
@@ -397,7 +402,8 @@ class DiffTest extends TestCase
         $dt1 = $class::createFromDate(2001, 1, 31);
         $dt2 = $class::createFromDate(1999, 1, 1);
 
-        $this->assertSame(-12, $dt1->diffFiltered(ChronosInterval::month(), function ($date) {
+        $interval = Chronos::createInterval(0, 1);
+        $this->assertSame(-12, $dt1->diffFiltered($interval, function ($date) {
             return $date->year === 2000;
         }, $dt2, false));
     }

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -15,10 +15,8 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Chronos;
-use Cake\Chronos\ChronosInterval;
 use Cake\Chronos\Test\TestCase\TestCase;
 use Closure;
-use DateInterval;
 use DateTimeZone;
 
 class DiffTest extends TestCase

--- a/tests/TestCase/Interval/IntervalAddTest.php
+++ b/tests/TestCase/Interval/IntervalAddTest.php
@@ -24,23 +24,29 @@ class IntervalAddTest extends TestCase
 {
     public function testAdd()
     {
-        $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11)->add(new DateInterval('P2Y1M5DT22H33M44S'));
-        $this->assertDateTimeInterval($ci, 6, 4, 54, 30, 43, 55);
+        $this->deprecated(function () {
+            $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11)->add(new DateInterval('P2Y1M5DT22H33M44S'));
+            $this->assertDateTimeInterval($ci, 6, 4, 54, 30, 43, 55);
+        });
     }
 
     public function testAddWithDiffDateInterval()
     {
-        $now = Chronos::now();
-        $diff = $now->diff($now->addWeeks(3));
-        $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11, 123)->add($diff);
-        $this->assertDateTimeInterval($ci, 4, 3, 70, 8, 10, 11, 123);
+        $this->deprecated(function () {
+            $now = Chronos::now();
+            $diff = $now->diff($now->addWeeks(3));
+            $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11, 123)->add($diff);
+            $this->assertDateTimeInterval($ci, 4, 3, 70, 8, 10, 11, 123);
+        });
     }
 
     public function testAddWithNegativeDiffDateInterval()
     {
-        $now = Chronos::now();
-        $diff = $now->diff($now->subWeeks(3));
-        $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11, 123)->add($diff);
-        $this->assertDateTimeInterval($ci, 4, 3, 28, 8, 10, 11, 123);
+        $this->deprecated(function () {
+            $now = Chronos::now();
+            $diff = $now->diff($now->subWeeks(3));
+            $ci = ChronosInterval::create(4, 3, 6, 7, 8, 10, 11, 123)->add($diff);
+            $this->assertDateTimeInterval($ci, 4, 3, 28, 8, 10, 11, 123);
+        });
     }
 }

--- a/tests/TestCase/Interval/IntervalConstructTest.php
+++ b/tests/TestCase/Interval/IntervalConstructTest.php
@@ -24,238 +24,274 @@ class IntervalConstructTest extends TestCase
 {
     public function testDefaults()
     {
-        $ci = new ChronosInterval();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0);
+        });
     }
 
     public function testNulls()
     {
-        $ci = new ChronosInterval(null, null, null, null, null, null, null);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(null, null, null, null, null, null, null);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::days(null);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
+            $ci = ChronosInterval::days(null);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
+        });
     }
 
     public function testZeroes()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::days(0);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
+            $ci = ChronosInterval::days(0);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
+        });
     }
 
     public function testZeroesChained()
     {
-        $ci = ChronosInterval::days(0)->week(0)->minutes(0);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = ChronosInterval::days(0)->week(0)->minutes(0);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 0);
+        });
     }
 
     public function testYears()
     {
-        $ci = new ChronosInterval(1);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(1);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::years(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 2, 0, 0, 0, 0, 0, 0);
+            $ci = ChronosInterval::years(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 2, 0, 0, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::year();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0, 0);
+            $ci = ChronosInterval::year();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 1, 0, 0, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::year(3);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 3, 0, 0, 0, 0, 0, 0);
+            $ci = ChronosInterval::year(3);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 3, 0, 0, 0, 0, 0, 0);
+        });
     }
 
     public function testMonths()
     {
-        $ci = new ChronosInterval(0, 1);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 1, 0, 0, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 1);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 1, 0, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::months(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 2, 0, 0, 0, 0, 0);
+            $ci = ChronosInterval::months(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 2, 0, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::month();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 1, 0, 0, 0, 0, 0);
+            $ci = ChronosInterval::month();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 1, 0, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::month(3);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 3, 0, 0, 0, 0, 0);
+            $ci = ChronosInterval::month(3);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 3, 0, 0, 0, 0, 0);
+        });
     }
 
     public function testWeeks()
     {
-        $ci = new ChronosInterval(0, 0, 1);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 7, 0, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 1);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 7, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::weeks(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 14, 0, 0, 0, 0);
+            $ci = ChronosInterval::weeks(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 14, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::week();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 7, 0, 0, 0, 0);
+            $ci = ChronosInterval::week();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 7, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::week(3);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 21, 0, 0, 0, 0);
+            $ci = ChronosInterval::week(3);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 21, 0, 0, 0, 0);
+        });
     }
 
     public function testDays()
     {
-        $ci = new ChronosInterval(0, 0, 0, 1);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 1, 0, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 1);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 1, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::days(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 2, 0, 0, 0, 0);
+            $ci = ChronosInterval::days(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 2, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::dayz(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 2, 0, 0, 0, 0);
+            $ci = ChronosInterval::dayz(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 2, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::day();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 1, 0, 0, 0, 0);
+            $ci = ChronosInterval::day();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 1, 0, 0, 0, 0);
 
-        $ci = ChronosInterval::day(3);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 3, 0, 0, 0, 0);
+            $ci = ChronosInterval::day(3);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 3, 0, 0, 0, 0);
+        });
     }
 
     public function testHours()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 1);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 1, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 0, 1);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 1, 0, 0, 0);
 
-        $ci = ChronosInterval::hours(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 2, 0, 0, 0);
+            $ci = ChronosInterval::hours(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 2, 0, 0, 0);
 
-        $ci = ChronosInterval::hour();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 1, 0, 0, 0);
+            $ci = ChronosInterval::hour();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 1, 0, 0, 0);
 
-        $ci = ChronosInterval::hour(3);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 3, 0, 0, 0);
+            $ci = ChronosInterval::hour(3);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 3, 0, 0, 0);
+        });
     }
 
     public function testMinutes()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 0, 1);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 1, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 0, 0, 1);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 1, 0, 0);
 
-        $ci = ChronosInterval::minutes(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 2, 0, 0);
+            $ci = ChronosInterval::minutes(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 2, 0, 0);
 
-        $ci = ChronosInterval::minute();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 1, 0, 0);
+            $ci = ChronosInterval::minute();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 1, 0, 0);
 
-        $ci = ChronosInterval::minute(3);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 3, 0, 0);
+            $ci = ChronosInterval::minute(3);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 3, 0, 0);
+        });
     }
 
     public function testSeconds()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 1);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 1, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 1);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 1, 0);
 
-        $ci = ChronosInterval::seconds(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 2, 0);
+            $ci = ChronosInterval::seconds(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 2, 0);
 
-        $ci = ChronosInterval::second();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 1, 0);
+            $ci = ChronosInterval::second();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 1, 0);
 
-        $ci = ChronosInterval::second(3);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 3, 0);
+            $ci = ChronosInterval::second(3);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 3, 0);
+        });
     }
 
     public function testMicroseconds()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0, 123456);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 123456);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0, 123456);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 123456);
 
-        $ci = ChronosInterval::microseconds(2);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 2);
+            $ci = ChronosInterval::microseconds(2);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 2);
 
-        $ci = ChronosInterval::microsecond();
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 1);
+            $ci = ChronosInterval::microsecond();
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 1);
 
-        $ci = ChronosInterval::microsecond(3);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 3);
+            $ci = ChronosInterval::microsecond(3);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 0, 0, 0, 0, 0, 0, 3);
+        });
     }
 
     public function testYearsAndHours()
     {
-        $ci = new ChronosInterval(5, 0, 0, 0, 3, 0, 0, 0);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 5, 0, 0, 3, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(5, 0, 0, 0, 3, 0, 0, 0);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 5, 0, 0, 3, 0, 0, 0);
+        });
     }
 
     public function testAll()
     {
-        $ci = new ChronosInterval(5, 6, 2, 5, 9, 10, 11, 123);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 5, 6, 19, 9, 10, 11, 123);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(5, 6, 2, 5, 9, 10, 11, 123);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 5, 6, 19, 9, 10, 11, 123);
+        });
     }
 
     public function testAllWithCreate()
     {
-        $ci = ChronosInterval::create(5, 6, 2, 5, 9, 10, 11, 123);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 5, 6, 19, 9, 10, 11, 123);
+        $this->deprecated(function () {
+            $ci = ChronosInterval::create(5, 6, 2, 5, 9, 10, 11, 123);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 5, 6, 19, 9, 10, 11, 123);
+        });
     }
 
     public function testInstance()
     {
-        $ci = ChronosInterval::instance(new DateInterval('P2Y1M5DT22H33M44S'));
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 2, 1, 5, 22, 33, 44, 0);
-        $this->assertTrue($ci->days === false || $ci->days === 0 || $ci->days === ChronosInterval::PHP_DAYS_FALSE);
+        $this->deprecated(function () {
+            $ci = ChronosInterval::instance(new DateInterval('P2Y1M5DT22H33M44S'));
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 2, 1, 5, 22, 33, 44, 0);
+            $this->assertTrue($ci->days === false || $ci->days === 0 || $ci->days === ChronosInterval::PHP_DAYS_FALSE);
+        });
     }
 
     public function testInstanceWithNegativeDateInterval()
     {
-        $di = new DateInterval('P2Y1M5DT22H33M44S');
-        $di->invert = 1;
-        $ci = ChronosInterval::instance($di);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 2, 1, 5, 22, 33, 44, 0);
-        $this->assertTrue($ci->days === false || $ci->days === 0 || $ci->days === ChronosInterval::PHP_DAYS_FALSE);
-        $this->assertSame(1, $ci->invert);
+        $this->deprecated(function () {
+            $di = new DateInterval('P2Y1M5DT22H33M44S');
+            $di->invert = 1;
+            $ci = ChronosInterval::instance($di);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 2, 1, 5, 22, 33, 44, 0);
+            $this->assertTrue($ci->days === false || $ci->days === 0 || $ci->days === ChronosInterval::PHP_DAYS_FALSE);
+            $this->assertSame(1, $ci->invert);
+        });
     }
 
     public function testInstanceWithDaysThrowsException()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->deprecated(function () {
+            $this->expectException(\InvalidArgumentException::class);
 
-        $ci = ChronosInterval::instance(Chronos::now()->diff(Chronos::now()->addWeeks(3)));
+            $ci = ChronosInterval::instance(Chronos::now()->diff(Chronos::now()->addWeeks(3)));
+        });
     }
 }

--- a/tests/TestCase/Interval/IntervalGettersTest.php
+++ b/tests/TestCase/Interval/IntervalGettersTest.php
@@ -22,63 +22,83 @@ class IntervalGettersTest extends TestCase
 {
     public function testGettersThrowExceptionOnUnknownGetter()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->deprecated(function () {
+            $this->expectException(\InvalidArgumentException::class);
 
-        ChronosInterval::year()->sdfsdfss;
+            ChronosInterval::year()->sdfsdfss;
+        });
     }
 
     public function testYearsGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $this->assertSame(4, $d->years);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $this->assertSame(4, $d->years);
+        });
     }
 
     public function testMonthsGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $this->assertSame(5, $d->months);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $this->assertSame(5, $d->months);
+        });
     }
 
     public function testWeeksGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $this->assertSame(6, $d->weeks);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $this->assertSame(6, $d->weeks);
+        });
     }
 
     public function testDayzExcludingWeeksGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $this->assertSame(5, $d->daysExcludeWeeks);
-        $this->assertSame(5, $d->dayzExcludeWeeks);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $this->assertSame(5, $d->daysExcludeWeeks);
+            $this->assertSame(5, $d->dayzExcludeWeeks);
+        });
     }
 
     public function testDayzGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $this->assertSame(6 * 7 + 5, $d->dayz);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $this->assertSame(6 * 7 + 5, $d->dayz);
+        });
     }
 
     public function testHoursGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $this->assertSame(8, $d->hours);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $this->assertSame(8, $d->hours);
+        });
     }
 
     public function testMinutesGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $this->assertSame(9, $d->minutes);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $this->assertSame(9, $d->minutes);
+        });
     }
 
     public function testSecondsGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
-        $this->assertSame(10, $d->seconds);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
+            $this->assertSame(10, $d->seconds);
+        });
     }
 
     public function testMicrosecondsGetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
-        $this->assertSame(123, $d->microseconds);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
+            $this->assertSame(123, $d->microseconds);
+        });
     }
 }

--- a/tests/TestCase/Interval/IntervalSettersTest.php
+++ b/tests/TestCase/Interval/IntervalSettersTest.php
@@ -22,92 +22,116 @@ class IntervalSettersTest extends TestCase
 {
     public function testYearsSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $d->years = 2;
-        $this->assertSame(2, $d->years);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $d->years = 2;
+            $this->assertSame(2, $d->years);
+        });
     }
 
     public function testMonthsSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $d->months = 11;
-        $this->assertSame(11, $d->months);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $d->months = 11;
+            $this->assertSame(11, $d->months);
+        });
     }
 
     public function testWeeksSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $d->weeks = 11;
-        $this->assertSame(11, $d->weeks);
-        $this->assertSame(7 * 11, $d->dayz);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $d->weeks = 11;
+            $this->assertSame(11, $d->weeks);
+            $this->assertSame(7 * 11, $d->dayz);
+        });
     }
 
     public function testDayzSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $d->dayz = 11;
-        $this->assertSame(11, $d->dayz);
-        $this->assertSame(1, $d->weeks);
-        $this->assertSame(4, $d->dayzExcludeWeeks);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $d->dayz = 11;
+            $this->assertSame(11, $d->dayz);
+            $this->assertSame(1, $d->weeks);
+            $this->assertSame(4, $d->dayzExcludeWeeks);
+        });
     }
 
     public function testHoursSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $d->hours = 12;
-        $this->assertSame(12, $d->hours);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $d->hours = 12;
+            $this->assertSame(12, $d->hours);
+        });
     }
 
     public function testMinutesSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
-        $d->minutes = 11;
-        $this->assertSame(11, $d->minutes);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10);
+            $d->minutes = 11;
+            $this->assertSame(11, $d->minutes);
+        });
     }
 
     public function testSecondsSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
-        $d->seconds = 34;
-        $this->assertSame(34, $d->seconds);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
+            $d->seconds = 34;
+            $this->assertSame(34, $d->seconds);
+        });
     }
 
     public function testMicroecondsSetter()
     {
-        $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
-        $d->microseconds = 456;
-        $this->assertSame(456, $d->microseconds);
+        $this->deprecated(function () {
+            $d = ChronosInterval::create(4, 5, 6, 5, 8, 9, 10, 123);
+            $d->microseconds = 456;
+            $this->assertSame(456, $d->microseconds);
+        });
     }
 
     public function testFluentSetters()
     {
-        $ci = ChronosInterval::years(4)->months(2)->dayz(5)->hours(3)->minute()->seconds(59)->microseconds(123);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 4, 2, 5, 3, 1, 59, 123);
+        $this->deprecated(function () {
+            $ci = ChronosInterval::years(4)->months(2)->dayz(5)->hours(3)->minute()->seconds(59)->microseconds(123);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 4, 2, 5, 3, 1, 59, 123);
 
-        $ci = ChronosInterval::years(4)->months(2)->weeks(2)->hours(3)->minute()->seconds(59)->microseconds(123);
-        $this->assertInstanceOf(ChronosInterval::class, $ci);
-        $this->assertDateTimeInterval($ci, 4, 2, 14, 3, 1, 59, 123);
+            $ci = ChronosInterval::years(4)->months(2)->weeks(2)->hours(3)->minute()->seconds(59)->microseconds(123);
+            $this->assertInstanceOf(ChronosInterval::class, $ci);
+            $this->assertDateTimeInterval($ci, 4, 2, 14, 3, 1, 59, 123);
+        });
     }
 
     public function testFluentSettersDaysOverwritesWeeks()
     {
-        $ci = ChronosInterval::weeks(3)->days(5);
-        $this->assertDateTimeInterval($ci, 0, 0, 5, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = ChronosInterval::weeks(3)->days(5);
+            $this->assertDateTimeInterval($ci, 0, 0, 5, 0, 0, 0);
+        });
     }
 
     public function testFluentSettersWeeksOverwritesDays()
     {
-        $ci = ChronosInterval::days(5)->weeks(3);
-        $this->assertDateTimeInterval($ci, 0, 0, 3 * 7, 0, 0, 0);
+        $this->deprecated(function () {
+            $ci = ChronosInterval::days(5)->weeks(3);
+            $this->assertDateTimeInterval($ci, 0, 0, 3 * 7, 0, 0, 0);
+        });
     }
 
     public function testFluentSettersWeeksAndDaysIsCumulative()
     {
-        $ci = ChronosInterval::year(5)->weeksAndDays(2, 6);
-        $this->assertDateTimeInterval($ci, 5, 0, 20, 0, 0, 0);
-        $this->assertSame(20, $ci->dayz);
-        $this->assertSame(2, $ci->weeks);
-        $this->assertSame(6, $ci->dayzExcludeWeeks);
+        $this->deprecated(function () {
+            $ci = ChronosInterval::year(5)->weeksAndDays(2, 6);
+            $this->assertDateTimeInterval($ci, 5, 0, 20, 0, 0, 0);
+            $this->assertSame(20, $ci->dayz);
+            $this->assertSame(2, $ci->weeks);
+            $this->assertSame(6, $ci->dayzExcludeWeeks);
+        });
     }
 }

--- a/tests/TestCase/Interval/IntervalToStringTest.php
+++ b/tests/TestCase/Interval/IntervalToStringTest.php
@@ -23,14 +23,18 @@ class IntervalToStringTest extends TestCase
 {
     public function testZeroInterval()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0);
-        $this->assertSame('PT0S', (string)$ci);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 0);
+            $this->assertSame('PT0S', (string)$ci);
+        });
     }
 
     public function testNegativeArguments()
     {
-        $ci = new ChronosInterval(1, -2, 0, 15);
-        $this->assertSame('P1Y15D', (string)$ci, 'Negative arguments are not considered');
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(1, -2, 0, 15);
+            $this->assertSame('P1Y15D', (string)$ci, 'Negative arguments are not considered');
+        });
     }
 
     /**
@@ -38,62 +42,72 @@ class IntervalToStringTest extends TestCase
      */
     public function testYearInterval()
     {
-        $ci = new ChronosInterval();
-        $ci1 = new ChronosInterval(1);
-        $ci2 = new ChronosInterval(0, 12, 0, 0);
-        $ci3 = new ChronosInterval(0, 0, 0, 365);
-        $ci4 = new ChronosInterval(0, 0, 52, 1);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval();
+            $ci1 = new ChronosInterval(1);
+            $ci2 = new ChronosInterval(0, 12, 0, 0);
+            $ci3 = new ChronosInterval(0, 0, 0, 365);
+            $ci4 = new ChronosInterval(0, 0, 52, 1);
 
-        $this->assertSame('P1Y', (string)$ci);
-        $this->assertSame('P1Y', (string)$ci1);
-        $this->assertSame('P1Y', (string)$ci2);
-        $this->assertSame('P1Y', (string)$ci3);
-        $this->assertSame('P1Y', (string)$ci4);
+            $this->assertSame('P1Y', (string)$ci);
+            $this->assertSame('P1Y', (string)$ci1);
+            $this->assertSame('P1Y', (string)$ci2);
+            $this->assertSame('P1Y', (string)$ci3);
+            $this->assertSame('P1Y', (string)$ci4);
+        });
     }
 
     public function testMonthInterval()
     {
-        $ci1 = new ChronosInterval(0, 1);
-        $ci2 = new ChronosInterval(0, 0, 0, 30, 10);
-        $ci3 = new ChronosInterval(0, 0, 4, 2, 10);
+        $this->deprecated(function () {
+            $ci1 = new ChronosInterval(0, 1);
+            $ci2 = new ChronosInterval(0, 0, 0, 30, 10);
+            $ci3 = new ChronosInterval(0, 0, 4, 2, 10);
 
-        $this->assertSame('P1M', (string)$ci1);
-        $this->assertSame('P1M', (string)$ci2);
-        $this->assertSame('P1M', (string)$ci3);
+            $this->assertSame('P1M', (string)$ci1);
+            $this->assertSame('P1M', (string)$ci2);
+            $this->assertSame('P1M', (string)$ci3);
+        });
     }
 
     public function testWeekInterval()
     {
-        $ci1 = new ChronosInterval(0, 0, 1);
-        $ci2 = new ChronosInterval(0, 0, 0, 7);
-        $ci3 = new ChronosInterval(0, 0, 0, 0, 7 * 24);
-        $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 7 * 24 * 60);
+        $this->deprecated(function () {
+            $ci1 = new ChronosInterval(0, 0, 1);
+            $ci2 = new ChronosInterval(0, 0, 0, 7);
+            $ci3 = new ChronosInterval(0, 0, 0, 0, 7 * 24);
+            $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 7 * 24 * 60);
 
-        $this->assertSame('P7D', (string)$ci1);
-        $this->assertSame('P7D', (string)$ci2);
-        $this->assertSame('P7D', (string)$ci3);
-        $this->assertSame('P7D', (string)$ci4);
+            $this->assertSame('P7D', (string)$ci1);
+            $this->assertSame('P7D', (string)$ci2);
+            $this->assertSame('P7D', (string)$ci3);
+            $this->assertSame('P7D', (string)$ci4);
+        });
     }
 
     public function testDayInterval()
     {
-        $ci1 = new ChronosInterval(0, 0, 0, 1);
-        $ci2 = new ChronosInterval(0, 0, 0, 0, 24);
-        $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 24 * 60);
-        $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 0, 24 * 60 * 60);
+        $this->deprecated(function () {
+            $ci1 = new ChronosInterval(0, 0, 0, 1);
+            $ci2 = new ChronosInterval(0, 0, 0, 0, 24);
+            $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 24 * 60);
+            $ci4 = new ChronosInterval(0, 0, 0, 0, 0, 0, 24 * 60 * 60);
 
-        $this->assertSame('P1D', (string)$ci1);
-        $this->assertSame('P1D', (string)$ci2);
-        $this->assertSame('P1D', (string)$ci3);
-        $this->assertSame('P1D', (string)$ci4);
+            $this->assertSame('P1D', (string)$ci1);
+            $this->assertSame('P1D', (string)$ci2);
+            $this->assertSame('P1D', (string)$ci3);
+            $this->assertSame('P1D', (string)$ci4);
+        });
     }
 
     public function testMixedDateInterval()
     {
-        $ci1 = new ChronosInterval(1, 2, 0, 3);
-        $ci2 = new ChronosInterval(0, 14, 0, 3);
-        $this->assertSame('P1Y2M3D', (string)$ci1);
-        $this->assertSame('P1Y2M3D', (string)$ci2);
+        $this->deprecated(function () {
+            $ci1 = new ChronosInterval(1, 2, 0, 3);
+            $ci2 = new ChronosInterval(0, 14, 0, 3);
+            $this->assertSame('P1Y2M3D', (string)$ci1);
+            $this->assertSame('P1Y2M3D', (string)$ci2);
+        });
     }
 
     /**
@@ -101,35 +115,43 @@ class IntervalToStringTest extends TestCase
      */
     public function testHourInterval()
     {
-        $ci1 = new ChronosInterval(0, 0, 0, 0, 1);
-        $ci2 = new ChronosInterval(0, 0, 0, 0, 0, 60);
-        $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 0, 3600);
+        $this->deprecated(function () {
+            $ci1 = new ChronosInterval(0, 0, 0, 0, 1);
+            $ci2 = new ChronosInterval(0, 0, 0, 0, 0, 60);
+            $ci3 = new ChronosInterval(0, 0, 0, 0, 0, 0, 3600);
 
-        $this->assertSame('PT1H', (string)$ci1);
-        $this->assertSame('PT1H', (string)$ci2);
-        $this->assertSame('PT1H', (string)$ci3);
+            $this->assertSame('PT1H', (string)$ci1);
+            $this->assertSame('PT1H', (string)$ci2);
+            $this->assertSame('PT1H', (string)$ci3);
+        });
     }
 
     public function testMinuteInterval()
     {
-        $ci1 = new ChronosInterval(0, 0, 0, 0, 0, 1);
-        $ci2 = new ChronosInterval(0, 0, 0, 0, 0, 0, 60);
+        $this->deprecated(function () {
+            $ci1 = new ChronosInterval(0, 0, 0, 0, 0, 1);
+            $ci2 = new ChronosInterval(0, 0, 0, 0, 0, 0, 60);
 
-        $this->assertSame('PT1M', (string)$ci1);
-        $this->assertSame('PT1M', (string)$ci2);
+            $this->assertSame('PT1M', (string)$ci1);
+            $this->assertSame('PT1M', (string)$ci2);
+        });
     }
 
     public function testSecondInterval()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 1);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 0, 0, 0, 1);
 
-        $this->assertSame('PT1S', (string)$ci);
+            $this->assertSame('PT1S', (string)$ci);
+        });
     }
 
     public function testMixedTimeInterval()
     {
-        $ci = new ChronosInterval(0, 0, 0, 0, 1, 2, 3);
-        $this->assertSame('PT1H2M3S', (string)$ci);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(0, 0, 0, 0, 1, 2, 3);
+            $this->assertSame('PT1H2M3S', (string)$ci);
+        });
     }
 
     /**
@@ -137,26 +159,32 @@ class IntervalToStringTest extends TestCase
      */
     public function testMixedDateAndTimeInterval()
     {
-        $ci1 = new ChronosInterval(0, 0, 0, 0, 48, 120);
-        $ci2 = new ChronosInterval(0, 24, 0, 0, 48, 120);
+        $this->deprecated(function () {
+            $ci1 = new ChronosInterval(0, 0, 0, 0, 48, 120);
+            $ci2 = new ChronosInterval(0, 24, 0, 0, 48, 120);
 
-        $this->assertSame('P2DT2H', (string)$ci1);
-        $this->assertSame('P2Y2DT2H', (string)$ci2);
+            $this->assertSame('P2DT2H', (string)$ci1);
+            $this->assertSame('P2Y2DT2H', (string)$ci2);
+        });
     }
 
     public function testCreatingInstanceEquals()
     {
-        $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
-        $this->assertSame(
-            (string)$ci,
-            (string)ChronosInterval::instance(new DateInterval((string)$ci))
-        );
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
+            $this->assertSame(
+                (string)$ci,
+                (string)ChronosInterval::instance(new DateInterval((string)$ci))
+            );
+        });
     }
 
     public function testNegativeInterval()
     {
-        $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
-        $ci->invert = 1;
-        $this->assertSame('-P1Y2M3DT4H5M6S', (string)$ci);
+        $this->deprecated(function () {
+            $ci = new ChronosInterval(1, 2, 0, 3, 4, 5, 6);
+            $ci->invert = 1;
+            $this->assertSame('-P1Y2M3DT4H5M6S', (string)$ci);
+        });
     }
 }

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -20,6 +20,7 @@ use Cake\Chronos\Date;
 use Cake\Chronos\MutableDate;
 use Cake\Chronos\MutableDateTime;
 use Closure;
+use DateInterval;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -122,6 +123,37 @@ abstract class TestCase extends BaseTestCase
 
         if ($microseconds !== null) {
             $this->assertSame($microseconds, $ci->microseconds, 'ChronosInterval->microseconds');
+        }
+    }
+
+    protected function assertDateInterval(DateInterval $interval, $years = null, $months = null, $days = null, $hours = null, $minutes = null, $seconds = null, $microseconds = null)
+    {
+        if ($years !== null) {
+            $this->assertSame($years, $interval->y, 'DateInterval->y');
+        }
+
+        if ($months !== null) {
+            $this->assertSame($months, $interval->m, 'DateInterval->m');
+        }
+
+        if ($days !== null) {
+            $this->assertSame($days, $interval->d, 'DateInterval->d');
+        }
+
+        if ($hours !== null) {
+            $this->assertSame($hours, $interval->h, 'DateInterval->h');
+        }
+
+        if ($minutes !== null) {
+            $this->assertSame($minutes, $interval->i, 'DateInterval->i');
+        }
+
+        if ($seconds !== null) {
+            $this->assertSame($seconds, $interval->s, 'DateInterval->s');
+        }
+
+        if ($microseconds !== null) {
+            $this->assertSame($microseconds, $interval->f, 'DateInterval->f');
         }
     }
 

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -20,7 +20,6 @@ use Cake\Chronos\Date;
 use Cake\Chronos\MutableDate;
 use Cake\Chronos\MutableDateTime;
 use Closure;
-use DateInterval;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -20,6 +20,7 @@ use Cake\Chronos\Date;
 use Cake\Chronos\MutableDate;
 use Cake\Chronos\MutableDateTime;
 use Closure;
+use DateInterval;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase


### PR DESCRIPTION
Backport createInterval() and update diffFiltered() to be compatible with `DateInterval`.

The `createInterval()` method is pretty awkward to use without named parameters. But I don't think there is anything we can do there other than to encourage users to update to PHP8.1