### PR TITLE
Allow passing DatePeriod options to diffFiltered()

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -2301,13 +2301,15 @@ class Chronos extends DateTimeImmutable
      * @param callable $callback The callback to use for filtering.
      * @param \DateTimeInterface|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
     public function diffFiltered(
         DateInterval $interval,
         callable $callback,
         ?DateTimeInterface $other = null,
-        bool $absolute = true
+        bool $absolute = true,
+        int $options = 0
     ): int {
         $start = $this;
         $end = $other ?? static::now($this->tz);
@@ -2319,7 +2321,7 @@ class Chronos extends DateTimeImmutable
             $inverse = true;
         }
 
-        $period = new DatePeriod($start, $interval, $end);
+        $period = new DatePeriod($start, $interval, $end, $options);
         $vals = array_filter(iterator_to_array($period), function (DateTimeInterface $date) use ($callback) {
             return $callback(static::instance($date));
         });
@@ -2413,14 +2415,16 @@ class Chronos extends DateTimeImmutable
      * @param callable $callback The callback to use for filtering.
      * @param \DateTimeInterface|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
     public function diffInDaysFiltered(
         callable $callback,
         ?DateTimeInterface $other = null,
-        bool $absolute = true
+        bool $absolute = true,
+        int $options = 0
     ): int {
-        return $this->diffFiltered(new DateInterval('P1D'), $callback, $other, $absolute);
+        return $this->diffFiltered(new DateInterval('P1D'), $callback, $other, $absolute, $options);
     }
 
     /**
@@ -2429,14 +2433,16 @@ class Chronos extends DateTimeImmutable
      * @param callable $callback The callback to use for filtering.
      * @param \DateTimeInterface|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
     public function diffInHoursFiltered(
         callable $callback,
         ?DateTimeInterface $other = null,
-        bool $absolute = true
+        bool $absolute = true,
+        int $options = 0
     ): int {
-        return $this->diffFiltered(new DateInterval('PT1H'), $callback, $other, $absolute);
+        return $this->diffFiltered(new DateInterval('PT1H'), $callback, $other, $absolute, $options);
     }
 
     /**
@@ -2444,13 +2450,14 @@ class Chronos extends DateTimeImmutable
      *
      * @param \DateTimeInterface|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
-    public function diffInWeekdays(?DateTimeInterface $other = null, bool $absolute = true): int
+    public function diffInWeekdays(?DateTimeInterface $other = null, bool $absolute = true, int $options = 0): int
     {
         return $this->diffInDaysFiltered(function (Chronos $date) {
             return $date->isWeekday();
-        }, $other, $absolute);
+        }, $other, $absolute, $options);
     }
 
     /**
@@ -2458,13 +2465,14 @@ class Chronos extends DateTimeImmutable
      *
      * @param \DateTimeInterface|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
-    public function diffInWeekendDays(?DateTimeInterface $other = null, bool $absolute = true): int
+    public function diffInWeekendDays(?DateTimeInterface $other = null, bool $absolute = true, int $options = 0): int
     {
         return $this->diffInDaysFiltered(function (Chronos $date) {
             return $date->isWeekend();
-        }, $other, $absolute);
+        }, $other, $absolute, $options);
     }
 
     /**

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -1409,13 +1409,15 @@ class ChronosDate
      * @param callable $callback The callback to use for filtering.
      * @param \Cake\Chronos\ChronosDate|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
     public function diffFiltered(
         DateInterval $interval,
         callable $callback,
         ?ChronosDate $other = null,
-        bool $absolute = true
+        bool $absolute = true,
+        int $options = 0
     ): int {
         $start = $this;
         $end = $other ?? new ChronosDate(Chronos::now());
@@ -1430,7 +1432,7 @@ class ChronosDate
         // within the range. Sadly INCLUDE_END_DATE doesn't land until 8.2
         $endTime = $end->native->modify('+1 second');
 
-        $period = new DatePeriod($start->native, $interval, $endTime);
+        $period = new DatePeriod($start->native, $interval, $endTime, $options);
         $vals = array_filter(iterator_to_array($period), function (DateTimeInterface $date) use ($callback) {
             return $callback(static::parse($date));
         });
@@ -1501,14 +1503,16 @@ class ChronosDate
      * @param callable $callback The callback to use for filtering.
      * @param \Cake\Chronos\ChronosDate|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
     public function diffInDaysFiltered(
         callable $callback,
         ?ChronosDate $other = null,
-        bool $absolute = true
+        bool $absolute = true,
+        int $options = 0
     ): int {
-        return $this->diffFiltered(new DateInterval('P1D'), $callback, $other, $absolute);
+        return $this->diffFiltered(new DateInterval('P1D'), $callback, $other, $absolute, $options);
     }
 
     /**
@@ -1516,13 +1520,14 @@ class ChronosDate
      *
      * @param \Cake\Chronos\ChronosDate|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
-    public function diffInWeekdays(?ChronosDate $other = null, bool $absolute = true): int
+    public function diffInWeekdays(?ChronosDate $other = null, bool $absolute = true, int $options = 0): int
     {
         return $this->diffInDaysFiltered(function (ChronosDate $date) {
             return $date->isWeekday();
-        }, $other, $absolute);
+        }, $other, $absolute, $options);
     }
 
     /**
@@ -1530,13 +1535,14 @@ class ChronosDate
      *
      * @param \Cake\Chronos\ChronosDate|null $other The instance to difference from.
      * @param bool $absolute Get the absolute of the difference
+     * @param int $options DatePeriod options, {@see https://www.php.net/manual/en/class.dateperiod.php}
      * @return int
      */
