### PR TITLE
Default Chronos::create() time components to 0

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -563,10 +563,10 @@ class Chronos extends DateTimeImmutable
         ?int $year = null,
         ?int $month = null,
         ?int $day = null,
-        ?int $hour = null,
-        ?int $minute = null,
-        ?int $second = null,
-        ?int $microsecond = null,
+        ?int $hour = 0,
+        ?int $minute = 0,
+        ?int $second = 0,
+        ?int $microsecond = 0,
         DateTimeZone|string|null $timezone = null
     ): static {
         $now = static::now();
@@ -574,16 +574,10 @@ class Chronos extends DateTimeImmutable
         $month = $month ?? $now->format('m');
         $day = $day ?? $now->format('d');
 
-        if ($hour === null) {
-            $hour = $now->format('H');
-            $minute = $minute ?? $now->format('i');
-            $second = $second ?? $now->format('s');
-            $microsecond = $microsecond ?? $now->format('u');
-        } else {
-            $minute = $minute ?? 0;
-            $second = $second ?? 0;
-            $microsecond = $microsecond ?? 0;
-        }
+        $hour = $hour ?? $now->format('H');
+        $minute = $minute ?? $now->format('i');
+        $second = $second ?? $now->format('s');
+        $microsecond = $microsecond ?? $now->format('u');
 
         $instance = static::createFromFormat(
             'Y-m-d H:i:s.u',
@@ -595,7 +589,7 @@ class Chronos extends DateTimeImmutable
     }
 
     /**
-     * Create an instance from just a date. The time portion is set to now.
+     * Create an instance from just a date. The time portion is set to 00:00:00.000000.
      *
      * @param int|null $year The year to create an instance with.
      * @param int|null $month The month to create an instance with.
@@ -609,7 +603,7 @@ class Chronos extends DateTimeImmutable
         ?int $day = null,
         DateTimeZone|string|null $timezone = null
     ): static {
-        return static::create($year, $month, $day, null, null, null, null, $timezone);
+        return static::create($year, $month, $day, timezone: $timezone);
     }
 
     /**
@@ -623,10 +617,10 @@ class Chronos extends DateTimeImmutable
      * @return static
      */
     public static function createFromTime(
-        ?int $hour = null,
-        ?int $minute = null,
-        ?int $second = null,
-        ?int $microsecond = null,
+        ?int $hour = 0,
+        ?int $minute = 0,
+        ?int $second = 0,
+        ?int $microsecond = 0,
         DateTimeZone|string|null $timezone = null
     ): static {
         return static::create(null, null, null, $hour, $minute, $second, $microsecond, $timezone);

--- a/tests/TestCase/DateTime/CreateFromDateTest.php
+++ b/tests/TestCase/DateTime/CreateFromDateTest.php
@@ -24,7 +24,7 @@ class CreateFromDateTest extends TestCase
     public function testCreateFromDateWithDefaults()
     {
         $d = Chronos::createFromDate();
-        $this->assertSame($d->timestamp, Chronos::create(null, null, null, null, null, null, null)->timestamp);
+        $this->assertSame($d->timestamp, Chronos::create(null, null, null)->timestamp);
     }
 
     public function testCreateFromDate()

--- a/tests/TestCase/DateTime/CreateFromTimeTest.php
+++ b/tests/TestCase/DateTime/CreateFromTimeTest.php
@@ -24,7 +24,7 @@ class CreateFromTimeTest extends TestCase
     public function testCreateFromDateWithDefaults()
     {
         $d = Chronos::createFromTime();
-        $this->assertSame($d->timestamp, Chronos::create(null, null, null, null, null, null)->timestamp);
+        $this->assertSame($d->timestamp, Chronos::create(null, null, null)->timestamp);
     }
 
     public function testCreateFromDate()

--- a/tests/TestCase/DateTime/CreateTest.php
+++ b/tests/TestCase/DateTime/CreateTest.php
@@ -31,7 +31,10 @@ class CreateTest extends TestCase
     public function testCreateWithDefaults()
     {
         $d = Chronos::create();
-        $this->assertSame($d->timestamp, Chronos::now()->timestamp);
+        $this->assertSame($d->timestamp, Chronos::now()->setTime(0, 0)->timestamp);
+
+        $d = Chronos::create(2023, 1, 1, minute: 1);
+        $this->assertSame($d->timestamp, Chronos::parse('2023-01-01 00:01:00')->timestamp);
     }
 
     public function testCreateWithYear()

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -177,7 +177,7 @@ class DiffTest extends TestCase
 
     public function testDiffInDaysFilteredNegativeWithSignWithMutated()
     {
-        $dt = Chronos::createFromDate(2000, 1, 31);
+        $dt = Chronos::create(2000, 1, 31, hour: 12);
         $this->assertSame(-5, $dt->diffInDaysFiltered(function ($date) {
             return $date->dayOfWeek === 1;
         }, $dt->startOfMonth(), false));
@@ -330,13 +330,13 @@ class DiffTest extends TestCase
 
     public function testDiffInWeekdaysNegativeNoSign()
     {
-        $dt = Chronos::createFromDate(2000, 1, 31);
+        $dt = Chronos::create(2000, 1, 31, hour: 12);
         $this->assertSame(21, $dt->diffInWeekdays($dt->startOfMonth()));
     }
 
     public function testDiffInWeekdaysNegativeWithSign()
     {
-        $dt = Chronos::createFromDate(2000, 1, 31);
+        $dt = Chronos::create(2000, 1, 31, hour: 12);
         $this->assertSame(-21, $dt->diffInWeekdays($dt->startOfMonth(), false));
     }
 


### PR DESCRIPTION
closes https://github.com/cakephp/chronos/issues/419

This expands the scope of the RFC a little since other wrappers that call Chronos::create() were also defaulting to `null`.