### PR TITLE
Fix error on PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,57 @@ permissions:
 
 jobs:
   testsuite:
-    uses: cakephp/.github/.github/workflows/testsuite-without-db.yml@5.x
-    secrets: inherit
+    runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.unstable }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.1']
+        dependencies: [highest]
+        unstable: [false]
+        include:
+          - php-version: '8.1'
+            dependencies: lowest
+            unstable: false
+          - php-version: '8.2'
+            dependencies: highest
+            unstable: false
+          - php-version: '8.3'
+            dependencies: highest
+            unstable: false
+          - php-version: '8.4'
+            dependencies: highest
+            unstable: true
+            composer-options: "--ignore-platform-req=php"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        extensions: mbstring, intl
+        ini-values: zend.assertions=1
+        coverage: pcov
+
+    - name: Composer install
+      uses: ramsey/composer-install@v2
+      with:
+        dependency-versions: ${{ matrix.dependencies }}
+        composer-options: ${{ matrix.composer-options }}
+
+    - name: Run PHPUnit
+      run: |
+        if [[ ${{ matrix.php-version }} == '8.1' && ${{ matrix.dependencies }} == 'highest' ]]; then
+          export CODECOVERAGE=1 && vendor/bin/phpunit --display-deprecations --display-warnings --display-incomplete --display-skipped --coverage-clover=coverage.xml
+        else
+          vendor/bin/phpunit --display-deprecations --display-warnings
+        fi
+
+    - name: Code Coverage Report
+      if: success() && matrix.php-version == '8.1' && matrix.dependencies == 'highest'
+      uses: codecov/codecov-action@v3
 
   cs-stan:
     uses: cakephp/.github/.github/workflows/cs-stan.yml@5.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
           - php-version: '8.4'
             dependencies: highest
             unstable: true
-            composer-options: "--ignore-platform-req=php"
 
     steps:
     - uses: actions/checkout@v4

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,7 @@ parameters:
 		- src/
 	ignoreErrors:
 		- identifier: missingType.iterableValue
+		-
+			message: "#^Call to an undefined static method DateTimeImmutable\\:\\:createFromTimestamp\\(\\)\\.$#"
+			count: 1
+			path: src/Chronos.php

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -736,13 +736,23 @@ class Chronos extends DateTimeImmutable implements Stringable
     /**
      * Create an instance from a timestamp
      *
-     * @param int $timestamp The timestamp to create an instance from.
+     * @param float|int $timestamp The timestamp to create an instance from.
      * @param \DateTimeZone|string|null $timezone The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function createFromTimestamp(int $timestamp, DateTimeZone|string|null $timezone = null): static
+    public static function createFromTimestamp(float|int $timestamp, DateTimeZone|string|null $timezone = null): static
     {
-        return static::now($timezone)->setTimestamp($timestamp);
+        if (PHP_VERSION_ID >= 80400 && $timezone === null) {
+            return parent::createFromTimestamp($timestamp);
+        }
+
+        $instance = static::now($timezone);
+
+        if (is_int($timestamp)) {
+            return $instance->setTimestamp($timestamp);
+        }
+
+        return $instance->modify('@' . $timestamp);
     }
 
     /**

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -742,17 +742,9 @@ class Chronos extends DateTimeImmutable implements Stringable
      */
     public static function createFromTimestamp(float|int $timestamp, DateTimeZone|string|null $timezone = null): static
     {
-        if (PHP_VERSION_ID >= 80400 && $timezone === null) {
-            return parent::createFromTimestamp($timestamp);
-        }
+        $instance = PHP_VERSION_ID >= 80400 ? parent::createFromTimestamp($timestamp) : new static('@' . $timestamp);
 
-        $instance = static::now($timezone);
-
-        if (is_int($timestamp)) {
-            return $instance->setTimestamp($timestamp);
-        }
-
-        return $instance->modify('@' . $timestamp);
+        return $timezone ? $instance->setTimezone($timezone) : $instance;
     }
 
     /**

--- a/tests/TestCase/DateTime/CreateFromTimestampTest.php
+++ b/tests/TestCase/DateTime/CreateFromTimestampTest.php
@@ -24,16 +24,17 @@ class CreateFromTimestampTest extends TestCase
     public function testCreateReturnsDatingInstance()
     {
         $d = Chronos::createFromTimestamp(Chronos::create(1975, 5, 21, 22, 32, 5)->timestamp);
-        $this->assertDateTime($d, 1975, 5, 21, 22, 32, 5);
+        $this->assertDateTime($d, 1975, 5, 22, 2, 32, 5);
+        $this->assertSame('+00:00', $d->tzName);
     }
 
-    public function testCreateFromTimestampUsesDefaultTimezone()
+    public function testCreateFromTimestampUsesUTC()
     {
         $d = Chronos::createFromTimestamp(0);
 
-        // We know Toronto is -5 since no DST in Jan
-        $this->assertSame(1969, $d->year);
-        $this->assertSame(-5 * 3600, $d->offset);
+        $this->assertSame(1970, $d->year);
+        $this->assertSame(0, $d->offset);
+        $this->assertSame('+00:00', $d->tzName);
     }
 
     public function testCreateFromTimestampWithDateTimeZone()
@@ -45,9 +46,10 @@ class CreateFromTimestampTest extends TestCase
 
     public function testCreateFromTimestampWithString()
     {
-        $d = Chronos::createFromTimestamp(0, 'UTC');
-        $this->assertDateTime($d, 1970, 1, 1, 0, 0, 0);
-        $this->assertSame(0, $d->offset);
-        $this->assertSame('UTC', $d->tzName);
+        $d = Chronos::createFromTimestamp(0, 'America/Toronto');
+        // We know Toronto is -5 since no DST in Jan
+        $this->assertSame(1969, $d->year);
+        $this->assertSame(-5 * 3600, $d->offset);
+        $this->assertSame('America/Toronto', $d->tzName);
     }
 }


### PR DESCRIPTION
PHP 8.4 adds a new interface method DatetimeImmutable::createFromTimestamp().