### PR TITLE
PHPStan fixes, set level to 8 now

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,8 +9,8 @@
         <severity>0</severity>
     </rule>
 
-    <file>./src</file>
-    <file>./tests</file>
+    <file>src/</file>
+    <file>tests/</file>
 
     <arg name="extensions" value="php"/>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 6
+	level: 7
 	checkMissingIterableValueType: false
 	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 7
+	level: 8
 	checkMissingIterableValueType: false
 	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -268,13 +268,13 @@ class Chronos
         }
 
         $relative = static::hasRelativeKeywords($time);
-        if (!empty($time) && $time !== 'now' && !$relative) {
+        if ($time && $time !== 'now' && !$relative) {
             return new DateTimeImmutable($time, $timezone);
         }
 
         $testNow = clone $testNow;
-        $relativetime = self::isTimeExpression($time);
-        if (!$relativetime && $timezone !== $testNow->getTimezone()) {
+        $relativeTime = self::isTimeExpression($time);
+        if (!$relativeTime && $timezone !== $testNow->getTimezone()) {
             $testNow = $testNow->setTimezone($timezone ?? date_default_timezone_get());
         }
 
@@ -678,7 +678,9 @@ class Chronos
 
         $errors = DateTimeImmutable::getLastErrors();
         if (!$dateTime) {
-            throw new InvalidArgumentException(implode(PHP_EOL, $errors['errors']));
+            $message = $errors ? implode(PHP_EOL, $errors['errors']) : 'Unknown error';
+
+            throw new InvalidArgumentException($message);
         }
 
         $dateTime = new static($dateTime->format('Y-m-d H:i:s.u'), $dateTime->getTimezone());
@@ -728,7 +730,7 @@ class Chronos
             $values['hour'] = 0;
         }
         if (isset($values['meridian'])) {
-            $values['hour'] = strtolower($values['meridian']) === 'am' ? $values['hour'] : $values['hour'] + 12;
+            $values['hour'] = strtolower((string)$values['meridian']) === 'am' ? (int)$values['hour'] : (int)$values['hour'] + 12;
         }
         $formatted .= sprintf(
             '%02d:%02d:%02d.%06d',
@@ -737,6 +739,8 @@ class Chronos
             $values['second'],
             $values['microsecond']
         );
+
+        assert(!is_int($values['timezone']), 'Timezone cannot be of type `int`');
 
         return static::parse($formatted, $values['timezone']);
     }
@@ -2311,7 +2315,7 @@ class Chronos
     {
         $diff = $this->diff($other ?? static::now($this->tz), $absolute);
 
-        return $diff->invert ? -$diff->days : $diff->days;
+        return $diff->invert ? -(int)$diff->days : (int)$diff->days;
     }
 
     /**
@@ -2440,10 +2444,10 @@ class Chronos
     /**
      * Convenience method for getting the remaining time from a given time.
      *
-     * @param \Cake\Chronos\Chronos $other The date to get the remaining time from.
+     * @param \Cake\Chronos\Chronos|\DateTimeInterface $other The date to get the remaining time from.
      * @return \DateInterval|bool The DateInterval object representing the difference between the two dates or FALSE on failure.
      */
-    public static function fromNow(Chronos|ChronosDate $other): DateInterval|bool
+    public static function fromNow(Chronos|DateTimeInterface $other): DateInterval|bool
     {
         $timeNow = new static();
 
@@ -2539,7 +2543,10 @@ class Chronos
                 return $this->getTimezone();
 
             case $name === 'timezoneName' || $name === 'tzName':
-                return $this->getTimezone()->getName();
+                $timezone = $this->getTimezone();
+                assert($timezone !== false, 'Timezone is not set');
+
+                return $timezone->getName();
 
             default:
                 throw new InvalidArgumentException(sprintf("Unknown getter '%s'", $name));
@@ -2570,10 +2577,13 @@ class Chronos
      */
     public function __debugInfo(): array
     {
+        /** @var \DateTimeZone $timezone */
+        $timezone = $this->getTimezone();
+
         $properties = [
             'hasFixedNow' => static::hasTestNow(),
             'time' => $this->format('Y-m-d H:i:s.u'),
-            'timezone' => $this->getTimezone()->getName(),
+            'timezone' => $timezone->getName(),
         ];
 
         return $properties;

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -279,7 +279,7 @@ class Chronos
         }
 
         if ($relative) {
-            $testNow = $testNow->modify($time);
+            $testNow = $testNow->modify($time ?? 'now');
         }
 
         return new DateTimeImmutable($testNow->format('Y-m-d H:i:s.u'), $timezone);
@@ -2540,13 +2540,14 @@ class Chronos
                 return $this->offset === 0;
 
             case $name === 'timezone' || $name === 'tz':
+                assert($this->getTimezone() !== null, 'Timezone is not set');
+
                 return $this->getTimezone();
 
             case $name === 'timezoneName' || $name === 'tzName':
-                $timezone = $this->getTimezone();
-                assert($timezone !== false, 'Timezone is not set');
+                assert($this->getTimezone() !== null, 'Timezone is not set');
 
-                return $timezone->getName();
+                return $this->getTimezone()->getName();
 
             default:
                 throw new InvalidArgumentException(sprintf("Unknown getter '%s'", $name));


### PR DESCRIPTION
Also solved the remaining ones of level 8:
```
 ------ ---------------------------------------------------------------------------------------------------------------------- 
  Line   Chronos.php                                                                                                           
 ------ ---------------------------------------------------------------------------------------------------------------------- 
  282    Parameter #1 $modifier of method Cake\Chronos\Chronos::modify() expects string, string|null given.                    
  2543   Method Cake\Chronos\Chronos::__get() should return bool|DateTimeZone|float|int|string but returns DateTimeZone|null.  
  2549   Cannot call method getName() on DateTimeZone|null.                                                                    
 ------ ---------------------------------------------------------------------------------------------------------------------- 


                                                                                                                        
 [ERROR] Found 3 errors 
```

Should be all green now.