### PR TITLE
Restore Chronos::toNative()

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -2581,6 +2581,18 @@ class Chronos extends DateTimeImmutable implements Stringable
     }
 
     /**
+     * Returns a DateTimeImmutable instance
+     *
+     * This method returns a PHP DateTimeImmutable without Chronos extensions.
+     *
+     * @return \DateTimeImmutable
+     */
+    public function toNative(): DateTimeImmutable
+    {
+        return new DateTimeImmutable($this->format('Y-m-d H:i:s.u'), $this->getTimezone());
+    }
+
+    /**
      * Get a part of the object
      *
      * @param string $name The property name to read.

--- a/tests/TestCase/DateTime/StringsTest.php
+++ b/tests/TestCase/DateTime/StringsTest.php
@@ -213,4 +213,13 @@ class StringsTest extends TestCase
     {
         $this->assertSame($expected, (new Chronos($date))->toWeek());
     }
+
+    public function testToNative(): void
+    {
+        $c = Chronos::now();
+        $native = $c->toNative();
+        $this->assertSame($c->format(DATE_ATOM), $native->format(DATE_ATOM));
+        $this->assertEquals($c->getTimezone(), $native->getTimezone());
+        $this->assertEquals($c->format('u'), $native->format('u'));
+    }
 }


### PR DESCRIPTION
This was accidently removed in the shuffle of #417 and #427

Fixes #432