### PR TITLE
2.5 - Backport date

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<Cake\\\\Chronos\\\\Chronos\\> and 'Cake\\\\\\\\Chronos\\\\\\\\ChronosDate' will always evaluate to false\\.$#"
+			count: 2
+			path: src/Chronos.php
+
+		-
 			message: "#^Unsafe call to private method Cake\\\\Chronos\\\\Chronos\\:\\:isTimeExpression\\(\\) through static\\:\\:\\.$#"
 			count: 1
 			path: src/Chronos.php
@@ -11,9 +16,24 @@ parameters:
 			path: src/Chronos.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 10
-			path: src/ChronosInterval.php
+			message: "#^Parameter \\#1 \\$year of static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) expects int, null given\\.$#"
+			count: 1
+			path: src/ChronosDate.php
+
+		-
+			message: "#^Parameter \\#2 \\$month of static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) expects int, null given\\.$#"
+			count: 1
+			path: src/ChronosDate.php
+
+		-
+			message: "#^Parameter \\#3 \\$day of static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) expects int, null given\\.$#"
+			count: 1
+			path: src/ChronosDate.php
+
+		-
+			message: "#^Static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) invoked with 8 parameters, 3 required\\.$#"
+			count: 2
+			path: src/ChronosDate.php
 
 		-
 			message: "#^Unsafe call to private method Cake\\\\Chronos\\\\ChronosDate\\:\\:isRelativeOnly\\(\\) through static\\:\\:\\.$#"
@@ -26,9 +46,19 @@ parameters:
 			path: src/ChronosDate.php
 
 		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 10
+			path: src/ChronosInterval.php
+
+		-
 			message: "#^Access to an undefined property Cake\\\\Chronos\\\\ChronosInterface\\:\\:\\$tz\\.$#"
 			count: 1
 			path: src/DifferenceFormatter.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<Cake\\\\Chronos\\\\MutableDate\\> and 'Cake\\\\\\\\Chronos\\\\\\\\ChronosDate' will always evaluate to false\\.$#"
+			count: 2
+			path: src/MutableDate.php
 
 		-
 			message: "#^Unsafe call to private method Cake\\\\Chronos\\\\MutableDate\\:\\:isRelativeOnly\\(\\) through static\\:\\:\\.$#"
@@ -39,6 +69,11 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 13
 			path: src/MutableDate.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<Cake\\\\Chronos\\\\MutableDateTime\\> and 'Cake\\\\\\\\Chronos\\\\\\\\ChronosDate' will always evaluate to false\\.$#"
+			count: 2
+			path: src/MutableDateTime.php
 
 		-
 			message: "#^Unsafe call to private method Cake\\\\Chronos\\\\MutableDateTime\\:\\:isTimeExpression\\(\\) through static\\:\\:\\.$#"

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -277,4 +277,27 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
 
         return $properties;
     }
+
+    /**
+     * Deprecation helper to compare types
+     *
+     * Future versions of Chronos will not support comparing date/datetimes to each other.
+     *
+     * @param object $first The first object.
+     * @param object|null $second The second object
+     * @return void
+     * @internal
+     */
+    public static function checkTypes(object $first, $second): void
+    {
+        $firstClass = get_class($first);
+        $secondClass = $second !== null ? get_class($second) : null;
+        if ($second !== null && $firstClass !== $secondClass) {
+            trigger_error(
+                "2.5 Comparing {$firstClass} and {$secondClass} is deprecated. " .
+                'In 3.0 this functionality will be removed.',
+                E_USER_DEPRECATED
+            );
+        }
+    }
 }

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace Cake\Chronos;
 
