### PR TITLE
Fix fatal error on PHP 8.4

### DIFF
--- a/src/Traits/FactoryTrait.php
+++ b/src/Traits/FactoryTrait.php
@@ -336,7 +336,8 @@ trait FactoryTrait
      * @param \DateTimeZone|string|null $tz The DateTimeZone object or timezone name the new instance should use.
      * @return static
      */
-    public static function createFromTimestamp(int $timestamp, $tz = null): ChronosInterface
+    #[ReturnTypeWillChange]
+    public static function createFromTimestamp(int|float $timestamp, $tz = null): ChronosInterface
     {
         $instance = static::now($tz)->setTimestamp($timestamp);
         if (get_class($instance) === ChronosDate::class) {


### PR DESCRIPTION
I'm trying to use cakephp 4.x with php 8.4 and but this signature is causing problems. 
https://php.watch/versions/8.4/datetime-createFromTimestamp
`Fatal error: Declaration of Cake\Chronos\Traits\FactoryTrait::createFromTimestamp(int $timestamp, $tz = null): Cake\Chronos\ChronosInterface must be compatible with DateTimeImmutable::createFromTimestamp(int|float $timestamp): static`
