### PR TITLE
Return the false returned by parent::getLastErrors() as default errors array

### DIFF
--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -358,7 +358,12 @@ trait FactoryTrait
     public static function getLastErrors(): array
     {
         if (empty(static::$_lastErrors)) {
-            return parent::getLastErrors();
+            return parent::getLastErrors() ?: [
+                'warning_count' => 0,
+                'warnings' => [],
+                'error_count' => 0,
+                'errors' => [],
+            ];
         }
 
         return static::$_lastErrors;


### PR DESCRIPTION
# Motivation

[`DateTime::getLastErrors()`](https://www.php.net/manual/datetimeimmutable.getlasterrors.php) returns an array of shape.

```
array{
    warning_count: 0|positive-int,
    warnings: array<int, string>,
    error_count: 0|positive-int,
    errors: array<int, string>
}
```

However, the PHP manual Changelog states:

> Before PHP 8.2.0, this function did not return false when there were no warnings or errors. Instead, it would always return the documented array structure.

| status               | old PHP returns  | 8.2 returns     |
|----------------------|-----------------|-----------------|
| never parse yet      | `false`         | `false`         |
| parsed without error | `array` count=0 | `false`         |
| parse got errors     | `array` count>0 | `array` count>0 |

An `array` with 'count=0' is:

```php
[
    'warning_count' => 0,
    'warnings' => [],
    'error_count' => 0,
    'errors' => [],
]
```

You can see this behavior in 3v4l below: https://3v4l.org/gH7rO

Previously this problem did not surface because it is common to instantiate a DateTime and then call `DateTime::getLastErrors()`. However, starting with PHP 8.2, it returns false unless the parse fails, so returning false at runtime violates the return type declaration of the method.

This patch makes the method return a legacy compatible array with count=0.

Another option is to declare the method as the same `array|false` as the parent class.