### PR TITLE
add halfOfYear, isFirstHalfOfYear, IsSecondHalfOfYear; improve getter…

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -290,7 +290,7 @@ Other properties that can be accessed are:
 - daysInMonth
 - timestamp
 - quarter
-- halfOfYear
+- half
 
 Testing Aids
 ------------

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -290,6 +290,7 @@ Other properties that can be accessed are:
 - daysInMonth
 - timestamp
 - quarter
+- halfOfYear
 
 Testing Aids
 ------------

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -302,6 +302,7 @@ Les autres propriétés accessibles sont:
 - daysInMonth
 - timestamp
 - quarter
+- halfOfYear
 
 Aides aux Tests
 ---------------

--- a/docs/fr/index.rst
+++ b/docs/fr/index.rst
@@ -302,7 +302,7 @@ Les autres propriétés accessibles sont:
 - daysInMonth
 - timestamp
 - quarter
-- halfOfYear
+- half
 
 Aides aux Tests
 ---------------

--- a/docs/ja/index.rst
+++ b/docs/ja/index.rst
@@ -276,7 +276,7 @@ Chronos は、出力した日時オブジェクトを表示するための多く
 - daysInMonth
 - timestamp
 - quarter
-- halfOfYear
+- half
 
 テストの支援
 ------------

--- a/docs/ja/index.rst
+++ b/docs/ja/index.rst
@@ -276,6 +276,7 @@ Chronos は、出力した日時オブジェクトを表示するための多く
 - daysInMonth
 - timestamp
 - quarter
+- halfOfYear
 
 テストの支援
 ------------

--- a/docs/pt/index.rst
+++ b/docs/pt/index.rst
@@ -258,6 +258,7 @@ Outras propriedades que podem ser acessadas são:
 - daysInMonth
 - timestamp
 - quarter
+- halfOfYear
 
 Auxílio para testes
 -------------------

--- a/docs/pt/index.rst
+++ b/docs/pt/index.rst
@@ -258,7 +258,7 @@ Outras propriedades que podem ser acessadas são:
 - daysInMonth
 - timestamp
 - quarter
-- halfOfYear
+- half
 
 Auxílio para testes
 -------------------

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -29,23 +29,24 @@ use InvalidArgumentException;
  *
  * @property-read int $year
  * @property-read int $yearIso
- * @property-read int $month
- * @property-read int $day
- * @property-read int $hour
- * @property-read int $minute
- * @property-read int $second
- * @property-read int $micro
- * @property-read int $microsecond
+ * @property-read int<1, 12> $month
+ * @property-read int<1, 31> $day
+ * @property-read int<0, 23> $hour
+ * @property-read int<0, 59> $minute
+ * @property-read int<0, 59> $second
+ * @property-read int<0, 999999> $micro
+ * @property-read int<0, 999999> $microsecond
  * @property-read int $timestamp seconds since the Unix Epoch
  * @property-read \DateTimeZone $timezone the current timezone
  * @property-read \DateTimeZone $tz alias of timezone
- * @property-read int $dayOfWeek 1 (for Monday) through 7 (for Sunday)
- * @property-read int $dayOfYear 0 through 365
- * @property-read int $weekOfMonth 1 through 5
- * @property-read int $weekOfYear ISO-8601 week number of year, weeks starting on Monday
- * @property-read int $daysInMonth number of days in the given month
+ * @property-read int<1, 7> $dayOfWeek 1 (for Monday) through 7 (for Sunday)
+ * @property-read int<0, 365> $dayOfYear 0 through 365
+ * @property-read int<1, 5> $weekOfMonth 1 through 5
+ * @property-read int<1, 53> $weekOfYear ISO-8601 week number of year, weeks starting on Monday
+ * @property-read int<1, 31> $daysInMonth number of days in the given month
  * @property-read int $age does a diffInYears() with default parameters
- * @property-read int $quarter the quarter of this instance, 1 - 4
+ * @property-read int<1, 4> $quarter the quarter of this instance, 1 - 4
+ * @property-read int<1, 2> $halfOfYear the half of year of this instance, 1 - 2
  * @property-read int $offset the timezone offset in seconds from UTC
  * @property-read int $offsetHours the timezone offset in hours from UTC
  * @property-read bool $dst daylight savings time indicator, true if DST, false otherwise
