### PR TITLE
Bring back toNative() alias of toDateTimeImmutable()

### DIFF
--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -1574,6 +1574,18 @@ class ChronosDate
     }
 
     /**
+     * Returns an `DateTimeImmutable` instance set to this clock time.
+     *
+     * Alias of `toDateTimeImmutable()`.
+     *
+     * @return \DateTimeImmutable
+     */
+    public function toNative(): DateTimeImmutable
+    {
+        return $this->toDateTimeImmutable();
+    }
+
+    /**
      * Get a part of the object
      *
      * @param string $name The property name to read.

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -413,4 +413,16 @@ class ChronosTime
             $this->getMicroseconds()
         );
     }
+
+    /**
+     * Returns an `DateTimeImmutable` instance set to this clock time.
+     *
+     * Alias of `toDateTimeImmutable()`.
+     *
+     * @return \DateTimeImmutable
+     */
+    public function toNative(): DateTimeImmutable
+    {
+        return $this->toDateTimeImmutable();
+    }
 }

--- a/tests/TestCase/ChronosTimeTest.php
+++ b/tests/TestCase/ChronosTimeTest.php
@@ -264,5 +264,8 @@ class ChronosTimeTest extends TestCase
     {
         $native = ChronosTime::parse('23:59:59.999999')->toDateTimeImmutable();
         $this->assertSame('23:59:59.999999', $native->format('H:i:s.u'));
+
+        $native = ChronosTime::parse('23:59:59.999999')->toNative();
+        $this->assertSame('23:59:59.999999', $native->format('H:i:s.u'));
     }
 }

--- a/tests/TestCase/Date/StringsTest.php
+++ b/tests/TestCase/Date/StringsTest.php
@@ -177,5 +177,8 @@ class StringsTest extends TestCase
     {
         $d = ChronosDate::now();
         $this->assertSame($d->format('Y-m-d'), $d->toDateTimeImmutable()->format('Y-m-d'));
+
+        $d = ChronosDate::now();
+        $this->assertSame($d->format('Y-m-d'), $d->toNative()->format('Y-m-d'));
     }
 }


### PR DESCRIPTION
refs https://github.com/cakephp/chronos/pull/424

We want to keep BC with 3.0 as users have changed code to call `toNative()`. Users can decide which makes their code clearer or cleaner.