### PR TITLE
Change only Chronos to extend DateTimeImmutable once again

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.10.0@a5effd2d2dddd1a7ea7a0f6a051ce63ff979e356">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="src/Chronos.php">
     <ImpureFunctionCall>
       <code>array_filter</code>
@@ -11,12 +11,14 @@
       <code>diffForHumans</code>
       <code>diffFormatter</code>
       <code>format</code>
-      <code>getTestNow</code>
+      <code>format</code>
+      <code>format</code>
+      <code>format</code>
+      <code>format</code>
+      <code>getTimestamp</code>
       <code>getTimezone</code>
       <code>getWeekendDays</code>
-      <code>hasRelativeKeywords</code>
       <code>hasTestNow</code>
-      <code>isTimeExpression</code>
       <code>now</code>
       <code>now</code>
       <code>now</code>
@@ -40,7 +42,6 @@
       <code>now</code>
       <code>now</code>
       <code>safeCreateDateTimeZone</code>
-      <code>toDateString</code>
       <code>toDateString</code>
       <code>toDateString</code>
       <code>toDateString</code>
@@ -87,6 +88,9 @@
     <InaccessibleProperty>
       <code><![CDATA[$instance->f]]></code>
     </InaccessibleProperty>
+    <MissingImmutableAnnotation>
+      <code>public static function createFromFormat(</code>
+    </MissingImmutableAnnotation>
   </file>
   <file src="src/ChronosDate.php">
     <ImpureFunctionCall>

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -100,11 +100,11 @@ class ChronosDate
      * are used when parsing relative date expressions like `today` and `yesterday`
      * but do not participate in parsing values like `2022-01-01`.
      *
-     * @param \Cake\Chronos\Chronos|\Cake\Chronos\ChronosDate|\DateTimeInterface|string $time Fixed or relative time
+     * @param \Cake\Chronos\ChronosDate|\DateTimeInterface|string $time Fixed or relative time
      * @param \DateTimeZone|string|null $timezone The time zone used for 'now'
      */
     public function __construct(
-        Chronos|ChronosDate|DateTimeInterface|string $time = 'now',
+        ChronosDate|DateTimeInterface|string $time = 'now',
         DateTimeZone|string|null $timezone = null
     ) {
         $this->native = $this->createNative($time, $timezone);
@@ -113,12 +113,12 @@ class ChronosDate
     /**
      * Initializes the PHP DateTimeImmutable object.
      *
-     * @param \Cake\Chronos\Chronos|\Cake\Chronos\ChronosDate|\DateTimeInterface|string $time Fixed or relative time
+     * @param \Cake\Chronos\ChronosDate|\DateTimeInterface|string $time Fixed or relative time
      * @param \DateTimeZone|string|null $timezone The time zone used for 'now'
      * @return \DateTimeImmutable
      */
     protected function createNative(
-        Chronos|ChronosDate|DateTimeInterface|string $time,
+        ChronosDate|DateTimeInterface|string $time,
         DateTimeZone|string|null $timezone
     ): DateTimeImmutable {
         if (!is_string($time)) {
@@ -193,10 +193,10 @@ class ChronosDate
      * Chronos::parse('Monday next week')->fn() rather than
      * (new Chronos('Monday next week'))->fn()
      *
-     * @param \Cake\Chronos\Chronos|\Cake\Chronos\ChronosDate|\DateTimeInterface|string $time The strtotime compatible string to parse
+     * @param \Cake\Chronos\ChronosDate|\DateTimeInterface|string $time The strtotime compatible string to parse
      * @return static
      */
-    public static function parse(Chronos|ChronosDate|DateTimeInterface|string $time): static
+    public static function parse(ChronosDate|DateTimeInterface|string $time): static
     {
         return new static($time);
     }
@@ -809,9 +809,9 @@ class ChronosDate
      * to indicate the desired dayOfWeek, ex. Chronos::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function next(?int $dayOfWeek = null): mixed
+    public function next(?int $dayOfWeek = null): static
     {
         if ($dayOfWeek === null) {
             $dayOfWeek = $this->dayOfWeek;
@@ -829,9 +829,9 @@ class ChronosDate
      * to indicate the desired dayOfWeek, ex. Chronos::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function previous(?int $dayOfWeek = null): mixed
+    public function previous(?int $dayOfWeek = null): static
     {
         if ($dayOfWeek === null) {
             $dayOfWeek = $this->dayOfWeek;
@@ -849,9 +849,9 @@ class ChronosDate
      * to indicate the desired dayOfWeek, ex. Chronos::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfMonth(?int $dayOfWeek = null): mixed
+    public function firstOfMonth(?int $dayOfWeek = null): static
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -865,9 +865,9 @@ class ChronosDate
      * to indicate the desired dayOfWeek, ex. Chronos::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfMonth(?int $dayOfWeek = null): mixed
+    public function lastOfMonth(?int $dayOfWeek = null): static
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -882,9 +882,9 @@ class ChronosDate
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfMonth(int $nth, int $dayOfWeek): mixed
+    public function nthOfMonth(int $nth, int $dayOfWeek): static|false
     {
         $dateTime = $this->firstOfMonth();
         $check = $dateTime->format('Y-m');
@@ -900,9 +900,9 @@ class ChronosDate
      * to indicate the desired dayOfWeek, ex. Chronos::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfQuarter(?int $dayOfWeek = null): mixed
+    public function firstOfQuarter(?int $dayOfWeek = null): static
     {
         return $this
             ->day(1)
@@ -917,9 +917,9 @@ class ChronosDate
      * to indicate the desired dayOfWeek, ex. Chronos::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfQuarter(?int $dayOfWeek = null): mixed
+    public function lastOfQuarter(?int $dayOfWeek = null): static
     {
         return $this
             ->day(1)
@@ -935,9 +935,9 @@ class ChronosDate
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfQuarter(int $nth, int $dayOfWeek): mixed
+    public function nthOfQuarter(int $nth, int $dayOfWeek): static|false
     {
         $dateTime = $this->day(1)->month($this->quarter * Chronos::MONTHS_PER_QUARTER);
         $lastMonth = $dateTime->month;
@@ -954,9 +954,9 @@ class ChronosDate
      * to indicate the desired dayOfWeek, ex. Chronos::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function firstOfYear(?int $dayOfWeek = null): mixed
+    public function firstOfYear(?int $dayOfWeek = null): static
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -970,9 +970,9 @@ class ChronosDate
      * to indicate the desired dayOfWeek, ex. Chronos::MONDAY.
      *
      * @param int|null $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static
      */
-    public function lastOfYear(?int $dayOfWeek = null): mixed
+    public function lastOfYear(?int $dayOfWeek = null): static
     {
         $day = $dayOfWeek === null ? 'day' : static::$days[$dayOfWeek];
 
@@ -987,9 +987,9 @@ class ChronosDate
      *
      * @param int $nth The offset to use.
      * @param int $dayOfWeek The day of the week to move to.
-     * @return mixed
+     * @return static|false
      */
-    public function nthOfYear(int $nth, int $dayOfWeek): mixed
+    public function nthOfYear(int $nth, int $dayOfWeek): static|false
     {
         $dateTime = $this->firstOfYear()->modify("+$nth " . static::$days[$dayOfWeek]);
 

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -60,11 +60,11 @@ class ChronosTime
      *
      * Defaults to server time.
      *
-     * @param \Cake\Chronos\Chronos|\Cake\Chronos\ChronosTime|\DateTimeInterface|string|null $time Time
+     * @param \Cake\Chronos\ChronosTime|\DateTimeInterface|string|null $time Time
      * @param \DateTimeZone|string|null $timezone The timezone to use for now
      */
     public function __construct(
-        Chronos|ChronosTime|DateTimeInterface|string|null $time = null,
+        ChronosTime|DateTimeInterface|string|null $time = null,
         DateTimeZone|string|null $timezone = null
     ) {
         if ($time === null) {
@@ -87,12 +87,12 @@ class ChronosTime
      *
      * Defaults to server time.
      *
-     * @param \Cake\Chronos\Chronos|\Cake\Chronos\ChronosTime|\DateTimeInterface|string $time Time
+     * @param \Cake\Chronos\ChronosTime|\DateTimeInterface|string $time Time
      * @param \DateTimeZone|string|null $timezone The timezone to use for now
      * @return static
      */
     public static function parse(
-        Chronos|ChronosTime|DateTimeInterface|string|null $time = null,
+        ChronosTime|DateTimeInterface|string|null $time = null,
         DateTimeZone|string|null $timezone = null
     ): static {
         return new static($time, $timezone);

--- a/src/DifferenceFormatter.php
+++ b/src/DifferenceFormatter.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos;
 
+use DateTimeInterface;
+
 /**
  * Handles formatting differences in text.
  *
@@ -45,8 +47,8 @@ class DifferenceFormatter implements DifferenceFormatterInterface
      * @inheritDoc
      */
     public function diffForHumans(
-        Chronos|ChronosDate $first,
-        Chronos|ChronosDate|null $second = null,
+        ChronosDate|DateTimeInterface $first,
+        ChronosDate|DateTimeInterface|null $second = null,
         bool $absolute = false
     ): string {
         $isNow = $second === null;
@@ -57,6 +59,11 @@ class DifferenceFormatter implements DifferenceFormatterInterface
                 $second = Chronos::now($first->getTimezone());
             }
         }
+        assert(
+            ($first instanceof ChronosDate && $second instanceof ChronosDate) ||
+            ($first instanceof DateTimeInterface && $second instanceof DateTimeInterface)
+        );
+
         $diffInterval = $first->diff($second);
 
         switch (true) {

--- a/src/DifferenceFormatterInterface.php
+++ b/src/DifferenceFormatterInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
  */
 namespace Cake\Chronos;
 
+use DateTimeInterface;
+
 /**
  * Interface for formatting differences in text.
  */
@@ -21,14 +23,14 @@ interface DifferenceFormatterInterface
     /**
      * Get the difference in a human readable format.
      *
-     * @param \Cake\Chronos\Chronos|\Cake\Chronos\ChronosDate $first The datetime to start with.
-     * @param \Cake\Chronos\Chronos|\Cake\Chronos\ChronosDate|null $second The datetime to compare against.
+     * @param \Cake\Chronos\ChronosDate|\DateTimeInterface $first The datetime to start with.
+     * @param \Cake\Chronos\ChronosDate|\DateTimeInterface|null $second The datetime to compare against.
      * @param bool $absolute removes time difference modifiers ago, after, etc
      * @return string The difference between the two days in a human readable format
      */
     public function diffForHumans(
-        Chronos|ChronosDate $first,
-        Chronos|ChronosDate|null $second = null,
+        ChronosDate|DateTimeInterface $first,
+        ChronosDate|DateTimeInterface|null $second = null,
         bool $absolute = false
     ): string;
 }

--- a/tests/TestCase/DateTime/ComparisonTest.php
+++ b/tests/TestCase/DateTime/ComparisonTest.php
@@ -17,6 +17,8 @@ namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
+use DateTimeImmutable;
+use DateTimeZone;
 
 class ComparisonTest extends TestCase
 {
@@ -32,195 +34,169 @@ class ComparisonTest extends TestCase
         Chronos::setWeekendDays($expected);
     }
 
-    public function testEqualToTrue()
+    public function testEquals()
     {
-        $this->assertTrue(Chronos::create(2000, 1, 1, 0, 0, 0)->equals(Chronos::create(2000, 1, 1, 0, 0, 0)));
+        $left = Chronos::create(2000, 1, 1, 0, 0, 0);
+        $this->assertTrue($left == new Chronos('2000-01-01 00:00:00'));
+        $this->assertTrue($left->equals(new Chronos('2000-01-01 00:00:00')));
+        $this->assertTrue($left->equals(new DateTimeImmutable('2000-01-01 00:00:00')));
+
+        $this->assertFalse($left == new Chronos('2000-01-02 00:00:00'));
+        $this->assertFalse($left->equals(new Chronos('2000-01-02 00:00:00')));
+        $this->assertFalse($left->equals(new DateTimeImmutable('2000-01-02 00:00:00')));
+
+        $left = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $this->assertTrue($left == new Chronos('2000-01-01 9:00:00', 'America/Vancouver'));
+        $this->assertTrue($left->equals(new Chronos('2000-01-01 9:00:00', 'America/Vancouver')));
+        $this->assertTrue($left->equals(new DateTimeImmutable('2000-01-01 9:00:00', new DateTimeZone('America/Vancouver'))));
+
+        $this->assertFalse($left == new Chronos('2000-01-01 12:00:00', 'America/Vancouver'));
+        $this->assertFalse($left->equals(new Chronos('2000-01-01 12:00:00', 'America/Vancouver')));
+        $this->assertFalse($left->equals(new DateTimeImmutable('2000-01-01 12:00:00', new DateTimeZone('America/Vancouver'))));
     }
 
-    public function testEqualToFalse()
+    public function testNotEquals()
     {
-        $this->assertFalse(Chronos::create(2000, 1, 1, 0, 0, 0)->equals(Chronos::create(2000, 1, 2, 0, 0, 0)));
+        $left = Chronos::create(2000, 1, 1, 0, 0, 0);
+        $this->assertTrue($left != new Chronos('2000-01-02 00:00:00'));
+        $this->assertTrue($left->notEquals(new Chronos('2000-01-02 00:00:00')));
+        $this->assertTrue($left->notEquals(new DateTimeImmutable('2000-01-02 00:00:00')));
+
+        $this->assertFalse($left != new Chronos('2000-01-01 00:00:00'));
+        $this->assertFalse($left->notEquals(new Chronos('2000-01-01 00:00:00')));
+        $this->assertFalse($left->notEquals(new DateTimeImmutable('2000-01-01 00:00:00')));
+
+        $left = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $this->assertTrue($left != new Chronos('2000-01-01 12:00:00', 'America/Vancouver'));
+        $this->assertTrue($left->notEquals(new Chronos('2000-01-01 12:00:00', 'America/Vancouver')));
+        $this->assertTrue($left->notEquals(new DateTimeImmutable('2000-01-01 12:00:00', new DateTimeZone('America/Vancouver'))));
+
+        $this->assertFalse($left != new Chronos('2000-01-01 9:00:00', 'America/Vancouver'));
+        $this->assertFalse($left->notEquals(new Chronos('2000-01-01 9:00:00', 'America/Vancouver')));
+        $this->assertFalse($left->notEquals(new DateTimeImmutable('2000-01-01 9:00:00', new DateTimeZone('America/Vancouver'))));
     }
 
-    public function testEqualWithTimezoneTrue()
+    public function testGreaterThan()
     {
-        $this->assertTrue(Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto')->equals(Chronos::create(
-            2000,
-            1,
-            1,
-            9,
-            0,
-            0,
-            0,
-            'America/Vancouver'
-        )));
+        $left = Chronos::create(2000, 1, 2, 0, 0, 0);
+        $this->assertTrue($left > new Chronos('2000-01-01 00:00:00'));
+        $this->assertTrue($left->greaterThan(new Chronos('2000-01-01 00:00:00')));
+        $this->assertTrue($left->greaterThan(new DateTimeImmutable('2000-01-01 00:00:00')));
+
+        $this->assertFalse($left > new Chronos('2000-01-03 00:00:00'));
+        $this->assertFalse($left->greaterThan(new Chronos('2000-01-03 00:00:00')));
+        $this->assertFalse($left->greaterThan(new DateTimeImmutable('2000-01-03 00:00:00')));
+
+        $left = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $this->assertTrue($left > new Chronos('2000-01-01 08:00:00', 'America/Vancouver'));
+        $this->assertTrue($left->greaterThan(new Chronos('2000-01-01 08:00:00', 'America/Vancouver')));
+        $this->assertTrue($left->greaterThan(new DateTimeImmutable('2000-01-01 08:00:00', new DateTimeZone('America/Vancouver'))));
+
+        $this->assertFalse($left > new Chronos('2000-01-01 09:00:00', 'America/Vancouver'));
+        $this->assertFalse($left->greaterThan(new Chronos('2000-01-01 09:00:00', 'America/Vancouver')));
+        $this->assertFalse($left->greaterThan(new DateTimeImmutable('2000-01-01 09:00:00', new DateTimeZone('America/Vancouver'))));
     }
 
-    public function testEqualWithTimezoneFalse()
+    public function testGreaterThanOrEqual()
     {
-        $this->assertFalse(Chronos::createFromDate(2000, 1, 1, 'America/Toronto')->equals(Chronos::createFromDate(
-            2000,
-            1,
-            1,
-            'America/Vancouver'
-        )));
+        $left = Chronos::create(2000, 1, 2, 0, 0, 0);
+        $this->assertTrue($left >= new Chronos('2000-01-01 00:00:00'));
+        $this->assertTrue($left->greaterThanOrEquals(new Chronos('2000-01-01 00:00:00')));
+        $this->assertTrue($left->greaterThanOrEquals(new DateTimeImmutable('2000-01-01 00:00:00')));
+
+        $this->assertTrue($left >= new Chronos('2000-01-02 00:00:00'));
+        $this->assertTrue($left->greaterThanOrEquals(new Chronos('2000-01-02 00:00:00')));
+        $this->assertTrue($left->greaterThanOrEquals(new DateTimeImmutable('2000-01-02 00:00:00')));
+
+        $this->assertFalse($left >= new Chronos('2000-01-03 00:00:00'));
+        $this->assertFalse($left->greaterThanOrEquals(new Chronos('2000-01-03 00:00:00')));
+        $this->assertFalse($left->greaterThanOrEquals(new DateTimeImmutable('2000-01-03 00:00:00')));
+
+        $left = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $this->assertTrue($left >= new Chronos('2000-01-01 09:00:00', 'America/Vancouver'));
+        $this->assertTrue($left->greaterThanOrEquals(new Chronos('2000-01-01 09:00:00', 'America/Vancouver')));
+        $this->assertTrue($left->greaterThanOrEquals(new DateTimeImmutable('2000-01-01 09:00:00', new DateTimeZone('America/Vancouver'))));
+
+        $this->assertTrue($left >= new Chronos('2000-01-01 08:00:00', 'America/Vancouver'));
+        $this->assertTrue($left->greaterThanOrEquals(new Chronos('2000-01-01 08:00:00', 'America/Vancouver')));
+        $this->assertTrue($left->greaterThanOrEquals(new DateTimeImmutable('2000-01-01 08:00:00', new DateTimeZone('America/Vancouver'))));
+
+        $this->assertFalse($left >= new Chronos('2000-01-01 10:00:00', 'America/Vancouver'));
+        $this->assertFalse($left->greaterThanOrEquals(new Chronos('2000-01-01 10:00:00', 'America/Vancouver')));
+        $this->assertFalse($left->greaterThanOrEquals(new DateTimeImmutable('2000-01-01 10:00:00', new DateTimeZone('America/Vancouver'))));
     }
 
-    public function testNotEqualToTrue()
+    public function testLessThan()
     {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->notEquals(Chronos::createFromDate(2000, 1, 2)));
+        $left = Chronos::create(2000, 1, 1, 0, 0, 0);
+        $this->assertTrue($left < new Chronos('2000-01-02 00:00:00'));
+        $this->assertTrue($left->lessThan(new Chronos('2000-01-02 00:00:00')));
+        $this->assertTrue($left->lessThan(new DateTimeImmutable('2000-01-02 00:00:00')));
+
+        $this->assertFalse($left < new Chronos('2000-01-01 00:00:00'));
+        $this->assertFalse($left->lessThan(new Chronos('2000-01-01 00:00:00')));
+        $this->assertFalse($left->lessThan(new DateTimeImmutable('2000-01-01 00:00:00')));
+
+        $left = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $this->assertTrue($left < new Chronos('2000-01-01 12:00:00', 'America/Vancouver'));
+        $this->assertTrue($left->lessThan(new Chronos('2000-01-01 12:00:00', 'America/Vancouver')));
+        $this->assertTrue($left->lessThan(new DateTimeImmutable('2000-01-01 12:00:00', new DateTimeZone('America/Vancouver'))));
+
+        $this->assertFalse($left < new Chronos('2000-01-01 09:00:00', 'America/Vancouver'));
+        $this->assertFalse($left->lessThan(new Chronos('2000-01-01 09:00:00', 'America/Vancouver')));
+        $this->assertFalse($left->lessThan(new DateTimeImmutable('2000-01-01 09:00:00', new DateTimeZone('America/Vancouver'))));
     }
 
-    public function testNotEqualToFalse()
+    public function testLessThanOrEqual()
     {
-        $this->assertFalse(Chronos::create(2000, 1, 1, 0, 0, 0)->notEquals(Chronos::create(2000, 1, 1, 0, 0, 0)));
+        $left = Chronos::create(2000, 1, 2, 0, 0, 0);
+        $this->assertTrue($left <= new Chronos('2000-01-03 00:00:00'));
+        $this->assertTrue($left->lessThanOrEquals(new Chronos('2000-01-03 00:00:00')));
+        $this->assertTrue($left->lessThanOrEquals(new DateTimeImmutable('2000-01-03 00:00:00')));
+
+        $this->assertTrue($left <= new Chronos('2000-01-02 00:00:00'));
+        $this->assertTrue($left->lessThanOrEquals(new Chronos('2000-01-02 00:00:00')));
+        $this->assertTrue($left->lessThanOrEquals(new DateTimeImmutable('2000-01-02 00:00:00')));
+
+        $this->assertFalse($left <= new Chronos('2000-01-01 00:00:00'));
+        $this->assertFalse($left->lessThanOrEquals(new Chronos('2000-01-01 00:00:00')));
+        $this->assertFalse($left->lessThanOrEquals(new DateTimeImmutable('2000-01-01 00:00:00')));
+
+        $left = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
+        $this->assertTrue($left <= new Chronos('2000-01-01 10:00:00', 'America/Vancouver'));
+        $this->assertTrue($left->lessThanOrEquals(new Chronos('2000-01-01 10:00:00', 'America/Vancouver')));
+        $this->assertTrue($left->lessThanOrEquals(new DateTimeImmutable('2000-01-01 10:00:00', new DateTimeZone('America/Vancouver'))));
+
+        $this->assertTrue($left <= new Chronos('2000-01-01 09:00:00', 'America/Vancouver'));
+        $this->assertTrue($left->lessThanOrEquals(new Chronos('2000-01-01 09:00:00', 'America/Vancouver')));
+        $this->assertTrue($left->lessThanOrEquals(new DateTimeImmutable('2000-01-01 09:00:00', new DateTimeZone('America/Vancouver'))));
+
+        $this->assertFalse($left <= new Chronos('2000-01-01 08:00:00', 'America/Vancouver'));
+        $this->assertFalse($left->lessThanOrEquals(new Chronos('2000-01-01 08:00:00', 'America/Vancouver')));
+        $this->assertFalse($left->lessThanOrEquals(new DateTimeImmutable('2000-01-01 08:00:00', new DateTimeZone('America/Vancouver'))));
     }
 
-    public function testNotEqualWithTimezone()
+    public function testBetween()
     {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 1, 'America/Toronto')->notEquals(Chronos::createFromDate(
-            2000,
-            1,
-            1,
-            'America/Vancouver'
-        )));
-    }
+        $date = new Chronos('2000-01-15 00:00:00');
+        $this->assertTrue($date->between(new Chronos('2000-01-14 00:00:00'), new Chronos('2000-01-15 00:00:00')));
+        $this->assertTrue($date->between(new DateTimeImmutable('2000-01-14 00:00:00'), new DateTimeImmutable('2000-01-15 00:00:00')));
 
-    public function testGreaterThanTrue()
-    {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->greaterThan(Chronos::createFromDate(1999, 12, 31)));
-    }
+        $this->assertTrue($date->between(new Chronos('2000-01-14 00:00:00'), new Chronos('2000-01-16 00:00:00'), false));
+        $this->assertTrue($date->between(new DateTimeImmutable('2000-01-14 00:00:00'), new DateTimeImmutable('2000-01-16 00:00:00'), false));
 
-    public function testGreaterThanFalse()
-    {
-        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->greaterThan(Chronos::createFromDate(2000, 1, 2)));
-    }
+        $this->assertFalse($date->between(new Chronos('2000-01-16 00:00:00'), new Chronos('2000-01-17 00:00:00')));
+        $this->assertFalse($date->between(new DateTimeImmutable('2000-01-16 00:00:00'), new DateTimeImmutable('2000-01-17 00:00:00')));
 
-    public function testGreaterThanWithTimezoneTrue()
-    {
-        $dt1 = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
-        $dt2 = Chronos::create(2000, 1, 1, 8, 59, 59, 0, 'America/Vancouver');
-        $this->assertTrue($dt1->greaterThan($dt2));
-    }
+        $this->assertFalse($date->between(new Chronos('2000-01-14 00:00:00'), new Chronos('2000-01-15 00:00:00'), false));
+        $this->assertFalse($date->between(new DateTimeImmutable('2000-01-14 00:00:00'), new DateTimeImmutable('2000-01-15 00:00:00'), false));
 
-    public function testGreaterThanWithTimezoneFalse()
-    {
-        $dt1 = Chronos::create(2000, 1, 1, 12, 0, 0, 0, 'America/Toronto');
-        $dt2 = Chronos::create(2000, 1, 1, 9, 0, 1, 0, 'America/Vancouver');
-        $this->assertFalse($dt1->greaterThan($dt2));
-        $this->assertFalse($dt1->greaterThan($dt2));
-    }
+        // switched
+        $this->assertTrue($date->between(new Chronos('2000-01-16 00:00:00'), new Chronos('2000-01-14 00:00:00'), false));
+        $this->assertTrue($date->between(new DateTimeImmutable('2000-01-16 00:00:00'), new DateTimeImmutable('2000-01-14 00:00:00'), false));
 
-    public function testGreaterThanOrEqualTrue()
-    {
-        $this->assertTrue(Chronos::create(2000, 1, 1)->greaterThanOrEquals(Chronos::createFromDate(1999, 12, 31)));
-    }
-
-    public function testGreaterThanOrEqualTrueEqual()
-    {
-        $this->assertTrue(Chronos::create(2000, 1, 1, 0, 0, 0)->greaterThanOrEquals(Chronos::create(2000, 1, 1, 0, 0, 0)));
-    }
-
-    public function testGreaterThanOrEqualFalse()
-    {
-        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->greaterThanOrEquals(Chronos::createFromDate(2000, 1, 2)));
-    }
-
-    public function testLessThanTrue()
-    {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->lessThan(Chronos::createFromDate(2000, 1, 2)));
-    }
-
-    public function testLessThanFalse()
-    {
-        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->lessThanOrEquals(Chronos::createFromDate(1999, 12, 31)));
-    }
-
-    public function testLessThanOrEqualTrue()
-    {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->lessThanOrEquals(Chronos::createFromDate(2000, 1, 2)));
-    }
-
-    public function testLessThanOrEqualTrueEqual()
-    {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 1)->lessThanOrEquals(Chronos::createFromDate(2000, 1, 1)));
-    }
-
-    public function testLessThanOrEqualFalse()
-    {
-        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->lessThanOrEquals(Chronos::createFromDate(1999, 12, 31)));
-    }
-
-    public function testBetweenEqualTrue()
-    {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 15)->between(
-            Chronos::createFromDate(2000, 1, 1),
-            Chronos::createFromDate(2000, 1, 31),
-            true
-        ));
-    }
-
-    public function testBetweenNotEqualTrue()
-    {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 15)->between(
-            Chronos::createFromDate(2000, 1, 1),
-            Chronos::createFromDate(2000, 1, 31),
-            false
-        ));
-    }
-
-    public function testBetweenEqualFalse()
-    {
-        $this->assertFalse(Chronos::createFromDate(1999, 12, 31)->between(
-            Chronos::createFromDate(2000, 1, 1),
-            Chronos::createFromDate(2000, 1, 31),
-            true
-        ));
-    }
-
-    public function testBetweenNotEqualFalse()
-    {
-        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->between(
-            Chronos::createFromDate(2000, 1, 1),
-            Chronos::createFromDate(2000, 1, 31),
-            false
-        ));
-    }
-
-    public function testBetweenEqualSwitchTrue()
-    {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 15)->between(
-            Chronos::createFromDate(2000, 1, 31),
-            Chronos::createFromDate(2000, 1, 1),
-            true
-        ));
-    }
-
-    public function testBetweenNotEqualSwitchTrue()
-    {
-        $this->assertTrue(Chronos::createFromDate(2000, 1, 15)->between(
-            Chronos::createFromDate(2000, 1, 31),
-            Chronos::createFromDate(2000, 1, 1),
-            false
-        ));
-    }
-
-    public function testBetweenEqualSwitchFalse()
-    {
-        $this->assertFalse(Chronos::createFromDate(1999, 12, 31)->between(
-            Chronos::createFromDate(2000, 1, 31),
-            Chronos::createFromDate(2000, 1, 1),
-            true
-        ));
-    }
-
-    public function testBetweenNotEqualSwitchFalse()
-    {
-        $this->assertFalse(Chronos::createFromDate(2000, 1, 1)->between(
-            Chronos::createFromDate(2000, 1, 31),
-            Chronos::createFromDate(2000, 1, 1),
-            false
-        ));
+        $this->assertFalse($date->between(new Chronos('2000-01-15 00:00:00'), new Chronos('2000-01-14 00:00:00'), false));
+        $this->assertFalse($date->between(new DateTimeImmutable('2000-01-15 00:00:00'), new DateTimeImmutable('2000-01-14 00:00:00'), false));
     }
 
     public function testMinIsFluid()
