### PR TITLE
Improve exception messages

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -936,7 +936,7 @@ class Chronos extends DateTimeImmutable implements Stringable
     {
         $new = parent::modify($modifier);
         if ($new === false) {
-            throw new InvalidArgumentException('Unable to modify date using: ' . $modifier);
+            throw new InvalidArgumentException(sprintf('Unable to modify date using `%s', $modifier));
         }
 
         return $new;
@@ -2665,7 +2665,7 @@ class Chronos extends DateTimeImmutable implements Stringable
                 return $this->getTimezone()->getName();
 
             default:
-                throw new InvalidArgumentException(sprintf("Unknown getter '%s'", $name));
+                throw new InvalidArgumentException(sprintf('Unknown getter `%s`', $name));
         }
     }
 
@@ -2673,7 +2673,7 @@ class Chronos extends DateTimeImmutable implements Stringable
      * Check if an attribute exists on the object
      *
      * @param string $name The property name to check.
-     * @return bool Whether or not the property exists.
+     * @return bool Whether the property exists.
      */
     public function __isset(string $name): bool
     {

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -936,7 +936,7 @@ class Chronos extends DateTimeImmutable implements Stringable
     {
         $new = parent::modify($modifier);
         if ($new === false) {
-            throw new InvalidArgumentException(sprintf('Unable to modify date using `%s', $modifier));
+            throw new InvalidArgumentException(sprintf('Unable to modify date using `%s`', $modifier));
         }
 
         return $new;

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -356,7 +356,7 @@ class ChronosDate implements Stringable
         $new = clone $this;
         $new->native = $new->native->modify($modifier);
         if ($new->native === false) {
-            throw new InvalidArgumentException('Unable to modify date using: ' . $modifier);
+            throw new InvalidArgumentException(sprintf('Unable to modify date using `%s`', $modifier));
         }
 
         if ($new->format('H:i:s') !== '00:00:00') {
@@ -1647,7 +1647,7 @@ class ChronosDate implements Stringable
                 return $this->month <= 6 ? 1 : 2;
 
             default:
-                throw new InvalidArgumentException(sprintf("Unknown getter '%s'", $name));
+                throw new InvalidArgumentException(sprintf('Unknown getter `%s`', $name));
         }
     }
 
@@ -1655,7 +1655,7 @@ class ChronosDate implements Stringable
      * Check if an attribute exists on the object
      *
      * @param string $name The property name to check.
-     * @return bool Whether or not the property exists.
+     * @return bool Whether the property exists.
      */
     public function __isset(string $name): bool
     {

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -120,7 +120,7 @@ class ChronosTime implements Stringable
     {
         if (!preg_match('/^\s*(\d{1,2})[:.](\d{1,2})(?|[:.](\d{1,2})[.](\d+)|[:.](\d{1,2}))?\s*$/', $time, $matches)) {
             throw new InvalidArgumentException(
-                'Time string is not in expected format: "HH[:.]mm" or "HH[:.]mm[:.]ss.u".'
+                sprintf('Time string `%s` is not in expected format `HH[:.]mm` or `HH[:.]mm[:.]ss.u`.', $time)
             );
         }
 
@@ -130,7 +130,7 @@ class ChronosTime implements Stringable
         $microseconds = (int)substr($matches[4] ?? '', 0, 6);
 
         if ($hours > 24 || $minutes > 59 || $seconds > 59 || $microseconds > 999_999) {
-            throw new InvalidArgumentException('Time string contains invalid values.');
+            throw new InvalidArgumentException(sprintf('Time string `%s` contains invalid values.', $time));
         }
 
         $ticks = $hours * self::TICKS_PER_HOUR;

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -50,7 +50,7 @@ class Translator
      * Check if a translation key exists.
      *
      * @param string $key The key to check.
-     * @return bool Whether or not the key exists.
+     * @return bool Whether the key exists.
      */
     public function exists(string $key): bool
     {


### PR DESCRIPTION
```
1) Data\Test\TestCase\Model\Table\AddressesTableTest::testTouch
InvalidArgumentException: Time string is not in expected format: "HH[:.]mm" or "HH[:.]mm[:.]ss.u".

/home/runner/work/cakephp-data/cakephp-data/vendor/cakephp/chronos/src/ChronosTime.php:122
```

hard to understand

it is possible to give the values for quicker debugging however.

```
InvalidArgumentException: Time string `-2 seconds` is not in expected format `HH[:.]mm` or `HH[:.]mm[:.]ss.u`.
```

fixed also some formatting around code fencing.