### PR TITLE
Default ChronosTime to server time

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.x-dev@">
+<files psalm-version="dev-master@">
   <file src="src/Chronos.php">
     <ImpureFunctionCall occurrences="4">
       <code>array_filter</code>
@@ -7,8 +7,7 @@
       <code>date_default_timezone_get</code>
       <code>iterator_to_array</code>
     </ImpureFunctionCall>
-    <ImpureMethodCall occurrences="43">
-      <code>$period</code>
+    <ImpureMethodCall occurrences="42">
       <code>diffForHumans</code>
       <code>diffFormatter</code>
       <code>format</code>
@@ -75,8 +74,7 @@
       <code>date_default_timezone_get</code>
       <code>iterator_to_array</code>
     </ImpureFunctionCall>
-    <ImpureMethodCall occurrences="50">
-      <code>$period</code>
+    <ImpureMethodCall occurrences="24">
       <code>diffForHumans</code>
       <code>diffFormatter</code>
       <code>format</code>
@@ -87,31 +85,6 @@
       <code>getWeekStartsAt</code>
       <code>getWeekendDays</code>
       <code>hasTestNow</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
-      <code>modify</code>
       <code>now</code>
       <code>now</code>
       <code>now</code>
@@ -139,5 +112,15 @@
       <code>static::$days</code>
     </ImpureStaticProperty>
     <ImpureStaticVariable occurrences="1"/>
+  </file>
+  <file src="src/ChronosTime.php">
+    <ImpureMethodCall occurrences="6">
+      <code>format</code>
+      <code>mod</code>
+      <code>mod</code>
+      <code>mod</code>
+      <code>mod</code>
+      <code>mod</code>
+    </ImpureMethodCall>
   </file>
 </files>

--- a/tests/TestCase/ChronosTimeTest.php
+++ b/tests/TestCase/ChronosTimeTest.php
@@ -23,71 +23,43 @@ class ChronosTimeTest extends TestCase
 {
     public function testConstructDefault(): void
     {
+        Chronos::setTestNow('2001-01-01 12:13:14.123456');
+
         $t = new ChronosTime();
-        $this->assertSame(0, $t->getMicroseconds());
-        $this->assertSame(0, $t->getSeconds());
-        $this->assertSame(0, $t->getMinutes());
-        $this->assertSame(0, $t->getHours());
+        $this->assertSame('12:13:14.123456', $t->format('H:i:s.u'));
 
         $t = new ChronosTime(null);
-        $this->assertSame(0, $t->getMicroseconds());
-        $this->assertSame(0, $t->getSeconds());
-        $this->assertSame(0, $t->getMinutes());
-        $this->assertSame(0, $t->getHours());
+        $this->assertSame('12:13:14.123456', $t->format('H:i:s.u'));
     }
 
     public function testConstructFromString(): void
     {
         $t = new ChronosTime('0.0.0.0');
-        $this->assertSame(0, $t->getMicroseconds());
-        $this->assertSame(0, $t->getSeconds());
-        $this->assertSame(0, $t->getMinutes());
-        $this->assertSame(0, $t->getHours());
+        $this->assertSame('00:00:00.000000', $t->format('H:i:s.u'));
 
         $t = new ChronosTime('1:01:1.000001');
-        $this->assertSame(1, $t->getMicroseconds());
-        $this->assertSame(1, $t->getSeconds());
-        $this->assertSame(1, $t->getMinutes());
-        $this->assertSame(1, $t->getHours());
+        $this->assertSame('01:01:01.000001', $t->format('H:i:s.u'));
 
         $t = new ChronosTime('23:59.59.999999');
-        $this->assertSame(999999, $t->getMicroseconds());
-        $this->assertSame(59, $t->getSeconds());
-        $this->assertSame(59, $t->getMinutes());
-        $this->assertSame(23, $t->getHours());
+        $this->assertSame('23:59:59.999999', $t->format('H:i:s.u'));
 
         $t = new ChronosTime('23:59.59.9999991');
-        $this->assertSame(999999, $t->getMicroseconds());
-        $this->assertSame(59, $t->getSeconds());
-        $this->assertSame(59, $t->getMinutes());
-        $this->assertSame(23, $t->getHours());
+        $this->assertSame('23:59:59.999999', $t->format('H:i:s.u'));
 
         $t = new ChronosTime('12:13');
-        $this->assertSame(0, $t->getMicroseconds());
-        $this->assertSame(0, $t->getSeconds());
-        $this->assertSame(13, $t->getMinutes());
-        $this->assertSame(12, $t->getHours());
+        $this->assertSame('12:13:00.000000', $t->format('H:i:s.u'));
     }
 
     public function testConstructFromInstance(): void
     {
         $t = new ChronosTime(new DateTimeImmutable('23:59:59.999999'));
-        $this->assertSame(999999, $t->getMicroseconds());
-        $this->assertSame(59, $t->getSeconds());
-        $this->assertSame(59, $t->getMinutes());
-        $this->assertSame(23, $t->getHours());
+        $this->assertSame('23:59:59.999999', $t->format('H:i:s.u'));
 
         $t = new ChronosTime(new Chronos('23:59:59.999999'));
-        $this->assertSame(999999, $t->getMicroseconds());
-        $this->assertSame(59, $t->getSeconds());
-        $this->assertSame(59, $t->getMinutes());
-        $this->assertSame(23, $t->getHours());
+        $this->assertSame('23:59:59.999999', $t->format('H:i:s.u'));
 
         $t = new ChronosTime(new ChronosTime(new Chronos('23:59:59.999999')));
-        $this->assertSame(999999, $t->getMicroseconds());
-        $this->assertSame(59, $t->getSeconds());
-        $this->assertSame(59, $t->getMinutes());
-        $this->assertSame(23, $t->getHours());
+        $this->assertSame('23:59:59.999999', $t->format('H:i:s.u'));
     }
 
     public function testConstructInvalid(): void
@@ -120,53 +92,86 @@ class ChronosTimeTest extends TestCase
         new ChronosTime('23:59:60');
     }
 
