### PR TITLE
Fix up getTimezone()

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -1000,11 +1000,11 @@ class Chronos
     /**
      * Return time zone set for this instance.
      *
-     * @return \DateTimeZone|false
+     * @return \DateTimeZone|null
      */
-    public function getTimezone(): DateTimeZone|false
+    public function getTimezone(): ?DateTimeZone
     {
-        return $this->native->getTimezone();
+        return $this->native->getTimezone() ?: null;
     }
 
     /**

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -1004,7 +1004,10 @@ class Chronos
      */
     public function getTimezone(): ?DateTimeZone
     {
-        return $this->native->getTimezone() ?: null;
+        /** @var \DateTimeZone|false $timezone */
+        $timezone = $this->native->getTimezone();
+
+        return $timezone ?: null;
     }
 
     /**


### PR DESCRIPTION
Before we release RCs, we need to raise PHPStan to level 8
There are quite a few bugs and issues around still regarding false and nullable etc.

`|false` in many cases is a code smell, making things outside the API more complicated.
Here we dont need it, but also we cannot use it, since e.g.

    Chronos::now($first->getTimezone());
    
Expects `DateTimeZone|string|null $timezone = null`

So better to clean up the API to the outside.