@@ -238,6 +214,10 @@ class ComparisonTest extends TestCase
     public function testMinWithInstance()
     {
         $dt1 = Chronos::create(2013, 12, 31, 23, 59, 59);
+        $dt2 = Chronos::create(2012, 1, 1, 0, 0, 0)->min($dt1);
+        $this->assertDateTime($dt2, 2012, 1, 1, 0, 0, 0);
+
+        $dt1 = new DateTimeImmutable('2013-12-31 23:59:59');
         $dt2 = Chronos::create(2012, 1, 1, 0, 0, 0)->min($dt1);
         $this->assertDateTime($dt2, 2012, 1, 1, 0, 0, 0);
     }
@@ -259,6 +239,10 @@ class ComparisonTest extends TestCase
         $dt1 = Chronos::create(2012, 1, 1, 0, 0, 0);
         $dt2 = Chronos::create(2099, 12, 31, 23, 59, 59)->max($dt1);
         $this->assertDateTime($dt2, 2099, 12, 31, 23, 59, 59);
+
+        $dt1 = new DateTimeImmutable('2012-01-01 00:00:00');
+        $dt2 = Chronos::create(2099, 12, 31, 23, 59, 59)->max($dt1);
+        $this->assertDateTime($dt2, 2099, 12, 31, 23, 59, 59);
     }
 
     public function testIsBirthday()
