### PR TITLE
2.5 - More deprecations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,7 +2,7 @@ parameters:
 	ignoreErrors:
 		-
 			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<Cake\\\\Chronos\\\\Chronos\\> and 'Cake\\\\\\\\Chronos\\\\\\\\ChronosDate' will always evaluate to false\\.$#"
-			count: 2
+			count: 5
 			path: src/Chronos.php
 
 		-
@@ -57,7 +57,7 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<Cake\\\\Chronos\\\\MutableDate\\> and 'Cake\\\\\\\\Chronos\\\\\\\\ChronosDate' will always evaluate to false\\.$#"
-			count: 2
+			count: 5
 			path: src/MutableDate.php
 
 		-
@@ -72,7 +72,7 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between class\\-string\\<Cake\\\\Chronos\\\\MutableDateTime\\> and 'Cake\\\\\\\\Chronos\\\\\\\\ChronosDate' will always evaluate to false\\.$#"
-			count: 2
+			count: 5
 			path: src/MutableDateTime.php
 
 		-

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -140,6 +140,8 @@ class Chronos extends DateTimeImmutable implements ChronosInterface
      */
     public function toMutable(): MutableDateTime
     {
+        trigger_error('2.5 Mutable classes will be removed in 3.0', E_USER_DEPRECATED);
+
         return MutableDateTime::instance($this);
     }
 

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -114,7 +114,12 @@ trait FactoryTrait
      */
     public static function maxValue(): ChronosInterface
     {
-        return static::createFromTimestampUTC(PHP_INT_MAX);
+        $instance = static::createFromTimestampUTC(PHP_INT_MAX);
+        if (get_class($instance) === ChronosDate::class) {
+            trigger_error('2.5 Using minValue() to create Date objects will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
+        return $instance;
     }
 
     /**
@@ -126,7 +131,12 @@ trait FactoryTrait
     {
         $max = PHP_INT_SIZE === 4 ? PHP_INT_MAX : PHP_INT_MAX / 10;
 
-        return static::createFromTimestampUTC(~$max);
+        $instance = static::createFromTimestampUTC(~$max);
+        if (get_class($instance) === ChronosDate::class) {
+            trigger_error('2.5 Using minValue() to create Date objects will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
+        return $instance;
     }
 
     /**
@@ -321,7 +331,12 @@ trait FactoryTrait
      */
     public static function createFromTimestamp(int $timestamp, $tz = null): ChronosInterface
     {
-        return static::now($tz)->setTimestamp($timestamp);
+        $instance = static::now($tz)->setTimestamp($timestamp);
+        if (get_class($instance) === ChronosDate::class) {
+            trigger_error('2.5 Creating Date instances with createFromTimestamp() will be removed in 3.0', E_USER_DEPRECATED);
+        }
+
+        return $instance;
     }
 
     /**

--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -333,7 +333,10 @@ trait FactoryTrait
     {
         $instance = static::now($tz)->setTimestamp($timestamp);
         if (get_class($instance) === ChronosDate::class) {
-            trigger_error('2.5 Creating Date instances with createFromTimestamp() will be removed in 3.0', E_USER_DEPRECATED);
+            trigger_error(
+                '2.5 Creating Date instances with createFromTimestamp() will be removed in 3.0',
+                E_USER_DEPRECATED
+            );
         }
 
         return $instance;

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -31,6 +31,11 @@ class ConstructTest extends TestCase
             $date = ChronosDate::createFromTimestamp(time());
             $this->assertGreaterThanOrEqual(2022, $date->year);
         });
+
+        $this->deprecated(function () {
+            $date = ChronosDate::createFromTimestampUTC(time());
+            $this->assertGreaterThanOrEqual(2022, $date->year);
+        });
     }
 
     /**

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -25,6 +25,14 @@ use DateTimeZone;
  */
 class ConstructTest extends TestCase
 {
+    public function testCreateFromTimestampDeprecated()
+    {
+        $this->deprecated(function () {
+            $date = ChronosDate::createFromTimestamp(time());
+            $this->assertGreaterThanOrEqual(2022, $date->year);
+        });
+    }
+
     /**
      * @dataProvider dateClassProvider
      * @return void

--- a/tests/TestCase/MutabilityConversionTest.php
+++ b/tests/TestCase/MutabilityConversionTest.php
@@ -42,9 +42,11 @@ class MutabilityConversionTest extends TestCase
 
     public function testToMutable()
     {
-        $dt1 = Chronos::create(2001, 2, 3, 10, 20, 30);
-        $dt2 = $dt1->toMutable();
-        $this->checkBothInstances($dt2, $dt1);
+        $this->deprecated(function () {
+            $dt1 = Chronos::create(2001, 2, 3, 10, 20, 30);
+            $dt2 = $dt1->toMutable();
+            $this->checkBothInstances($dt2, $dt1);
+        });
     }
 
     public function testMutableFromImmutable()


### PR DESCRIPTION
* Deprecate `toMutable()`
* Deprecate factory methods that won't exist on ChronosDate in the future.