@@ -2056,6 +2057,26 @@ class Chronos
     }
 
     /**
+     * Determines if the instance is within the first half of year
+     *
+     * @return bool
+     */
+    public function isFirstHalfOfYear(): bool
+    {
+        return $this->halfOfYear === 1;
+    }
+
+    /**
+     * Determines if the instance is within the second half of year
+     *
+     * @return bool
+     */
+    public function isSecondHalfOfYear(): bool
+    {
+        return $this->halfOfYear === 2;
+    }
+
+    /**
      * Determines if the instance is in the future, ie. greater (after) than now
      *
      * @return bool
@@ -2591,6 +2612,9 @@ class Chronos
 
             case $name === 'quarter':
                 return (int)ceil($this->month / 3);
+
+            case $name === 'halfOfYear':
+                return $this->month <= 6 ? 1 : 2;
 
             case $name === 'offset':
                 return $this->getOffset();

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -2061,7 +2061,7 @@ class Chronos
      *
      * @return bool
      */
-    public function isFirstHalfOfYear(): bool
+    public function isFirstHalf(): bool
     {
         return $this->half === 1;
     }
@@ -2071,7 +2071,7 @@ class Chronos
      *
      * @return bool
      */
-    public function isSecondHalfOfYear(): bool
+    public function isSecondHalf(): bool
     {
         return $this->half === 2;
     }

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -46,7 +46,7 @@ use InvalidArgumentException;
  * @property-read int<1, 31> $daysInMonth number of days in the given month
  * @property-read int $age does a diffInYears() with default parameters
  * @property-read int<1, 4> $quarter the quarter of this instance, 1 - 4
- * @property-read int<1, 2> $halfOfYear the half of year of this instance, 1 - 2
+ * @property-read int<1, 2> $halfOfYear the half of the year, with 1 for months Jan...Jun and 2 for Jul...Dec.
  * @property-read int $offset the timezone offset in seconds from UTC
  * @property-read int $offsetHours the timezone offset in hours from UTC
  * @property-read bool $dst daylight savings time indicator, true if DST, false otherwise

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -46,7 +46,7 @@ use InvalidArgumentException;
  * @property-read int<1, 31> $daysInMonth number of days in the given month
  * @property-read int $age does a diffInYears() with default parameters
  * @property-read int<1, 4> $quarter the quarter of this instance, 1 - 4
- * @property-read int<1, 2> $halfOfYear the half of the year, with 1 for months Jan...Jun and 2 for Jul...Dec.
+ * @property-read int<1, 2> $half the half of the year, with 1 for months Jan...Jun and 2 for Jul...Dec.
  * @property-read int $offset the timezone offset in seconds from UTC
  * @property-read int $offsetHours the timezone offset in hours from UTC
  * @property-read bool $dst daylight savings time indicator, true if DST, false otherwise
@@ -2063,7 +2063,7 @@ class Chronos
      */
     public function isFirstHalfOfYear(): bool
     {
-        return $this->halfOfYear === 1;
+        return $this->half === 1;
     }
 
     /**
@@ -2073,7 +2073,7 @@ class Chronos
      */
     public function isSecondHalfOfYear(): bool
     {
-        return $this->halfOfYear === 2;
+        return $this->half === 2;
     }
 
     /**
@@ -2613,7 +2613,7 @@ class Chronos
             case $name === 'quarter':
                 return (int)ceil($this->month / 3);
 
-            case $name === 'halfOfYear':
+            case $name === 'half':
                 return $this->month <= 6 ? 1 : 2;
 
             case $name === 'offset':

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -30,15 +30,16 @@ use InvalidArgumentException;
  *
  * @property-read int $year
  * @property-read int $yearIso
- * @property-read int $month
- * @property-read int $day
- * @property-read int $dayOfWeek 1 (for Monday) through 7 (for Sunday)
- * @property-read int $dayOfYear 0 through 365
- * @property-read int $weekOfMonth 1 through 5
- * @property-read int $weekOfYear ISO-8601 week number of year, weeks starting on Monday
- * @property-read int $daysInMonth number of days in the given month
+ * @property-read int<1, 12> $month
+ * @property-read int<1, 31> $day
+ * @property-read int<1, 7> $dayOfWeek 1 (for Monday) through 7 (for Sunday)
+ * @property-read int<0, 365> $dayOfYear 0 through 365
+ * @property-read int<1, 5> $weekOfMonth 1 through 5
+ * @property-read int<1, 53> $weekOfYear ISO-8601 week number of year, weeks starting on Monday
+ * @property-read int<1, 31> $daysInMonth number of days in the given month
  * @property-read int $age does a diffInYears() with default parameters
- * @property-read int $quarter the quarter of this instance, 1 - 4
+ * @property-read int<1, 4> $quarter the quarter of this instance, 1 - 4
+ * @property-read int<1, 2> $halfOfYear the half of year of this instance, 1 - 2
  * @psalm-immutable
  * @psalm-consistent-constructor
  */
