### PR TITLE
Fix deprecations from internals for Date

### DIFF
--- a/src/Traits/ModifierTrait.php
+++ b/src/Traits/ModifierTrait.php
@@ -1051,6 +1051,9 @@ trait ModifierTrait
         if ($dt->dayOfWeek !== static::$weekStartsAt) {
             $dt = $dt->previous(static::$weekStartsAt);
         }
+        if ($dt instanceof ChronosDate) {
+            return $dt;
+        }
 
         return $dt->startOfDay();
     }
@@ -1065,6 +1068,9 @@ trait ModifierTrait
         $dt = $this;
         if ($dt->dayOfWeek !== static::$weekEndsAt) {
             $dt = $dt->next(static::$weekEndsAt);
+        }
+        if ($dt instanceof ChronosDate) {
+            return $dt;
         }
 
         return $dt->endOfDay();

--- a/tests/TestCase/Date/AddTest.php
+++ b/tests/TestCase/Date/AddTest.php
@@ -135,4 +135,22 @@ class AddTest extends TestCase
         $this->assertSame(2, $class::create(1975, 5, 31)->addWeekdays(1)->day);
         $this->assertSame(30, $class::create(1975, 5, 31)->addWeekdays(-1)->day);
     }
+
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testAddWeeksStartOfWeek($class)
+    {
+        $this->assertSame(8, (new $class('2024-7-2'))->addWeeks(1)->startOfWeek()->day);
+    }
+
+    /**
+     * @dataProvider dateClassProvider
+     * @return void
+     */
+    public function testAddWeeksEndOfWeek($class)
+    {
+        $this->assertSame(14, (new $class('2024-7-2'))->addWeeks(1)->endOfWeek()->day);
+    }
 }

--- a/tests/TestCase/DateTime/AddTest.php
+++ b/tests/TestCase/DateTime/AddTest.php
@@ -276,9 +276,9 @@ class AddTest extends TestCase
      */
     public function testAddWeeksStartOfWeek($class)
     {
-        $this->assertSame(5, (new $class(2024, 7, 2,))->addWeeks(1)->startOfWeek()->day);
+        $this->assertSame(5, (new $class(2024, 7, 2))->addWeeks(1)->startOfWeek()->day);
 
-        $this->assertSame(14, $class::createFromDate(2024, 7, 2,)->addWeeks(1)->endOfWeek()->day);
+        $this->assertSame(14, $class::createFromDate(2024, 7, 2)->addWeeks(1)->endOfWeek()->day);
     }
 
     /**


### PR DESCRIPTION
Fix deprecations for startOfDay/endOfDay being called by startOfWeek/endOfWeek. Because dates don't have times we don't need to modify any time related components and can just return early.

Fixes #453