### PR TITLE
Restore Date::create() compatibility with no params

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,22 +21,7 @@ parameters:
 			path: src/Chronos.php
 
 		-
-			message: "#^Parameter \\#1 \\$year of static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) expects int, null given\\.$#"
-			count: 1
-			path: src/ChronosDate.php
-
-		-
-			message: "#^Parameter \\#2 \\$month of static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) expects int, null given\\.$#"
-			count: 1
-			path: src/ChronosDate.php
-
-		-
-			message: "#^Parameter \\#3 \\$day of static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) expects int, null given\\.$#"
-			count: 1
-			path: src/ChronosDate.php
-
-		-
-			message: "#^Static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) invoked with 8 parameters, 3 required\\.$#"
+			message: "#^Static method Cake\\\\Chronos\\\\ChronosDate\\:\\:create\\(\\) invoked with 8 parameters, 0-3 required\\.$#"
 			count: 2
 			path: src/ChronosDate.php
 

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -151,8 +151,13 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
      * @param int $day The day to create an instance with.
      * @return static
      */
-    public static function create(int $year, int $month, int $day)
+    public static function create(?int $year = null, ?int $month = null, ?int $day = null)
     {
+        $now = static::today();
+        $year = $year ?? (int)$now->format('Y');
+        $month = $month ?? $now->format('m');
+        $day = $day ?? $now->format('d');
+
         $instance = static::createFromFormat(
             'Y-m-d',
             sprintf('%s-%s-%s', 0, $month, $day)

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -146,9 +146,9 @@ class ChronosDate extends DateTimeImmutable implements ChronosInterface
     /**
      * Create an instance from a specific date.
      *
-     * @param int $year The year to create an instance with.
-     * @param int $month The month to create an instance with.
-     * @param int $day The day to create an instance with.
+     * @param ?int $year The year to create an instance with.
+     * @param ?int $month The month to create an instance with.
+     * @param ?int $day The day to create an instance with.
      * @return static
      */
     public static function create(?int $year = null, ?int $month = null, ?int $day = null)

--- a/tests/TestCase/Date/ConstructTest.php
+++ b/tests/TestCase/Date/ConstructTest.php
@@ -297,6 +297,26 @@ class ConstructTest extends TestCase
     /**
      * @dataProvider dateClassProvider
      */
+    public function testCreateWithTestNowNoParams($class)
+    {
+        $class::setTestNow($class::create(2001, 1, 1));
+        $date = $class::create();
+        $this->assertDate($date, 2001, 1, 1);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     */
+    public function testCreateWithSomeParams($class)
+    {
+        $now = $class::today();
+        $date = $class::create(2022, 1);
+        $this->assertDate($date, 2022, 1, (int)$now->format('d'));
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     */
     public function testConstructWithRelative($class)
     {
         $c = new $class('+7 days');


### PR DESCRIPTION
Restore the historical behavior of create() that uses the current day by default.

Fixes #434