@@ -1226,6 +1227,26 @@ class ChronosDate
     }
 
     /**
+     * Determines if the instance is within the first half of year
+     *
+     * @return bool
+     */
+    public function isFirstHalfOfYear(): bool
+    {
+        return $this->halfOfYear === 1;
+    }
+
+    /**
+     * Determines if the instance is within the second half of year
+     *
+     * @return bool
+     */
+    public function isSecondHalfOfYear(): bool
+    {
+        return $this->halfOfYear === 2;
+    }
+
+    /**
      * Determines if the instance is in the future, ie. greater (after) than now
      *
      * @param \DateTimeZone|string|null $timezone Time zone to use for now.
@@ -1565,6 +1586,9 @@ class ChronosDate
 
             case $name === 'quarter':
                 return (int)ceil($this->month / 3);
+
+            case $name === 'halfOfYear':
+                return $this->month <= 6 ? 1 : 2;
 
             default:
                 throw new InvalidArgumentException(sprintf("Unknown getter '%s'", $name));

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -1231,7 +1231,7 @@ class ChronosDate
      *
      * @return bool
      */
-    public function isFirstHalfOfYear(): bool
+    public function isFirstHalf(): bool
     {
         return $this->half === 1;
     }
@@ -1241,7 +1241,7 @@ class ChronosDate
      *
      * @return bool
      */
-    public function isSecondHalfOfYear(): bool
+    public function isSecondHalf(): bool
     {
         return $this->half === 2;
     }

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -39,7 +39,7 @@ use InvalidArgumentException;
  * @property-read int<1, 31> $daysInMonth number of days in the given month
  * @property-read int $age does a diffInYears() with default parameters
  * @property-read int<1, 4> $quarter the quarter of this instance, 1 - 4
- * @property-read int<1, 2> $halfOfYear the half of the year, with 1 for months Jan...Jun and 2 for Jul...Dec.
+ * @property-read int<1, 2> $half the half of the year, with 1 for months Jan...Jun and 2 for Jul...Dec.
  * @psalm-immutable
  * @psalm-consistent-constructor
  */
@@ -1233,7 +1233,7 @@ class ChronosDate
      */
     public function isFirstHalfOfYear(): bool
     {
-        return $this->halfOfYear === 1;
+        return $this->half === 1;
     }
 
     /**
@@ -1243,7 +1243,7 @@ class ChronosDate
      */
     public function isSecondHalfOfYear(): bool
     {
-        return $this->halfOfYear === 2;
+        return $this->half === 2;
     }
 
     /**
@@ -1587,7 +1587,7 @@ class ChronosDate
             case $name === 'quarter':
                 return (int)ceil($this->month / 3);
 
-            case $name === 'halfOfYear':
+            case $name === 'half':
                 return $this->month <= 6 ? 1 : 2;
 
             default:

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -39,7 +39,7 @@ use InvalidArgumentException;
  * @property-read int<1, 31> $daysInMonth number of days in the given month
  * @property-read int $age does a diffInYears() with default parameters
  * @property-read int<1, 4> $quarter the quarter of this instance, 1 - 4
- * @property-read int<1, 2> $halfOfYear the half of year of this instance, 1 - 2
+ * @property-read int<1, 2> $halfOfYear the half of the year, with 1 for months Jan...Jun and 2 for Jul...Dec.
  * @psalm-immutable
  * @psalm-consistent-constructor
  */

--- a/tests/TestCase/Date/GettersTest.php
+++ b/tests/TestCase/Date/GettersTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @copyright     Copyright (c) Brian Nesbitt <brian@nesbot.com>
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Cake\Chronos\Test\TestCase\Date;
+
+use Cake\Chronos\ChronosDate;
+use Cake\Chronos\Test\TestCase\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
+
+class GettersTest extends TestCase
+{
+    #[TestWith([1, 1])]
+    #[TestWith([2, 1])]
+    #[TestWith([3, 1])]
+    #[TestWith([4, 1])]
+    #[TestWith([5, 1])]
+    #[TestWith([6, 1])]
+    #[TestWith([7, 2])]
+    #[TestWith([8, 2])]
+    #[TestWith([9, 2])]
+    #[TestWith([10, 2])]
+    #[TestWith([11, 2])]
+    #[TestWith([12, 2])]
+    public function testHalfOfYear(int $month, int $expectedHalfOfYear): void
+    {
+        $d = ChronosDate::create(year: 2012, month: $month, day: 1);
+        $this->assertSame($expectedHalfOfYear, $d->halfOfYear);
+    }
+}

