### PR TITLE
2.next: fix setISODate

### DIFF
--- a/src/Traits/FrozenTimeTrait.php
+++ b/src/Traits/FrozenTimeTrait.php
@@ -227,7 +227,7 @@ trait FrozenTimeTrait
      * @deprecated
      */
     #[ReturnTypeWillChange]
-    public function setISODate($year, $week, $dayOfWeek = null)
+    public function setISODate($year, $week, $dayOfWeek = 1)
     {
         trigger_error('2.5 setISODate will be removed in 3.x');
 


### PR DESCRIPTION
just tried the current `4.next` state of cakephp/cakephp (which is basically 4.5) and noticed, that my app broke due to this default value overwrite.

see https://www.php.net/manual/en/datetimeimmutable.setisodate.php