### PR TITLE
Update docs for Date + timezone

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -97,9 +97,9 @@ Date Objects
 PHP only provides a single DateTime object. Representing calendar dates can be
 a bit awkward with this class as it includes timezones, and time components that
 don't really belong in the concept of a 'day'. Chronos provides a ``Date``
-object that allows you to represent dates. The time and timezone for these
-objects is always fixed to ``00:00:00 UTC`` and all formatting/difference
-methods operate at the day resolution::
+object that allows you to represent dates. The time for date objects is always
+fixed to ``00:00:00``, and the timezone is set to the server local timezone. All
+formatting/difference methods operate at the day resolution::
 
     use Cake\Chronos\Date;
 


### PR DESCRIPTION
In 2.x the timezone used for `Date` and `MutableDate` has changed from UTC to the server local time. Update the docs to reflect that.

Refs #385