--- a/tests/TestCase/Date/GettersTest.php
+++ b/tests/TestCase/Date/GettersTest.php
@@ -36,6 +36,6 @@ class GettersTest extends TestCase
     public function testHalfOfYear(int $month, int $expectedHalfOfYear): void
     {
         $d = ChronosDate::create(year: 2012, month: $month, day: 1);
-        $this->assertSame($expectedHalfOfYear, $d->halfOfYear);
+        $this->assertSame($expectedHalfOfYear, $d->half);
     }
 }

--- a/tests/TestCase/Date/GettersTest.php
+++ b/tests/TestCase/Date/GettersTest.php
@@ -1,18 +1,6 @@
 <?php
 declare(strict_types=1);
 
-/**
- * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- *
- * Licensed under The MIT License
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @copyright     Copyright (c) Brian Nesbitt <brian@nesbot.com>
- * @link          https://cakephp.org CakePHP(tm) Project
- * @license       https://www.opensource.org/licenses/mit-license.php MIT License
- */
-
 namespace Cake\Chronos\Test\TestCase\Date;
 
 use Cake\Chronos\ChronosDate;

--- a/tests/TestCase/Date/IsTest.php
+++ b/tests/TestCase/Date/IsTest.php
@@ -17,6 +17,7 @@ namespace Cake\Chronos\Test\TestCase\Date;
 use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosDate;
 use Cake\Chronos\Test\TestCase\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 
 class IsTest extends TestCase
 {
@@ -363,5 +364,24 @@ class IsTest extends TestCase
         $this->assertTrue((new Chronos('+1 day'))->isWithinNext('1 day'));
         $this->assertTrue((new Chronos('+1 week'))->isWithinNext('7 day'));
         $this->assertTrue((new Chronos('+1 month'))->isWithinNext('1 month'));
+    }
+
+    #[TestWith([1, true, false])]
+    #[TestWith([2, true, false])]
+    #[TestWith([3, true, false])]
+    #[TestWith([4, true, false])]
+    #[TestWith([5, true, false])]
+    #[TestWith([6, true, false])]
+    #[TestWith([7, false, true])]
+    #[TestWith([8, false, true])]
+    #[TestWith([9, false, true])]
+    #[TestWith([10, false, true])]
+    #[TestWith([11, false, true])]
+    #[TestWith([12, false, true])]
+    public function testIsFirstOrSecondHalfOfYear(int $month, bool $isFirstHalfOfYear, bool $isSecondHalfOfYear): void
+    {
+        $d = Chronos::createFromDate(2023, $month, 1);
+        $this->assertSame($isFirstHalfOfYear, $d->isFirstHalfOfYear());
+        $this->assertSame($isSecondHalfOfYear, $d->isSecondHalfOfYear());
     }
 }

--- a/tests/TestCase/Date/IsTest.php
+++ b/tests/TestCase/Date/IsTest.php
@@ -381,7 +381,7 @@ class IsTest extends TestCase
     public function testIsFirstOrSecondHalfOfYear(int $month, bool $isFirstHalfOfYear, bool $isSecondHalfOfYear): void
     {
         $d = Chronos::createFromDate(2023, $month, 1);
-        $this->assertSame($isFirstHalfOfYear, $d->isFirstHalfOfYear());
-        $this->assertSame($isSecondHalfOfYear, $d->isSecondHalfOfYear());
+        $this->assertSame($isFirstHalfOfYear, $d->isFirstHalf());
+        $this->assertSame($isSecondHalfOfYear, $d->isSecondHalf());
     }
 }