-use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
@@ -156,7 +155,7 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
     {
         $instance = static::createFromFormat(
             'Y-m-d',
-            sprintf('%s-%s-%s', 0, $month, $day),
+            sprintf('%s-%s-%s', 0, $month, $day)
         );
 
         return $instance->addYears($year);

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -171,7 +171,7 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      * @return static A modified Date instance
      */
     #[\ReturnTypeWillChange]
-    public function add(DateInterval $interval)
+    public function add($interval)
     {
         if ($interval->f > 0 || $interval->s > 0 || $interval->i > 0 || $interval->h > 0) {
             trigger_error('2.5 Adding intervals with time components will be removed in 3.0', E_USER_DEPRECATED);
@@ -189,7 +189,7 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      * @return static A modified Date instance
      */
     #[\ReturnTypeWillChange]
-    public function sub(DateInterval $interval)
+    public function sub($interval)
     {
         if ($interval->f > 0 || $interval->s > 0 || $interval->i > 0 || $interval->h > 0) {
             trigger_error('2.5 Subtracting intervals with time components will be removed in 3.0', E_USER_DEPRECATED);

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -152,7 +152,7 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      * @param int $day The day to create an instance with.
      * @return static
      */
-    public static function create(int $year, int $month, int $day): static
+    public static function create(int $year, int $month, int $day)
     {
         $instance = static::createFromFormat(
             'Y-m-d',
@@ -170,7 +170,8 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      * @param \DateInterval $interval The interval to modify this date by.
      * @return static A modified Date instance
      */
-    public function add(DateInterval $interval): static
+    #[\ReturnTypeWillChange]
+    public function add(DateInterval $interval)
     {
         if ($interval->f > 0 || $interval->s > 0 || $interval->i > 0 || $interval->h > 0) {
             trigger_error('2.5 Adding intervals with time components will be removed in 3.0', E_USER_DEPRECATED);
@@ -187,7 +188,8 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      * @param \DateInterval $interval The interval to modify this date by.
      * @return static A modified Date instance
      */
-    public function sub(DateInterval $interval): static
+    #[\ReturnTypeWillChange]
+    public function sub(DateInterval $interval)
     {
         if ($interval->f > 0 || $interval->s > 0 || $interval->i > 0 || $interval->h > 0) {
             trigger_error('2.5 Subtracting intervals with time components will be removed in 3.0', E_USER_DEPRECATED);
@@ -204,7 +206,8 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      * @param string $modifier Date modifier
      * @return static
      */
-    public function modify(string $modifier): static
+    #[\ReturnTypeWillChange]
+    public function modify(string $modifier)
     {
         if (preg_match('/hour|minute|second/', $modifier)) {
             trigger_error('2.5 Modifying dates with time values will be removed in 3.0', E_USER_DEPRECATED);
@@ -225,7 +228,8 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
     /**
      * @inheritDoc
      */
-    public function setTimestamp($value): static
+    #[\ReturnTypeWillChange]
+    public function setTimestamp($value)
     {
         trigger_error('2.5 Setting timestamp values on Date values will be removed in 3.0', E_USER_DEPRECATED);
 

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 
 namespace Cake\Chronos;
 
+use DateInterval;
 use DateTimeImmutable;
 use DateTimeZone;
+use InvalidArgumentException;
 
 /**
  * An immutable date object that converts all time components into 00:00:00.
@@ -122,6 +124,8 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      */
     public function toMutable(): MutableDate
     {
+        trigger_error('2.5 Mutable classes will be removed in 3.0', E_USER_DEPRECATED);
+
         return MutableDate::instance($this);
     }
 
@@ -138,6 +142,143 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
         ];
 
         return $properties;
+    }
+
+    /**
+     * Create an instance from a specific date.
+     *
+     * @param int $year The year to create an instance with.
+     * @param int $month The month to create an instance with.
+     * @param int $day The day to create an instance with.
+     * @return static
+     */
+    public static function create(int $year, int $month, int $day): static
+    {
+        $instance = static::createFromFormat(
+            'Y-m-d',
+            sprintf('%s-%s-%s', 0, $month, $day),
+        );
+
+        return $instance->addYears($year);
+    }
+
+    /**
+     * Add an Interval to a Date
+     *
+     * Any changes to the time will cause an exception to be raised.
+     *
+     * @param \DateInterval $interval The interval to modify this date by.
+     * @return static A modified Date instance
+     */
+    public function add(DateInterval $interval): static
+    {
+        if ($interval->f > 0 || $interval->s > 0 || $interval->i > 0 || $interval->h > 0) {
+            trigger_error('2.5 Adding intervals with time components will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
+        return parent::add($interval)->setTime(0, 0, 0);
+    }
+
+    /**
+     * Subtract an Interval from a Date.
+     *
+     * Any changes to the time will cause an exception to be raised.
+     *
+     * @param \DateInterval $interval The interval to modify this date by.
+     * @return static A modified Date instance
+     */
+    public function sub(DateInterval $interval): static
+    {
+        if ($interval->f > 0 || $interval->s > 0 || $interval->i > 0 || $interval->h > 0) {
+            trigger_error('2.5 Subtracting intervals with time components will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
+        return parent::sub($interval)->setTime(0, 0, 0);
+    }
+
+    /**
+     * Creates a new instance with date modified according to DateTimeImmutable::modifier().
+     *
+     * Attempting to change a time component will raise an exception
+     *
+     * @param string $modifier Date modifier
+     * @return static
+     */
+    public function modify(string $modifier): static
+    {
+        if (preg_match('/hour|minute|second/', $modifier)) {
+            trigger_error('2.5 Modifying dates with time values will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
+        $new = parent::modify($modifier);
+        if ($new === false) {
+            throw new InvalidArgumentException('Unable to modify date using: ' . $modifier);
+        }
+
+        if ($new->format('H:i:s') !== '00:00:00') {
+            $new = $new->setTime(0, 0, 0);
+        }
+
+        return $new;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setTimestamp($value): static
+    {
+        trigger_error('2.5 Setting timestamp values on Date values will be removed in 3.0', E_USER_DEPRECATED);
+
+        return parent::setTimestamp($value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hour(int $value): ChronosInterface
+    {
+        trigger_error('2.5 Modifying hours on Date values will be removed in 3.0', E_USER_DEPRECATED);
+
+        return $this->setTime($value, $this->minute, $this->second);
+    }
+
+    /**
+     * Set the instance's minute
+     *
+     * @param int $value The minute value.
+     * @return static
+     */
+    public function minute(int $value): ChronosInterface
+    {
+        trigger_error('2.5 Modifying minutes on Date values will be removed in 3.0', E_USER_DEPRECATED);
+
+        return $this->setTime($this->hour, $value, $this->second);
+    }
+
+    /**
+     * Set the instance's second
+     *
+     * @param int $value The seconds value.
+     * @return static
+     */
+    public function second(int $value): ChronosInterface
+    {
+        trigger_error('2.5 Modifying second on Date values will be removed in 3.0', E_USER_DEPRECATED);
+
+        return $this->setTime($this->hour, $this->minute, $value);
+    }
+
+    /**
+     * Set the instance's microsecond
+     *
+     * @param int $value The microsecond value.
+     * @return static
+     */
+    public function microsecond(int $value): ChronosInterface
+    {
+        trigger_error('2.5 Modifying microsecond on Date values will be removed in 3.0', E_USER_DEPRECATED);
+
+        return $this->setTime($this->hour, $this->minute, $this->second, $value);
     }
 }
 

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -207,7 +207,7 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      * @return static
      */
     #[\ReturnTypeWillChange]
-    public function modify(string $modifier)
+    public function modify($modifier)
     {
         if (preg_match('/hour|minute|second/', $modifier)) {
             trigger_error('2.5 Modifying dates with time values will be removed in 3.0', E_USER_DEPRECATED);

--- a/src/Traits/ComparisonTrait.php
+++ b/src/Traits/ComparisonTrait.php
@@ -57,10 +57,13 @@ trait ComparisonTrait
      *
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
+     * @deprecated 2.5 eq() is deprecated. Use equals() instead.
      */
     public function eq(ChronosInterface $dt): bool
     {
-        return $this == $dt;
+        trigger_error('2.5 eq() is deprecated. Use equals() instead.');
+
+        return $this->equals($dt);
     }
 
     /**
@@ -71,7 +74,7 @@ trait ComparisonTrait
      */
     public function equals(ChronosInterface $dt)
     {
-        return $this->eq($dt);
+        return $this == $dt;
     }
 
     /**
@@ -79,10 +82,13 @@ trait ComparisonTrait
      *
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
+     * @deprecated 2.5 ne() is deprecated. Use notEquals() instead.
      */
     public function ne(ChronosInterface $dt): bool
     {
-        return !$this->eq($dt);
+        trigger_error('2.5 ne() is deprecated. Use notEquals() instead.');
+
+        return $this->notEquals($dt);
     }
 
     /**
@@ -93,7 +99,7 @@ trait ComparisonTrait
      */
     public function notEquals(ChronosInterface $dt)
     {
-        return $this->ne($dt);
+        return !$this->equals($dt);
     }
 
     /**
@@ -101,10 +107,13 @@ trait ComparisonTrait
      *
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
+     * @deprecated 2.5 gt() is deprecated. Use greaterThan() instead.
      */
     public function gt(ChronosInterface $dt): bool
     {
-        return $this > $dt;
+        trigger_error('2.5 gt() is deprecated. Use greaterThan() instead.');
+
+        return $this->greaterThan($dt);
     }
 
     /**
@@ -115,7 +124,7 @@ trait ComparisonTrait
      */
     public function greaterThan(ChronosInterface $dt)
     {
-        return $this->gt($dt);
+        return $this > $dt;
     }
 
     /**
@@ -123,10 +132,13 @@ trait ComparisonTrait
      *
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
+     * @deprecated 2.5 gte() is deprecated. Use greaterThanOrEquals() instead.
      */
     public function gte(ChronosInterface $dt): bool
     {
-        return $this >= $dt;
+        trigger_error('2.5 gte() is deprecated. Use greaterThanOrEquals() instead.');
+
+        return $this->greaterThanOrEquals($dt);
     }
 
     /**
@@ -137,7 +149,7 @@ trait ComparisonTrait
      */
     public function greaterThanOrEquals(ChronosInterface $dt)
     {
-        return $this->gte($dt);
+        return $this >= $dt;
     }
 
     /**
@@ -145,10 +157,13 @@ trait ComparisonTrait
      *
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
+     * @deprecated 2.5 lt() is deprecated. Use lessThan instead.
      */
     public function lt(ChronosInterface $dt): bool
     {
-        return $this < $dt;
+        trigger_error('2.5 lt() is deprecated. Use lessThan() instead.');
+
+        return $this->lessThan($dt);
     }
 
     /**
@@ -159,7 +174,7 @@ trait ComparisonTrait
      */
     public function lessThan(ChronosInterface $dt)
     {
-        return $this->lt($dt);
+        return $this < $dt;
     }
 
     /**
@@ -167,10 +182,13 @@ trait ComparisonTrait
      *
      * @param \Cake\Chronos\ChronosInterface $dt The instance to compare with.
      * @return bool
+     * @deprecated 2.5 lte() is deprecated. Use lessThanOrEquals() instead.
      */
     public function lte(ChronosInterface $dt): bool
     {
-        return $this <= $dt;
+        trigger_error('2.5 lte() is deprecated. Use lessthanOrEquals() instead.');
+
+        return $this->lessThanOrEquals($dt);
     }
 
     /**
@@ -181,7 +199,28 @@ trait ComparisonTrait
      */
     public function lessThanOrEquals(ChronosInterface $dt)
     {
-        return $this->lte($dt);
+        return $this <= $dt;
+    }
+
+    /**
+     * Deprecation helper to compare types
+     *
+     * Future versions of Chronos will not support comparing date/datetimes to each other.
+     *
+     * @param object $first The first object.
+     * @param object|null $second The second object
+     * @return void
+     */
+    private function checkTypes(object $first, object $second): void
+    {
+        $firstClass = get_class($first);
+        $secondClass = get_class($second);
+        if ($second !== null && $firstClass !== $secondClass) {
+            trigger_error(
+                "2.5 Comparing {$firstClass} and {$secondClass} is deprecated. " .
+                'In 3.0 this functionality will be removed.'
+            );
+        }
     }
 
     /**
@@ -199,12 +238,13 @@ trait ComparisonTrait
             $dt1 = $dt2;
             $dt2 = $temp;
         }
+        $this->checkTypes($dt1, $dt2);
 
         if ($equal) {
-            return $this->gte($dt1) && $this->lte($dt2);
+            return $this->greaterThanOrEquals($dt1) && $this->lessThanOrEquals($dt2);
         }
 
-        return $this->gt($dt1) && $this->lt($dt2);
+        return $this->greaterThan($dt1) && $this->lessThan($dt2);
     }
 
     /**
@@ -241,7 +281,7 @@ trait ComparisonTrait
     {
         $dt = $dt ?? static::now($this->tz);
 
-        return $this->lt($dt) ? $this : $dt;
+        return $this->lessThan($dt) ? $this : $dt;
     }
 
     /**
@@ -254,7 +294,7 @@ trait ComparisonTrait
     {
         $dt = $dt ?? static::now($this->tz);
 
-        return $this->gt($dt) ? $this : $dt;
+        return $this->greaterThan($dt) ? $this : $dt;
     }
 
     /**
@@ -374,7 +414,7 @@ trait ComparisonTrait
      */
     public function isFuture(): bool
     {
-        return $this->gt(static::now($this->tz));
+        return $this->greaterThan(static::now($this->tz));
     }
 
     /**
@@ -384,7 +424,7 @@ trait ComparisonTrait
      */
     public function isPast(): bool
     {
-        return $this->lt(static::now($this->tz));
+        return $this->lessThan(static::now($this->tz));
     }
 
     /**

--- a/src/Traits/ComparisonTrait.php
+++ b/src/Traits/ComparisonTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
+use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosInterface;
 use DateTime;
 
@@ -61,7 +62,7 @@ trait ComparisonTrait
      */
     public function eq(ChronosInterface $dt): bool
     {
-        trigger_error('2.5 eq() is deprecated. Use equals() instead.');
+        trigger_error('2.5 eq() is deprecated. Use equals() instead.', E_USER_DEPRECATED);
 
         return $this->equals($dt);
     }
@@ -86,7 +87,7 @@ trait ComparisonTrait
      */
     public function ne(ChronosInterface $dt): bool
     {
-        trigger_error('2.5 ne() is deprecated. Use notEquals() instead.');
+        trigger_error('2.5 ne() is deprecated. Use notEquals() instead.', E_USER_DEPRECATED);
 
         return $this->notEquals($dt);
     }
@@ -111,7 +112,7 @@ trait ComparisonTrait
      */
     public function gt(ChronosInterface $dt): bool
     {
-        trigger_error('2.5 gt() is deprecated. Use greaterThan() instead.');
+        trigger_error('2.5 gt() is deprecated. Use greaterThan() instead.', E_USER_DEPRECATED);
 
         return $this->greaterThan($dt);
     }
@@ -136,7 +137,7 @@ trait ComparisonTrait
      */
     public function gte(ChronosInterface $dt): bool
     {
-        trigger_error('2.5 gte() is deprecated. Use greaterThanOrEquals() instead.');
+        trigger_error('2.5 gte() is deprecated. Use greaterThanOrEquals() instead.', E_USER_DEPRECATED);
 
         return $this->greaterThanOrEquals($dt);
     }
@@ -161,7 +162,7 @@ trait ComparisonTrait
      */
     public function lt(ChronosInterface $dt): bool
     {
-        trigger_error('2.5 lt() is deprecated. Use lessThan() instead.');
+        trigger_error('2.5 lt() is deprecated. Use lessThan() instead.', E_USER_DEPRECATED);
 
         return $this->lessThan($dt);
     }
@@ -186,7 +187,7 @@ trait ComparisonTrait
      */
     public function lte(ChronosInterface $dt): bool
     {
-        trigger_error('2.5 lte() is deprecated. Use lessthanOrEquals() instead.');
+        trigger_error('2.5 lte() is deprecated. Use lessthanOrEquals() instead.', E_USER_DEPRECATED);
 
         return $this->lessThanOrEquals($dt);
     }
@@ -203,27 +204,6 @@ trait ComparisonTrait
     }
 
     /**
-     * Deprecation helper to compare types
-     *
-     * Future versions of Chronos will not support comparing date/datetimes to each other.
-     *
-     * @param object $first The first object.
-     * @param object|null $second The second object
-     * @return void
-     */
-    private function checkTypes(object $first, object $second): void
-    {
-        $firstClass = get_class($first);
-        $secondClass = get_class($second);
-        if ($second !== null && $firstClass !== $secondClass) {
-            trigger_error(
-                "2.5 Comparing {$firstClass} and {$secondClass} is deprecated. " .
-                'In 3.0 this functionality will be removed.'
-            );
-        }
-    }
-
-    /**
      * Determines if the instance is between two others
      *
      * @param \Cake\Chronos\ChronosInterface $dt1 The instance to compare with.
@@ -233,12 +213,12 @@ trait ComparisonTrait
      */
     public function between(ChronosInterface $dt1, ChronosInterface $dt2, bool $equal = true): bool
     {
-        if ($dt1->gt($dt2)) {
+        if ($dt1->greaterThan($dt2)) {
             $temp = $dt1;
             $dt1 = $dt2;
             $dt2 = $temp;
         }
-        $this->checkTypes($dt1, $dt2);
+        Chronos::checkTypes($dt1, $dt2);
 
         if ($equal) {
             return $this->greaterThanOrEquals($dt1) && $this->lessThanOrEquals($dt2);

--- a/src/Traits/DifferenceTrait.php
+++ b/src/Traits/DifferenceTrait.php
@@ -49,6 +49,8 @@ trait DifferenceTrait
      */
     public function diffInYears(?ChronosInterface $dt = null, bool $abs = true): int
     {
+        $this->checkTypes($this, $dt);
+
         $diff = $this->diff($dt ?? static::now($this->tz), $abs);
 
         return $diff->invert ? -$diff->y : $diff->y;
@@ -166,6 +168,7 @@ trait DifferenceTrait
         $start = $this;
         $end = $dt ?? static::now($this->tz);
         $inverse = false;
+        $this->checkTypes($start, $end);
 
         if ($end < $start) {
             $start = $end;

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Traits;
 
+use Cake\Chronos\ChronosDate;
 use Cake\Chronos\ChronosInterface;
 use DateTimeInterface;
 use DateTimeZone;
@@ -113,6 +114,10 @@ trait FactoryTrait
      */
     public static function maxValue(): ChronosInterface
     {
+        if (static::class == ChronosDate::class) {
+            trigger_error('2.5 Using minValue to create Date objects will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
         return static::createFromTimestampUTC(PHP_INT_MAX);
     }
 
@@ -123,6 +128,9 @@ trait FactoryTrait
      */
     public static function minValue(): ChronosInterface
     {
+        if (static::class == ChronosDate::class) {
+            trigger_error('2.5 Using minValue to create Date objects will be removed in 3.0', E_USER_DEPRECATED);
+        }
         $max = PHP_INT_SIZE === 4 ? PHP_INT_MAX : PHP_INT_MAX / 10;
 
         return static::createFromTimestampUTC(~$max);
@@ -219,6 +227,10 @@ trait FactoryTrait
         ?int $microsecond = null,
         $tz = null
     ): ChronosInterface {
+        if (static::class == ChronosDate::class) {
+            trigger_error('2.5 Using createFromTime to create Date objects will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
         return static::create(null, null, null, $hour, $minute, $second, $microsecond, $tz);
     }
 

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -114,10 +114,6 @@ trait FactoryTrait
      */
     public static function maxValue(): ChronosInterface
     {
-        if (static::class == ChronosDate::class) {
-            trigger_error('2.5 Using minValue to create Date objects will be removed in 3.0', E_USER_DEPRECATED);
-        }
-
         return static::createFromTimestampUTC(PHP_INT_MAX);
     }
 
@@ -128,9 +124,6 @@ trait FactoryTrait
      */
     public static function minValue(): ChronosInterface
     {
-        if (static::class == ChronosDate::class) {
-            trigger_error('2.5 Using minValue to create Date objects will be removed in 3.0', E_USER_DEPRECATED);
-        }
         $max = PHP_INT_SIZE === 4 ? PHP_INT_MAX : PHP_INT_MAX / 10;
 
         return static::createFromTimestampUTC(~$max);
@@ -227,11 +220,12 @@ trait FactoryTrait
         ?int $microsecond = null,
         $tz = null
     ): ChronosInterface {
-        if (static::class == ChronosDate::class) {
+        $instance = static::create(null, null, null, $hour, $minute, $second, $microsecond, $tz);
+        if (get_class($instance) === ChronosDate::class) {
             trigger_error('2.5 Using createFromTime to create Date objects will be removed in 3.0', E_USER_DEPRECATED);
         }
 
-        return static::create(null, null, null, $hour, $minute, $second, $microsecond, $tz);
+        return $instance;
     }
 
     /**
@@ -338,7 +332,12 @@ trait FactoryTrait
      */
     public static function createFromTimestampUTC(int $timestamp): ChronosInterface
     {
-        return new static($timestamp);
+        $instance = new static($timestamp);
+        if (get_class($instance) === ChronosDate::class) {
+            trigger_error('2.5 Creating Date objects from timestamps will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
+        return $instance;
     }
 
     /**

--- a/tests/TestCase/Date/AddTest.php
+++ b/tests/TestCase/Date/AddTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos\Test\TestCase\Date;
 
+use Cake\Chronos\MutableDate;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateInterval;
 
@@ -41,16 +42,22 @@ class AddTest extends TestCase
      */
     public function testAddIgnoreTime($class)
     {
-        $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
-        $date = $class::create(2001, 1, 1);
-        $new = $date->add($interval);
+        $scenario = function () use ($class) {
+            $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
+            $date = $class::create(2001, 1, 1);
+            $new = $date->add($interval);
 
-        $this->assertSame(0, $new->hour);
-        $this->assertSame(0, $new->minute);
-        $this->assertSame(0, $new->second);
-        $this->assertSame(0, $date->hour);
-        $this->assertSame(0, $date->minute);
-        $this->assertSame(0, $date->second);
+            $this->assertSame(0, $new->hour);
+            $this->assertSame(0, $new->minute);
+            $this->assertSame(0, $new->second);
+            $this->assertSame(0, $date->hour);
+            $this->assertSame(0, $date->minute);
+            $this->assertSame(0, $date->second);
+        };
+        if ($class == MutableDate::class) {
+            return $scenario();
+        }
+        $this->deprecated($scenario);
     }
 
     /**
@@ -75,16 +82,22 @@ class AddTest extends TestCase
      */
     public function testSubIgnoreTime($class)
     {
-        $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
-        $date = $class::create(2001, 1, 1);
-        $new = $date->sub($interval);
+        $scenario = function () use ($class) {
+            $interval = DateInterval::createFromDateString('1 hour, 1 minute, 3 seconds');
+            $date = $class::create(2001, 1, 1);
+            $new = $date->sub($interval);
 
-        $this->assertSame(0, $new->hour);
-        $this->assertSame(0, $new->minute);
-        $this->assertSame(0, $new->second);
-        $this->assertSame(0, $date->hour);
-        $this->assertSame(0, $date->minute);
-        $this->assertSame(0, $date->second);
+            $this->assertSame(0, $new->hour);
+            $this->assertSame(0, $new->minute);
+            $this->assertSame(0, $new->second);
+            $this->assertSame(0, $date->hour);
+            $this->assertSame(0, $date->minute);
+            $this->assertSame(0, $date->second);
+        };
+        if ($class == MutableDate::class) {
+            return $scenario();
+        }
+        $this->deprecated($scenario);
     }
 
     /**

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -63,7 +63,7 @@ class ConstructTest extends TestCase
      */
     public function testCreateFromTimestamp($class)
     {
-        $this->withTimezone('Europe/Berlin', function () use ($class) {
+        $scenario = function () use ($class) {
             $ts = 1454284800;
 
             $date = $class::createFromTimestamp($ts);
@@ -73,7 +73,14 @@ class ConstructTest extends TestCase
             $date = new $class($ts);
             $this->assertSame('Europe/Berlin', $date->tzName);
             $this->assertSame('2016-02-01', $date->format('Y-m-d'));
-        });
+        };
+        $wrapped = $scenario;
+        if ($class != MutableDate::class) {
+            $wrapped = function () use ($scenario) {
+                $this->deprecated($scenario);
+            };
+        }
+        $this->withTimezone('Europe/Berlin', $wrapped);
     }
 
     /**

--- a/tests/TestCase/Date/DateMutabilityConversionTest.php
+++ b/tests/TestCase/Date/DateMutabilityConversionTest.php
@@ -43,9 +43,11 @@ class DateMutabilityConversionTest extends TestCase
 
     public function testToMutable()
     {
-        $dt1 = ChronosDate::create(2001, 2, 3, 10, 20, 30);
-        $dt2 = $dt1->toMutable();
-        $this->checkBothInstances($dt2, $dt1);
+        $this->deprecated(function () {
+            $dt1 = ChronosDate::create(2001, 2, 3, 10, 20, 30);
+            $dt2 = $dt1->toMutable();
+            $this->checkBothInstances($dt2, $dt1);
+        });
     }
 
     public function testMutableFromImmutable()

--- a/tests/TestCase/Date/TimeMutateTest.php
+++ b/tests/TestCase/Date/TimeMutateTest.php
@@ -39,15 +39,17 @@ class TimeMutateTest extends TestCase
      */
     public function testModifyFails($value)
     {
-        $date = new ChronosDate();
-        $new = $date->modify($value);
+        $this->deprecated(function () use ($value) {
+            $date = new ChronosDate();
+            $new = $date->modify($value);
 
-        $this->assertSame(0, $date->hour);
-        $this->assertSame(0, $date->minute);
-        $this->assertSame(0, $date->second);
-        $this->assertSame(0, $new->hour);
-        $this->assertSame(0, $new->minute);
-        $this->assertSame(0, $new->second);
+            $this->assertSame(0, $date->hour);
+            $this->assertSame(0, $date->minute);
+            $this->assertSame(0, $date->second);
+            $this->assertSame(0, $new->hour);
+            $this->assertSame(0, $new->minute);
+            $this->assertSame(0, $new->second);
+        });
     }
 
     /**
@@ -75,16 +77,18 @@ class TimeMutateTest extends TestCase
      */
     public function testSetterMethodIsIgnored($method, $value)
     {
-        $date = new ChronosDate();
-        $new = $date->{$method}($value);
-        $this->assertSame(0, $new->hour);
-        $this->assertSame(0, $new->minute);
-        $this->assertSame(0, $new->second);
-        $this->assertSame('000000', $new->format('u'));
-        $this->assertSame(0, $date->hour);
-        $this->assertSame(0, $date->minute);
-        $this->assertSame(0, $date->second);
-        $this->assertSame('000000', $date->format('u'));
+        $this->deprecated(function () use ($method, $value) {
+            $date = new ChronosDate();
+            $new = $date->{$method}($value);
+            $this->assertSame(0, $new->hour);
+            $this->assertSame(0, $new->minute);
+            $this->assertSame(0, $new->second);
+            $this->assertSame('000000', $new->format('u'));
+            $this->assertSame(0, $date->hour);
+            $this->assertSame(0, $date->minute);
+            $this->assertSame(0, $date->second);
+            $this->assertSame('000000', $date->format('u'));
+        });
     }
 
     /**
@@ -92,6 +96,7 @@ class TimeMutateTest extends TestCase
      */
     public function testSetTimeIgnored()
     {
+        // This should have a deprecation but we use it internally quite a bit.
         $date = new ChronosDate();
         $new = $date->setTime(1, 2, 3, 4);
         $this->assertSame(0, $new->hour);
@@ -111,17 +116,19 @@ class TimeMutateTest extends TestCase
      */
     public function testSetTimestampRemovesTime()
     {
-        $date = new ChronosDate();
-        $date->setTimestamp(strtotime('+2 hours +2 minutes'));
-        $this->assertSame(0, $date->hour);
-        $this->assertSame(0, $date->minute);
-        $this->assertSame(0, $date->second);
+        $this->deprecated(function () {
+            $date = new ChronosDate();
+            $date->setTimestamp(strtotime('+2 hours +2 minutes'));
+            $this->assertSame(0, $date->hour);
+            $this->assertSame(0, $date->minute);
+            $this->assertSame(0, $date->second);
 
-        $date = new ChronosDate();
-        $date->timestamp(strtotime('+2 hours +2 minutes'));
-        $this->assertSame(0, $date->hour);
-        $this->assertSame(0, $date->minute);
-        $this->assertSame(0, $date->second);
+            $date = new ChronosDate();
+            $date->timestamp(strtotime('+2 hours +2 minutes'));
+            $this->assertSame(0, $date->hour);
+            $this->assertSame(0, $date->minute);
+            $this->assertSame(0, $date->second);
+        });
     }
 
     public function testStartOfDay()

--- a/tests/TestCase/DateTime/ComparisonTest.php
+++ b/tests/TestCase/DateTime/ComparisonTest.php
@@ -42,9 +42,10 @@ class ComparisonTest extends TestCase
      */
     public function testEqualToTrue($class)
     {
-        foreach (['eq', 'equals'] as $func) {
-            $this->assertTrue($class::create(2000, 1, 1, 0, 0, 0)->{$func}($class::create(2000, 1, 1, 0, 0, 0)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertTrue($class::create(2000, 1, 1, 0, 0, 0)->eq($class::create(2000, 1, 1, 0, 0, 0)));
+        });
+        $this->assertTrue($class::create(2000, 1, 1, 0, 0, 0)->equals($class::create(2000, 1, 1, 0, 0, 0)));
     }
 
     /**
@@ -53,9 +54,10 @@ class ComparisonTest extends TestCase
      */
     public function testEqualToFalse($class)
     {
-        foreach (['eq', 'equals'] as $func) {
-            $this->assertFalse($class::create(2000, 1, 1, 0, 0, 0)->{$func}($class::create(2000, 1, 2, 0, 0, 0)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertFalse($class::create(2000, 1, 1, 0, 0, 0)->eq($class::create(2000, 1, 2, 0, 0, 0)));
+        });
+        $this->assertFalse($class::create(2000, 1, 1, 0, 0, 0)->equals($class::create(2000, 1, 2, 0, 0, 0)));
     }
 
     /**
@@ -64,18 +66,11 @@ class ComparisonTest extends TestCase
      */
     public function testEqualWithTimezoneTrue($class)
     {
-        foreach (['eq', 'equals'] as $func) {
-            $this->assertTrue($class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto')->{$func}($class::create(
-                2000,
-                1,
-                1,
-                9,
-                0,
-                0,
-                0,
-                'America/Vancouver'
-            )));
-        }
+        $compare = $class::create(2000, 1, 1, 9, 0, 0, 0, 'America/Vancouver');
+        $this->deprecated(function () use ($class, $compare) {
+            $this->assertTrue($class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto')->eq($compare));
+        });
+        $this->assertTrue($class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto')->equals($compare));
     }
 
     /**
@@ -84,14 +79,11 @@ class ComparisonTest extends TestCase
      */
     public function testEqualWithTimezoneFalse($class)
     {
-        foreach (['eq', 'equals'] as $func) {
-            $this->assertFalse($class::createFromDate(2000, 1, 1, 'America/Toronto')->{$func}($class::createFromDate(
-                2000,
-                1,
-                1,
-                'America/Vancouver'
-            )));
-        }
+        $compare = $class::createFromDate(2000, 1, 1, 'America/Vancouver');
+        $this->deprecated(function () use ($class, $compare) {
+            $this->assertFalse($class::createFromDate(2000, 1, 1, 'America/Toronto')->eq($compare));
+        });
+        $this->assertFalse($class::createFromDate(2000, 1, 1, 'America/Toronto')->equals($compare));
     }
 
     /**
@@ -100,9 +92,10 @@ class ComparisonTest extends TestCase
      */
     public function testNotEqualToTrue($class)
     {
-        foreach (['ne', 'notEquals'] as $func) {
-            $this->assertTrue($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(2000, 1, 2)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertTrue($class::createFromDate(2000, 1, 1)->ne($class::createFromDate(2000, 1, 2)));
+        });
+        $this->assertTrue($class::createFromDate(2000, 1, 1)->notEquals($class::createFromDate(2000, 1, 2)));
     }
 
     /**
@@ -111,9 +104,10 @@ class ComparisonTest extends TestCase
      */
     public function testNotEqualToFalse($class)
     {
-        foreach (['ne', 'notEquals'] as $func) {
-            $this->assertFalse($class::create(2000, 1, 1, 0, 0, 0)->{$func}($class::create(2000, 1, 1, 0, 0, 0)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertFalse($class::create(2000, 1, 1, 0, 0, 0)->ne($class::create(2000, 1, 1, 0, 0, 0)));
+        });
+        $this->assertFalse($class::create(2000, 1, 1, 0, 0, 0)->notEquals($class::create(2000, 1, 1, 0, 0, 0)));
     }
 
     /**
@@ -122,14 +116,11 @@ class ComparisonTest extends TestCase
      */
     public function testNotEqualWithTimezone($class)
     {
-        foreach (['ne', 'notEquals'] as $func) {
-            $this->assertTrue($class::createFromDate(2000, 1, 1, 'America/Toronto')->{$func}($class::createFromDate(
-                2000,
-                1,
-                1,
-                'America/Vancouver'
-            )));
-        }
+        $compare = $class::createFromDate(2000, 1, 1, 'America/Vancouver');
+        $this->deprecated(function () use ($class, $compare) {
+            $this->assertTrue($class::createFromDate(2000, 1, 1, 'America/Toronto')->ne($compare));
+        });
+        $this->assertTrue($class::createFromDate(2000, 1, 1, 'America/Toronto')->notEquals($compare));
     }
 
     /**
@@ -138,9 +129,10 @@ class ComparisonTest extends TestCase
      */
     public function testGreaterThanTrue($class)
     {
-        foreach (['gt', 'greaterThan'] as $func) {
-            $this->assertTrue($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(1999, 12, 31)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertTrue($class::createFromDate(2000, 1, 1)->gt($class::createFromDate(1999, 12, 31)));
+        });
+        $this->assertTrue($class::createFromDate(2000, 1, 1)->greaterThan($class::createFromDate(1999, 12, 31)));
     }
 
     /**
@@ -149,9 +141,10 @@ class ComparisonTest extends TestCase
      */
     public function testGreaterThanFalse($class)
     {
-        foreach (['gt', 'greaterThan'] as $func) {
-            $this->assertFalse($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(2000, 1, 2)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertFalse($class::createFromDate(2000, 1, 1)->gt($class::createFromDate(2000, 1, 2)));
+        });
+        $this->assertFalse($class::createFromDate(2000, 1, 1)->greaterThan($class::createFromDate(2000, 1, 2)));
     }
 
     /**
@@ -162,9 +155,10 @@ class ComparisonTest extends TestCase
     {
         $dt1 = $class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
         $dt2 = $class::create(2000, 1, 1, 8, 59, 59, 0, 'America/Vancouver');
-        foreach (['gt', 'greaterThan'] as $func) {
-            $this->assertTrue($dt1->{$func}($dt2));
-        }
+        $this->deprecated(function () use ($dt1, $dt2) {
+            $this->assertTrue($dt1->gt($dt2));
+        });
+        $this->assertTrue($dt1->greaterThan($dt2));
     }
 
     /**
@@ -175,10 +169,10 @@ class ComparisonTest extends TestCase
     {
         $dt1 = $class::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
         $dt2 = $class::create(2000, 1, 1, 9, 0, 1, 0, 'America/Vancouver');
-        $this->assertFalse($dt1->gt($dt2));
-        foreach (['gt', 'greaterThan'] as $func) {
-            $this->assertFalse($dt1->{$func}($dt2));
-        }
+        $this->deprecated(function () use ($dt1, $dt2) {
+            $this->assertFalse($dt1->gt($dt2));
+        });
+        $this->assertFalse($dt1->greaterThan($dt2));
     }
 
     /**
@@ -187,9 +181,10 @@ class ComparisonTest extends TestCase
      */
     public function testGreaterThanOrEqualTrue($class)
     {
-        foreach (['gte', 'greaterThanOrEquals'] as $func) {
-            $this->assertTrue($class::create(2000, 1, 1)->{$func}($class::createFromDate(1999, 12, 31)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertTrue($class::create(2000, 1, 1)->gte($class::createFromDate(1999, 12, 31)));
+        });
+        $this->assertTrue($class::create(2000, 1, 1)->greaterThanOrEquals($class::createFromDate(1999, 12, 31)));
     }
 
     /**
@@ -198,9 +193,10 @@ class ComparisonTest extends TestCase
      */
     public function testGreaterThanOrEqualTrueEqual($class)
     {
-        foreach (['gte', 'greaterThanOrEquals'] as $func) {
-            $this->assertTrue($class::create(2000, 1, 1, 0, 0, 0)->{$func}($class::create(2000, 1, 1, 0, 0, 0)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertTrue($class::create(2000, 1, 1, 0, 0, 0)->gte($class::create(2000, 1, 1, 0, 0, 0)));
+        });
+        $this->assertTrue($class::create(2000, 1, 1, 0, 0, 0)->greaterThanOrEquals($class::create(2000, 1, 1, 0, 0, 0)));
     }
 
     /**
@@ -209,9 +205,10 @@ class ComparisonTest extends TestCase
      */
     public function testGreaterThanOrEqualFalse($class)
     {
-        foreach (['gte', 'greaterThanOrEquals'] as $func) {
-            $this->assertFalse($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(2000, 1, 2)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertFalse($class::createFromDate(2000, 1, 1)->gte($class::createFromDate(2000, 1, 2)));
+        });
+        $this->assertFalse($class::createFromDate(2000, 1, 1)->greaterThanOrEquals($class::createFromDate(2000, 1, 2)));
     }
 
     /**
@@ -220,9 +217,10 @@ class ComparisonTest extends TestCase
      */
     public function testLessThanTrue($class)
     {
-        foreach (['lt', 'lessThan'] as $func) {
-            $this->assertTrue($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(2000, 1, 2)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertTrue($class::createFromDate(2000, 1, 1)->lt($class::createFromDate(2000, 1, 2)));
+        });
+        $this->assertTrue($class::createFromDate(2000, 1, 1)->lessThan($class::createFromDate(2000, 1, 2)));
     }
 
     /**
@@ -231,9 +229,10 @@ class ComparisonTest extends TestCase
      */
     public function testLessThanFalse($class)
     {
-        foreach (['lte', 'lessThanOrEquals'] as $func) {
-            $this->assertFalse($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(1999, 12, 31)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertFalse($class::createFromDate(2000, 1, 1)->lte($class::createFromDate(1999, 12, 31)));
+        });
+        $this->assertFalse($class::createFromDate(2000, 1, 1)->lessThanOrEquals($class::createFromDate(1999, 12, 31)));
     }
 
     /**
@@ -242,9 +241,10 @@ class ComparisonTest extends TestCase
      */
     public function testLessThanOrEqualTrue($class)
     {
-        foreach (['lte', 'lessThanOrEquals'] as $func) {
-            $this->assertTrue($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(2000, 1, 2)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertTrue($class::createFromDate(2000, 1, 1)->lte($class::createFromDate(2000, 1, 2)));
+        });
+        $this->assertTrue($class::createFromDate(2000, 1, 1)->lessThanOrEquals($class::createFromDate(2000, 1, 2)));
     }
 
     /**
@@ -253,9 +253,10 @@ class ComparisonTest extends TestCase
      */
     public function testLessThanOrEqualTrueEqual($class)
     {
-        foreach (['lte', 'lessThanOrEquals'] as $func) {
-            $this->assertTrue($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(2000, 1, 1)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertTrue($class::createFromDate(2000, 1, 1)->lte($class::createFromDate(2000, 1, 1)));
+        });
+        $this->assertTrue($class::createFromDate(2000, 1, 1)->lessThanOrEquals($class::createFromDate(2000, 1, 1)));
     }
 
     /**
@@ -264,9 +265,10 @@ class ComparisonTest extends TestCase
      */
     public function testLessThanOrEqualFalse($class)
     {
-        foreach (['lte', 'lessThanOrEquals'] as $func) {
-            $this->assertFalse($class::createFromDate(2000, 1, 1)->{$func}($class::createFromDate(1999, 12, 31)));
-        }
+        $this->deprecated(function () use ($class) {
+            $this->assertFalse($class::createFromDate(2000, 1, 1)->lte($class::createFromDate(1999, 12, 31)));
+        });
+        $this->assertFalse($class::createFromDate(2000, 1, 1)->lessThan($class::createFromDate(1999, 12, 31)));
     }
 
     /**

--- a/tests/TestCase/DateTime/NowAndOtherStaticHelpersTest.php
+++ b/tests/TestCase/DateTime/NowAndOtherStaticHelpersTest.php
@@ -123,7 +123,7 @@ class NowAndOtherStaticHelpersTest extends TestCase
         date_default_timezone_set('Europe/Amsterdam');
 
         $this->assertLessThanOrEqual(-2147483647, $class::minValue()->getTimestamp());
-        $this->assertTrue($class::now()->gt($class::minValue()));
+        $this->assertTrue($class::now()->greaterThan($class::minValue()));
     }
 
     /**
@@ -144,6 +144,6 @@ class NowAndOtherStaticHelpersTest extends TestCase
         date_default_timezone_set('Europe/Amsterdam');
 
         $this->assertGreaterThanOrEqual(2147483647, $class::maxValue()->getTimestamp());
-        $this->assertTrue($class::now()->lt($class::maxValue()));
+        $this->assertTrue($class::now()->lessThan($class::maxValue()));
     }
 }

--- a/tests/TestCase/TestCase.php
+++ b/tests/TestCase/TestCase.php
@@ -159,6 +159,13 @@ abstract class TestCase extends BaseTestCase
         }
     }
 
+    protected function assertDate($d, $year, $month, $day)
+    {
+        $this->assertSame($year, $d->year, 'ChronosDate->year');
+        $this->assertSame($month, $d->month, 'ChronosDate->month');
+        $this->assertSame($day, $d->day, 'ChronosDate->day');
+    }
+
     protected function wrapWithTestNow(Closure $func, $dt = null)
     {
         Chronos::setTestNow($dt ?? Chronos::now());


### PR DESCRIPTION
There are a few things going on here as I started small but wanted to
stop before the diff got too large.

- Added deprecations for modifing dates by their time components.
- I've disallowed diffing dissimilar types with a runtime check. The
  goal of this was to approximate the type errors that will be present
  in 3.x.
- Add deprecations for short comparison methods.