@@ -276,6 +260,9 @@ class ComparisonTest extends TestCase
         $dt3 = Chronos::createFromDate(2014, 4, 23);
         $this->assertFalse($dt2->isBirthday($dt1));
         $this->assertTrue($dt3->isBirthday($dt1));
+
+        $this->assertTrue($dt1->isBirthday(new DateTimeImmutable('2014-04-23 00:00:00')));
+        $this->assertFalse($dt1->isBirthday(new DateTimeImmutable('2014-04-22 00:00:00')));
     }
 
     public function testClosest()
@@ -285,6 +272,12 @@ class ComparisonTest extends TestCase
         $dt2 = Chronos::create(2015, 5, 28, 14, 0, 0);
         $closest = $instance->closest($dt1, $dt2);
         $this->assertSame($dt1, $closest);
+
+        $dt1 = new DateTimeImmutable('2015-05-28 11:00:00');
+        $dt2 = new DateTimeImmutable('2015-05-28 14:00:00');
+        $closest = $instance->closest($dt1, $dt2);
+        $this->assertEquals($dt1, $closest);
+        $this->assertInstanceOf(Chronos::class, $closest);
     }
 
     public function testClosestWithEquals()
@@ -294,6 +287,12 @@ class ComparisonTest extends TestCase
         $dt2 = Chronos::create(2015, 5, 28, 14, 0, 0);
         $closest = $instance->closest($dt1, $dt2);
         $this->assertSame($dt1, $closest);