--- a/tests/TestCase/DateTime/GettersTest.php
+++ b/tests/TestCase/DateTime/GettersTest.php
@@ -18,6 +18,7 @@ namespace Cake\Chronos\Test\TestCase\DateTime;
 use Cake\Chronos\Chronos;
 use Cake\Chronos\Test\TestCase\TestCase;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\TestWith;
 
 class GettersTest extends TestCase
 {
@@ -160,6 +161,24 @@ class GettersTest extends TestCase
     {
         $d = Chronos::createFromDate(2012, 12, 31);
         $this->assertSame(4, $d->quarter);
+    }
+
+    #[TestWith([1, 1])]
+    #[TestWith([2, 1])]
+    #[TestWith([3, 1])]
+    #[TestWith([4, 1])]
+    #[TestWith([5, 1])]
+    #[TestWith([6, 1])]
+    #[TestWith([7, 2])]
+    #[TestWith([8, 2])]
+    #[TestWith([9, 2])]
+    #[TestWith([10, 2])]
+    #[TestWith([11, 2])]
+    #[TestWith([12, 2])]
+    public function testHalfOfYear(int $month, int $expectedHalfOfYear): void
+    {
+        $d = Chronos::createFromDate(2012, $month, 1);
+        $this->assertSame($expectedHalfOfYear, $d->halfOfYear);
     }
 
     public function testGetLocalTrue()

--- a/tests/TestCase/DateTime/GettersTest.php
+++ b/tests/TestCase/DateTime/GettersTest.php
@@ -178,7 +178,7 @@ class GettersTest extends TestCase
     public function testHalfOfYear(int $month, int $expectedHalfOfYear): void
     {
         $d = Chronos::createFromDate(2012, $month, 1);
-        $this->assertSame($expectedHalfOfYear, $d->halfOfYear);
+        $this->assertSame($expectedHalfOfYear, $d->half);
     }
 
     public function testGetLocalTrue()

--- a/tests/TestCase/DateTime/IsTest.php
+++ b/tests/TestCase/DateTime/IsTest.php
@@ -16,7 +16,9 @@ declare(strict_types=1);
 namespace Cake\Chronos\Test\TestCase\DateTime;
 
 use Cake\Chronos\Chronos;
+use Cake\Chronos\ChronosDate;
 use Cake\Chronos\Test\TestCase\TestCase;
+use PHPUnit\Framework\Attributes\TestWith;
 
 class IsTest extends TestCase
 {
@@ -439,5 +441,24 @@ class IsTest extends TestCase
         $this->assertTrue((new Chronos('+1 week'))->isWithinNext('7 day'));
         $this->assertTrue((new Chronos('+1 second'))->isWithinNext('1 minute'));
         $this->assertTrue((new Chronos('+1 month'))->isWithinNext('1 month'));
+    }
+
+    #[TestWith([1, true, false])]
+    #[TestWith([2, true, false])]
+    #[TestWith([3, true, false])]
+    #[TestWith([4, true, false])]
+    #[TestWith([5, true, false])]
+    #[TestWith([6, true, false])]
+    #[TestWith([7, false, true])]
+    #[TestWith([8, false, true])]
+    #[TestWith([9, false, true])]
+    #[TestWith([10, false, true])]
+    #[TestWith([11, false, true])]
+    #[TestWith([12, false, true])]
+    public function testIsFirstOrSecondHalfOfYear(int $month, bool $isFirstHalfOfYear, bool $isSecondHalfOfYear): void
+    {
+        $d = ChronosDate::create(2023, $month, 1);
+        $this->assertSame($isFirstHalfOfYear, $d->isFirstHalfOfYear());
+        $this->assertSame($isSecondHalfOfYear, $d->isSecondHalfOfYear());
     }
 }

--- a/tests/TestCase/DateTime/IsTest.php
+++ b/tests/TestCase/DateTime/IsTest.php
@@ -458,7 +458,7 @@ class IsTest extends TestCase
     public function testIsFirstOrSecondHalfOfYear(int $month, bool $isFirstHalfOfYear, bool $isSecondHalfOfYear): void
     {
         $d = ChronosDate::create(2023, $month, 1);
-        $this->assertSame($isFirstHalfOfYear, $d->isFirstHalfOfYear());
-        $this->assertSame($isSecondHalfOfYear, $d->isSecondHalfOfYear());
+        $this->assertSame($isFirstHalfOfYear, $d->isFirstHalf());
+        $this->assertSame($isSecondHalfOfYear, $d->isSecondHalf());
     }
 }

--- a/tests/TestCase/DateTime/IssetTest.php
+++ b/tests/TestCase/DateTime/IssetTest.php
@@ -47,6 +47,7 @@ class IssetTest extends TestCase
             'timezoneName',
             'tz',
             'tzName',
+            'halfOfYear',
         ];
 
         foreach ($properties as $property) {

--- a/tests/TestCase/DateTime/IssetTest.php
+++ b/tests/TestCase/DateTime/IssetTest.php
@@ -47,7 +47,7 @@ class IssetTest extends TestCase
             'timezoneName',
             'tz',
             'tzName',
-            'halfOfYear',
+            'half',
         ];
 
         foreach ($properties as $property) {


### PR DESCRIPTION
I would like to propose the inclusion of the `halfOfYear` property and the `isFirstHalfOfYear` and `isSecondHalfOfYear` methods. The first half of the year corresponds to the first 6 months, while the second half corresponds to the remaining months.

Furthermore, I've made some improvements to the type hinting of the read-only properties in order to specify the numeric range. For example, changing `daysInMonth` from `int` to `int<1, 31>`. This allows for better static code analysis by PHPStan and Psalm.


Thank you in advance.