-    public function diffInWeekendDays(?ChronosDate $other = null, bool $absolute = true): int
+    public function diffInWeekendDays(?ChronosDate $other = null, bool $absolute = true, int $options = 0): int
     {
         return $this->diffInDaysFiltered(function (ChronosDate $date) {
             return $date->isWeekend();
-        }, $other, $absolute);
+        }, $other, $absolute, $options);
     }
 
     /**

--- a/tests/TestCase/Date/DiffTest.php
+++ b/tests/TestCase/Date/DiffTest.php
@@ -18,6 +18,7 @@ use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosDate;
 use Cake\Chronos\Test\TestCase\TestCase;
 use Closure;
+use DatePeriod;
 
 class DiffTest extends TestCase
 {
@@ -207,6 +208,21 @@ class DiffTest extends TestCase
         $this->assertSame(-12, $dt1->diffFiltered($interval, function ($date) {
             return $date->year === 2000;
         }, $dt2, false));
+    }
+
+    public function testDiffFilteredWithOptions()
+    {
+        $dt1 = ChronosDate::create(2000, 1, 1);
+        $dt2 = ChronosDate::create(2000, 1, 2);
+        $interval = Chronos::createInterval(days: 1);
+
+        $this->assertSame(1, $dt1->diffFiltered($interval, function ($dt) {
+            return $dt->day === 1;
+        }, $dt2));
+
+        $this->assertSame(0, $dt1->diffFiltered($interval, function ($dt) {
+            return $dt->day === 1;
+        }, $dt2, options: DatePeriod::EXCLUDE_START_DATE));
     }
 
     public function testDiffInWeekdaysPositive()

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -18,6 +18,7 @@ use Cake\Chronos\Chronos;
 use Cake\Chronos\DifferenceFormatter;
 use Cake\Chronos\Test\TestCase\TestCase;
 use Closure;
+use DatePeriod;
 use DateTimeZone;
 
 class DiffTest extends TestCase
@@ -283,6 +284,21 @@ class DiffTest extends TestCase
         $this->assertSame(-12, $dt1->diffFiltered($interval, function ($date) {
             return $date->year === 2000;
         }, $dt2, false));
+    }
+
+    public function testDiffFilteredWithOptions()
+    {
+        $dt1 = Chronos::create(2000, 1, 1);
+        $dt2 = Chronos::create(2000, 1, 2);
+        $interval = Chronos::createInterval(days: 1);
+
+        $this->assertSame(1, $dt1->diffFiltered($interval, function ($dt) {
+            return $dt->day === 1;
+        }, $dt2));
+
+        $this->assertSame(0, $dt1->diffFiltered($interval, function ($dt) {
+            return $dt->day === 1;
+        }, $dt2, options: DatePeriod::EXCLUDE_START_DATE));
     }
 
     public function testBug188DiffWithSameDates()


### PR DESCRIPTION
This allows users to pass the new PHP 8.2 option that includes the end date in the period. This is helpful when iterating over dates that end on midnight as that day won't be included.