+    public function testParse(): void
+    {
+        $t = ChronosTime::parse('23:59:59.999999');
+        $this->assertSame('23:59:59.999999', $t->format('H:i:s.u'));
+    }
+
+    public function testNow(): void
+    {
+        Chronos::setTestNow('2001-01-01 12:13:14.123456');
+
+        $t = ChronosTime::now();
+        $this->assertSame('12:13:14.123456', $t->format('H:i:s.u'));
+    }
+
+    public function testMidnight(): void
+    {
+        $t = ChronosTime::midnight();
+        $this->assertSame('00:00:00.000000', $t->format('H:i:s.u'));
+    }
+
+    public function testNoon(): void
+    {
+        $t = ChronosTime::noon();
+        $this->assertSame('12:00:00.000000', $t->format('H:i:s.u'));
+    }
+
+    public function testSetters(): void
+    {
+        $t = ChronosTime::midnight()->setHours(24);
+        $this->assertSame('00:00:00.000000', $t->format('H:i:s.u'));
+
+        $t = ChronosTime::midnight()->setHours(-1);
+        $this->assertSame('23:00:00.000000', $t->format('H:i:s.u'));
+
+        $t = ChronosTime::midnight()->setMinutes(60);
+        $this->assertSame('01:00:00.000000', $t->format('H:i:s.u'));
+
+        $t = ChronosTime::midnight()->setMinutes(-1);
+        $this->assertSame('23:59:00.000000', $t->format('H:i:s.u'));
+
+        $t = ChronosTime::midnight()->setSeconds(60);
+        $this->assertSame('00:01:00.000000', $t->format('H:i:s.u'));
+
+        $t = ChronosTime::midnight()->setSeconds(-1);
+        $this->assertSame('23:59:59.000000', $t->format('H:i:s.u'));
+
+        $t = ChronosTime::midnight()->setMicroseconds(1_000_000);
+        $this->assertSame('00:00:01.000000', $t->format('H:i:s.u'));
+
+        $t = ChronosTime::midnight()->setMicroseconds(-1);
+        $this->assertSame('23:59:59.999999', $t->format('H:i:s.u'));
+
+        $t = ChronosTime::midnight()->setHours(25)->setMinutes(120)->setSeconds(120)->setMicroseconds(2_000_001);
+        $this->assertSame('03:02:02.000001', $t->format('H:i:s.u'));
+    }
+
+    public function testGetters(): void
+    {
+        $t = ChronosTime::midnight()->setTime(-1, -1, -1, -1);
+        $this->assertSame(22, $t->getHours());
+        $this->assertSame(58, $t->getMinutes());
+        $this->assertSame(58, $t->getSeconds());
+        $this->assertSame(999_999, $t->getMicroseconds());
+    }
+
     public function testSetTime(): void
     {
         $t = new ChronosTime();
         $new = $t->setTime();
         $this->assertNotSame($new, $t);
-        $this->assertSame(0, $new->getHours());
-        $this->assertSame(0, $new->getMinutes());
-        $this->assertSame(0, $new->getSeconds());
-        $this->assertSame(0, $new->getMicroseconds());
+        $this->assertSame('00:00:00.000000', $new->format('H:i:s.u'));
 
-        $t = new ChronosTime('23:59.59.9999991');
+        $t = ChronosTime::midnight()->setTime(24, 120, 120, 1_000_000);
+        $this->assertSame('02:02:01.000000', $t->format('H:i:s.u'));
 
-        $new = $t->setHours(24);
-        $this->assertSame(0, $new->getHours());
+        $t = ChronosTime::midnight()->setTime(-1, -1, -1, -1);
+        $this->assertSame('22:58:58.999999', $t->format('H:i:s.u'));
 
-        $new = $t->setHours(-1);
-        $this->assertSame(23, $new->getHours());
-
-        $new = $t->setMinutes(60);
-        $this->assertSame(0, $new->getMinutes());
-
-        $new = $t->setMinutes(-1);
-        $this->assertSame(59, $new->getMinutes());
-
-        $new = $t->setSeconds(60);
-        $this->assertSame(0, $new->getSeconds());
-
-        $new = $t->setSeconds(-1);
-        $this->assertSame(59, $new->getSeconds());
-
-        $new = $t->setMicroseconds(1_000_000);
-        $this->assertSame(0, $new->getMicroseconds());
-
-        $new = $t->setMicroseconds(-1);
-        $this->assertSame(999_999, $new->getMicroseconds());
-
-        $new = $t->setTime(24, 60, 60, 1_000_000);
-        $this->assertSame(0, $new->getHours());
-        $this->assertSame(0, $new->getMinutes());
-        $this->assertSame(0, $new->getSeconds());
-        $this->assertSame(0, $new->getMicroseconds());
-
-        $new = $t->setTime(-1, -1, -1, -1);
-        $this->assertSame(23, $new->getHours());
-        $this->assertSame(59, $new->getMinutes());
-        $this->assertSame(59, $new->getSeconds());
-        $this->assertSame(999_999, $new->getMicroseconds());
+        $t = ChronosTime::midnight()->setTime(-1, 120, -1, 1_000_001);
+        $this->assertSame('01:00:00.000001', $t->format('H:i:s.u'));
     }
 
     public function testFormat(): void


### PR DESCRIPTION
This fixes several issues:

- ChronosTime() should default to server time not 00:00:00 with support for Chronos test now
- Add static helper ChronosTime::parse() to match DateTime
- Add static helpers to create specific times
- Changed the setters to roll over to parent time instead of rolling over on the individual field

Rollover should work the same as DateTimeImmutable::setTime() where 120 minutes sets the hours to 02. The individual setters also rollover to parent values now.