+
+        $dt1 = new DateTimeImmutable('2015-05-28 11:00:00');
+        $dt2 = new DateTimeImmutable('2015-05-28 14:00:00');
+        $closest = $instance->closest($dt1, $dt2);
+        $this->assertEquals($dt1, $closest);
+        $this->assertInstanceOf(Chronos::class, $closest);
     }
 
     public function testClosestWithOthers(): void
@@ -314,6 +313,12 @@ class ComparisonTest extends TestCase
         $dt2 = Chronos::create(2015, 5, 28, 14, 0, 0);
         $Farthest = $instance->farthest($dt1, $dt2);
         $this->assertSame($dt2, $Farthest);
+
+        $dt1 = new DateTimeImmutable('2015-05-28 11:00:00');
+        $dt2 = new DateTimeImmutable('2015-05-28 14:00:00');
+        $farthest = $instance->farthest($dt1, $dt2);
+        $this->assertEquals($dt2, $farthest);
+        $this->assertInstanceOf(Chronos::class, $farthest);
     }
 
     public function testFarthestWithEquals()
@@ -323,6 +328,12 @@ class ComparisonTest extends TestCase
         $dt2 = Chronos::create(2015, 5, 28, 14, 0, 0);
         $Farthest = $instance->farthest($dt1, $dt2);
         $this->assertSame($dt2, $Farthest);
+
+        $dt1 = new DateTimeImmutable('2015-05-28 12:00:00');
+        $dt2 = new DateTimeImmutable('2015-05-28 14:00:00');
+        $farthest = $instance->farthest($dt1, $dt2);
+        $this->assertEquals($dt2, $farthest);
+        $this->assertInstanceOf(Chronos::class, $farthest);
     }
 
     public function testFarthestWithOthers(): void

--- a/tests/TestCase/DateTime/StringsTest.php
+++ b/tests/TestCase/DateTime/StringsTest.php
@@ -213,10 +213,4 @@ class StringsTest extends TestCase
     {
         $this->assertSame($expected, (new Chronos($date))->toWeek());
     }
-
-    public function testToNative(): void
-    {
-        $c = Chronos::now();
-        $this->assertSame($c->format(DATE_ATOM), $c->toNative()->format(DATE_ATOM));
-    }
 }


### PR DESCRIPTION
The original reasons for this change are described here: https://github.com/cakephp/chronos/issues/410#issuecomment-1722185717

- [x] Need to improve unit tests with more non-Chronos arguments now that the type declarations are relaxed.