### PR TITLE
Re-introduce Chronos::getLastErrors()

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -216,6 +216,13 @@ class Chronos
     protected static string $relativePattern = '/this|next|last|tomorrow|yesterday|midnight|today|[+-]|first|last|ago/i';
 
     /**
+     * Errors from last time createFromFormat() was called.
+     *
+     * @var array|false
+     */
+    protected static array|false $lastErrors = false;
+
+    /**
      * @var \DateTimeImmutable
      */
     protected DateTimeImmutable $native;
@@ -656,9 +663,9 @@ class Chronos
             $dateTime = DateTimeImmutable::createFromFormat($format, $time);
         }
 
-        $errors = DateTimeImmutable::getLastErrors();
+        static::$lastErrors = DateTimeImmutable::getLastErrors();
         if (!$dateTime) {
-            $message = $errors ? implode(PHP_EOL, $errors['errors']) : 'Unknown error';
+            $message = static::$lastErrors ? implode(PHP_EOL, static::$lastErrors['errors']) : 'Unknown error';
 
             throw new InvalidArgumentException($message);
         }
@@ -666,6 +673,19 @@ class Chronos
         $dateTime = new static($dateTime->format('Y-m-d H:i:s.u'), $dateTime->getTimezone());
 
         return $dateTime;
+    }
+
+    /**
+     * Returns parse warnings and errors from the last ``createFromFormat()``
+     * call.
+     *
+     * Returns the same data as DateTimeImmutable::getLastErrors().
+     *
+     * @return array|false
+     */
+    public static function getLastErrors(): array|false
+    {
+        return static::$lastErrors;
     }
 
     /**

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -76,6 +76,13 @@ class ChronosDate
     protected static ?DifferenceFormatterInterface $diffFormatter = null;
 
     /**
+     * Errors from last time createFromFormat() was called.
+     *
+     * @var array|false
+     */
+    protected static array|false $lastErrors = false;
+
+    /**
      * @var \DateTimeImmutable
      */
     protected DateTimeImmutable $native;
@@ -225,14 +232,27 @@ class ChronosDate
     ): static {
         $dateTime = DateTimeImmutable::createFromFormat($format, $time);
 
-        $errors = DateTimeImmutable::getLastErrors();
+        static::$lastErrors = DateTimeImmutable::getLastErrors();
         if (!$dateTime) {
-            $message = implode(PHP_EOL, $errors ? $errors['errors'] : ['Unknown error']);
+            $message = static::$lastErrors ? implode(PHP_EOL, static::$lastErrors['errors']) : 'Unknown error';
 
             throw new InvalidArgumentException($message);
         }
 
         return new static($dateTime);
+    }
+
+    /**
+     * Returns parse warnings and errors from the last ``createFromFormat()``
+     * call.
+     *
+     * Returns the same data as DateTimeImmutable::getLastErrors().
+     *
+     * @return array|false
+     */
+    public static function getLastErrors(): array|false
+    {
+        return static::$lastErrors;
     }
 
     /**

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -19,6 +19,7 @@ use Cake\Chronos\Test\TestCase\TestCase;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
+use InvalidArgumentException;
 
 /**
  * Test constructors for Date objects.
@@ -206,5 +207,19 @@ class ConstructTest extends TestCase
     {
         $date = ChronosDate::createFromFormat('Y-m-d P', '2014-02-01 Asia/Tokyo');
         $this->assertSame('2014-02-01 00:00:00 America/Toronto', $date->format('Y-m-d H:i:s e'));
+    }
+
+    public function testCreateFromFormatInvalidFormat()
+    {
+        $parseException = null;
+        try {
+            ChronosDate::createFromFormat('Y-m-d', '1975-05');
+        } catch (InvalidArgumentException $e) {
+            $parseException = $e;
+        }
+
+        $this->assertNotNull($parseException);
+        $this->assertIsArray(ChronosDate::getLastErrors());
+        $this->assertNotEmpty(ChronosDate::getLastErrors()['errors']);
     }
 }

--- a/tests/TestCase/DateTime/CreateFromFormatTest.php
+++ b/tests/TestCase/DateTime/CreateFromFormatTest.php
@@ -18,6 +18,7 @@ namespace Cake\Chronos\Test\TestCase\DateTime;
 use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTimeZone;
+use InvalidArgumentException;
 
 class CreateFromFormatTest extends TestCase
 {
@@ -46,5 +47,19 @@ class CreateFromFormatTest extends TestCase
     {
         $d = Chronos::createFromFormat('Y-m-d H:i:s.u', '1975-05-21 22:32:11.254687');
         $this->assertSame(254687, $d->micro);
+    }
+
+    public function testCreateFromFormatInvalidFormat()
+    {
+        $parseException = null;
+        try {
+            Chronos::createFromFormat('Y-m-d H:i:s.u', '1975-05-21');
+        } catch (InvalidArgumentException $e) {
+            $parseException = $e;
+        }
+
+        $this->assertNotNull($parseException);
+        $this->assertIsArray(Chronos::getLastErrors());
+        $this->assertNotEmpty(Chronos::getLastErrors()['errors']);
     }
 }


### PR DESCRIPTION
closes https://github.com/cakephp/chronos/issues/407

Parse errors will throw an exception with the errors collapsed into a string, but users might want to access the raw error data.