### PR TITLE
Fix casting to string for ChronosDate and ChronosTime.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -148,14 +148,4 @@
         ];]]></code>
     </ImpureStaticVariable>
   </file>
-  <file src="src/ChronosTime.php">
-    <ImpureMethodCall>
-      <code>format</code>
-      <code>mod</code>
-      <code>mod</code>
-      <code>mod</code>
-      <code>mod</code>
-      <code>mod</code>
-    </ImpureMethodCall>
-  </file>
 </files>

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -21,6 +21,7 @@ use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
 use RuntimeException;
+use Stringable;
 
 /**
  * An Immutable extension on the native DateTime object.
@@ -58,7 +59,7 @@ use RuntimeException;
  * @psalm-immutable
  * @psalm-consistent-constructor
  */
-class Chronos extends DateTimeImmutable
+class Chronos extends DateTimeImmutable implements Stringable
 {
     use FormattingTrait;
 

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -20,6 +20,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
+use Stringable;
 
 /**
  * An immutable date object.
@@ -43,16 +44,23 @@ use InvalidArgumentException;
  * @psalm-immutable
  * @psalm-consistent-constructor
  */
-class ChronosDate
+class ChronosDate implements Stringable
 {
     use FormattingTrait;
+
+    /**
+     * Default format to use for __toString method when type juggling occurs.
+     *
+     * @var string
+     */
+    public const DEFAULT_TO_STRING_FORMAT = 'Y-m-d';
 
     /**
      * Format to use for __toString method when type juggling occurs.
      *
      * @var string
      */
-    protected static string $toStringFormat = 'Y-m-d';
+    protected static string $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
 
     /**
      * Names of days of the week.

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -18,12 +18,13 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
+use Stringable;
 
 /**
  * @psalm-immutable
  * @psalm-consistent-constructor
  */
-class ChronosTime
+class ChronosTime implements Stringable
 {
     /**
      * @var int
@@ -49,6 +50,20 @@ class ChronosTime
      * @var int
      */
     protected const TICKS_PER_DAY = self::TICKS_PER_HOUR * 24;
+
+    /**
+     * Default format to use for __toString method.
+     *
+     * @var string
+     */
+    public const DEFAULT_TO_STRING_FORMAT = 'H:i:s';
+
+    /**
+     * Format to use for __toString method.
+     *
+     * @var string
+     */
+    protected static string $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
 
     /**
      * @var int
@@ -321,6 +336,37 @@ class ChronosTime
     public function format(string $format): string
     {
         return $this->toDateTimeImmutable()->format($format);
+    }
+
+    /**
+     * Reset the format used to the default when converting to a string
+     *
+     * @return void
+     */
+    public static function resetToStringFormat(): void
+    {
+        static::setToStringFormat(static::DEFAULT_TO_STRING_FORMAT);
+    }
+
+    /**
+     * Set the default format used when converting to a string
+     *
+     * @param string $format The format to use in future __toString() calls.
+     * @return void
+     */
+    public static function setToStringFormat(string $format): void
+    {
+        static::$toStringFormat = $format;
+    }
+
+    /**
+     * Format the instance as a string using the set format
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->format(static::$toStringFormat);
     }
 
     /**

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -21,7 +21,6 @@ use InvalidArgumentException;
 use Stringable;
 
 /**
- * @psalm-immutable
  * @psalm-consistent-constructor
  */
 class ChronosTime implements Stringable

--- a/src/FormattingTrait.php
+++ b/src/FormattingTrait.php
@@ -32,7 +32,7 @@ trait FormattingTrait
      */
     public static function resetToStringFormat(): void
     {
-        static::setToStringFormat(Chronos::DEFAULT_TO_STRING_FORMAT);
+        static::setToStringFormat(static::DEFAULT_TO_STRING_FORMAT);
     }
 
     /**

--- a/tests/TestCase/ChronosTimeTest.php
+++ b/tests/TestCase/ChronosTimeTest.php
@@ -268,4 +268,16 @@ class ChronosTimeTest extends TestCase
         $native = ChronosTime::parse('23:59:59.999999')->toNative();
         $this->assertSame('23:59:59.999999', $native->format('H:i:s.u'));
     }
+
+    public function testToString(): void
+    {
+        $t = new ChronosTime('12:13:14.123456');
+        $this->assertSame('12:13:14', (string)$t);
+
+        ChronosTime::setToStringFormat('H:i:s.u');
+        $this->assertSame('12:13:14.123456', (string)$t);
+
+        ChronosTime::resetToStringFormat();
+        $this->assertSame('12:13:14', (string)$t);
+    }
 }

--- a/tests/TestCase/Date/StringsTest.php
+++ b/tests/TestCase/Date/StringsTest.php
@@ -68,7 +68,7 @@ class StringsTest extends TestCase
         $d = ChronosDate::parse(Chronos::now());
         ChronosDate::setToStringFormat('123');
         ChronosDate::resetToStringFormat();
-        $this->assertSame($d->toDateTimeString(), '' . $d);
+        $this->assertSame($d->toDateString(), '' . $d);
     }
 
     public function testToDateString()


### PR DESCRIPTION
Make all classes explicitly implemement Stringable as recommeneded by the PHP docs.