### PR TITLE
Allow setting time zone when converting to DateTimeImmutable

### DIFF
--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -1578,25 +1578,33 @@ class ChronosDate implements Stringable
     }
 
     /**
-     * Returns the date as a `DateTimeImmutable` instance.
+     * Returns the date as a `DateTimeImmutable` instance at midnight.
      *
+     * @param \DateTimeZone|string|null $timezone Time zone the DateTimeImmutable instance will be in
      * @return \DateTimeImmutable
      */
-    public function toDateTimeImmutable(): DateTimeImmutable
+    public function toDateTimeImmutable(DateTimeZone|string|null $timezone = null): DateTimeImmutable
     {
-        return $this->native;
+        if ($timezone === null) {
+            return $this->native;
+        }
+
+        $timezone = is_string($timezone) ? new DateTimeZone($timezone) : $timezone;
+
+        return new DateTimeImmutable($this->native->format('Y-m-d H:i:s.u'), $timezone);
     }
 
     /**
-     * Returns an `DateTimeImmutable` instance set to this clock time.
+     * Returns the date as a `DateTimeImmutable` instance at midnight.
      *
      * Alias of `toDateTimeImmutable()`.
      *
+     * @param \DateTimeZone|string|null $timezone Time zone the DateTimeImmutable instance will be in
      * @return \DateTimeImmutable
      */
-    public function toNative(): DateTimeImmutable
+    public function toNative(DateTimeZone|string|null $timezone = null): DateTimeImmutable
     {
-        return $this->toDateTimeImmutable();
+        return $this->toDateTimeImmutable($timezone);
     }
 
     /**

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -447,11 +447,14 @@ class ChronosTime implements Stringable
     /**
      * Returns an `DateTimeImmutable` instance set to this clock time.
      *
+     * @param \DateTimeZone|string|null $timezone Time zone the DateTimeImmutable instance will be in
      * @return \DateTimeImmutable
      */
-    public function toDateTimeImmutable(): DateTimeImmutable
+    public function toDateTimeImmutable(DateTimeZone|string|null $timezone = null): DateTimeImmutable
     {
-        return (new DateTimeImmutable())->setTime(
+        $timezone = is_string($timezone) ? new DateTimeZone($timezone) : $timezone;
+
+        return (new DateTimeImmutable(timezone: $timezone))->setTime(
             $this->getHours(),
             $this->getMinutes(),
             $this->getSeconds(),
@@ -464,10 +467,11 @@ class ChronosTime implements Stringable
      *
      * Alias of `toDateTimeImmutable()`.
      *
+     * @param \DateTimeZone|string|null $timezone Time zone the DateTimeImmutable instance will be in
      * @return \DateTimeImmutable
      */
-    public function toNative(): DateTimeImmutable
+    public function toNative(DateTimeZone|string|null $timezone = null): DateTimeImmutable
     {
-        return $this->toDateTimeImmutable();
+        return $this->toDateTimeImmutable($timezone);
     }
 }

--- a/tests/TestCase/ChronosTimeTest.php
+++ b/tests/TestCase/ChronosTimeTest.php
@@ -262,11 +262,20 @@ class ChronosTimeTest extends TestCase
 
     public function testToDateTimeImmutable(): void
     {
-        $native = ChronosTime::parse('23:59:59.999999')->toDateTimeImmutable();
+        $time = ChronosTime::parse('23:59:59.999999');
+        $native = $time->toDateTimeImmutable();
         $this->assertSame('23:59:59.999999', $native->format('H:i:s.u'));
 
-        $native = ChronosTime::parse('23:59:59.999999')->toNative();
+        $native = $time->toNative();
         $this->assertSame('23:59:59.999999', $native->format('H:i:s.u'));
+
+        $native = $time->toDateTimeImmutable('Asia/Tokyo');
+        $this->assertSame('23:59:59.999999', $native->format('H:i:s.u'));
+        $this->assertSame('Asia/Tokyo', $native->getTimezone()->getName());
+
+        $native = $time->toNative('Asia/Tokyo');
+        $this->assertSame('23:59:59.999999', $native->format('H:i:s.u'));
+        $this->assertSame('Asia/Tokyo', $native->getTimezone()->getName());
     }
 
     public function testToString(): void

--- a/tests/TestCase/Date/StringsTest.php
+++ b/tests/TestCase/Date/StringsTest.php
@@ -176,9 +176,15 @@ class StringsTest extends TestCase
     public function testToDateTimeImmutable(): void
     {
         $d = ChronosDate::now();
-        $this->assertSame($d->format('Y-m-d'), $d->toDateTimeImmutable()->format('Y-m-d'));
+        $this->assertSame($d->format('Y-m-d H:i:s.u'), $d->toDateTimeImmutable()->format('Y-m-d H:i:s.u'));
+        $this->assertSame($d->format('Y-m-d H:i:s.u'), $d->toNative()->format('Y-m-d H:i:s.u'));
 
-        $d = ChronosDate::now();
-        $this->assertSame($d->format('Y-m-d'), $d->toNative()->format('Y-m-d'));
+        $native = $d->toDateTimeImmutable('Asia/Tokyo');
+        $this->assertSame($d->format('Y-m-d H:i:s.u'), $native->format('Y-m-d H:i:s.u'));
+        $this->assertSame('Asia/Tokyo', $native->getTimezone()->getName());
+
+        $native = $d->toNative('Asia/Tokyo');
+        $this->assertSame($d->format('Y-m-d H:i:s.u'), $native->format('Y-m-d H:i:s.u'));
+        $this->assertSame('Asia/Tokyo', $native->getTimezone()->getName());
     }
 }


### PR DESCRIPTION
Allow users to set the time zone when converting to DateTimeImmutable instead of only defaulting to the internal implementation.

Users will probably use this when converting between systems and will need flexibility.

This adds no extra overhead to the conversion.