### PR TITLE
Make setTimezone deprecation conditional

### DIFF
--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -157,7 +157,21 @@ trait FrozenTimeTrait
     public function setTimezone($value)
     {
         if (static::class === ChronosDate::class) {
-            trigger_error('2.5 setTimezone() will be removed in 3.x.', E_USER_DEPRECATED);
+            $trace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 5);
+            $found = false;
+            foreach ($trace as $frame) {
+                $found = in_array(
+                    $frame['class'],
+                    ['PHPUnit\Framework\Assert', 'PHPUnit\Framework\Constraint\IsEqual'],
+                    true
+                );
+                if ($found) {
+                    break;
+                }
+            }
+            if (!$found) {
+                trigger_error('2.5 setTimezone() will be removed in 3.x.', E_USER_DEPRECATED);
+            }
         }
 
         return $this;


### PR DESCRIPTION
Unfortunately the `assertEquals()` implementation for datetime values calls `setTimezone()` on instances. Because, I don't think it is reasonable to ask PHPUnit to have conditional logic for this, and I don't think it is reasonable to ask users to adapt all of their test code. These constraints led me to the solution of inspecting the preceding frames to see if we're inside PHPUnit assertion. If we aren't a deprecation is still emitted.

This helps improve compatibilty for the CakePHP tests.