### PR TITLE
Rename toNative() toDateTimeImmutable()

### DIFF
--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -1564,11 +1564,11 @@ class ChronosDate
     }
 
     /**
-     * Returns the date as a DateTimeImmutable instance.
+     * Returns the date as a `DateTimeImmutable` instance.
      *
      * @return \DateTimeImmutable
      */
-    public function toNative(): DateTimeImmutable
+    public function toDateTimeImmutable(): DateTimeImmutable
     {
         return $this->native;
     }

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -320,7 +320,7 @@ class ChronosTime
      */
     public function format(string $format): string
     {
-        return $this->toNative()->format($format);
+        return $this->toDateTimeImmutable()->format($format);
     }
 
     /**
@@ -404,7 +404,7 @@ class ChronosTime
      *
      * @return \DateTimeImmutable
      */
-    public function toNative(): DateTimeImmutable
+    public function toDateTimeImmutable(): DateTimeImmutable
     {
         return (new DateTimeImmutable())->setTime(
             $this->getHours(),

--- a/tests/TestCase/ChronosTimeTest.php
+++ b/tests/TestCase/ChronosTimeTest.php
@@ -260,9 +260,9 @@ class ChronosTimeTest extends TestCase
         $this->assertFalse($t3->between($t1, $t2));
     }
 
-    public function testToNative(): void
+    public function testToDateTimeImmutable(): void
     {
-        $native = ChronosTime::parse('23:59:59.999999')->toNative();
+        $native = ChronosTime::parse('23:59:59.999999')->toDateTimeImmutable();
         $this->assertSame('23:59:59.999999', $native->format('H:i:s.u'));
     }
 }

--- a/tests/TestCase/Date/StringsTest.php
+++ b/tests/TestCase/Date/StringsTest.php
@@ -173,9 +173,9 @@ class StringsTest extends TestCase
         $this->assertSame('1975-12-25T00:00:00+00:00', $d->toW3cString());
     }
 
-    public function testToNative(): void
+    public function testToDateTimeImmutable(): void
     {
         $d = ChronosDate::now();
-        $this->assertSame($d->format('Y-m-d'), $d->toNative()->format('Y-m-d'));
+        $this->assertSame($d->format('Y-m-d'), $d->toDateTimeImmutable()->format('Y-m-d'));
     }
 }


### PR DESCRIPTION
The term "native" made sense internally only. This is more explicit and easier to find.