### PR TITLE
Add toRfc7231String() helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0",
-        "phpunit/phpunit": "^10.1.0 || ^11.1.3"
+        "phpunit/phpunit": "^10.5.58 || ^11.1.3"
     },
     "provide": {
         "psr/clock-implementation": "1.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         colors="true">
+         colors="true"
+         failOnDeprecation="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true">
     <testsuites>
         <testsuite name="Chronos Test Suite">
             <directory>tests</directory>
@@ -13,4 +15,9 @@
             <directory suffix=".php">src/</directory>
         </include>
     </source>
+
+    <php>
+        <!-- E_ALL (32767) -->
+        <ini name="error_reporting" value="32767"/>
+    </php>
 </phpunit>

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -2588,6 +2588,17 @@ class Chronos extends DateTimeImmutable implements Stringable
     }
 
     /**
+     * Converts the time zone to UTC and returns a string in RFC7231 format.
+     * This replaced the deprecated and broken ``DATE_RFC7231`` formatting constant.
+     *
+     * @return string
+     */
+    public function toRfc7231String(): string
+    {
+        return $this->setTimezone('UTC')->format('D, d M Y H:i:s \G\M\T');
+    }
+
+    /**
      * Returns a DateTimeImmutable instance
      *
      * This method returns a PHP DateTimeImmutable without Chronos extensions.

--- a/tests/TestCase/DateTime/StringsTest.php
+++ b/tests/TestCase/DateTime/StringsTest.php
@@ -160,6 +160,12 @@ class StringsTest extends TestCase
         $this->assertSame('1639224001', $time->toUnixString());
     }
 
+    public function testToRfc7231String()
+    {
+        $time = Chronos::parse('2014-04-20 08:00:00', 'America/Toronto');
+        $this->assertSame('Sun, 20 Apr 2014 12:00:00 GMT', $time->toRfc7231String());
+    }
+
     /**
      * Provides values and expectations for the toQuarter method
      *

--- a/tests/TestCase/DateTime/StringsTest.php
+++ b/tests/TestCase/DateTime/StringsTest.php
@@ -177,10 +177,6 @@ class StringsTest extends TestCase
             ['2007-12-25', 4],
             ['2007-9-25', 3],
             ['2007-3-25', 1],
-            ['2007-3-25', ['2007-01-01', '2007-03-31'], true],
-            ['2007-5-25', ['2007-04-01', '2007-06-30'], true],
-            ['2007-8-25', ['2007-07-01', '2007-09-30'], true],
-            ['2007-12-25', ['2007-10-01', '2007-12-31'], true],
         ];
     }
 
@@ -192,7 +188,26 @@ class StringsTest extends TestCase
     #[DataProvider('toQuarterProvider')]
     public function testToQuarter($date, $expected, $range = false)
     {
-        $this->assertSame($expected, (new Chronos($date))->toQuarter($range));
+        $this->assertSame($expected, (new Chronos($date))->toQuarter());
+    }
+
+    public static function toQuarterRangeProvider()
+    {
+        return [
+            ['2007-3-25', ['2007-01-01', '2007-03-31']],
+            ['2007-5-25', ['2007-04-01', '2007-06-30']],
+            ['2007-8-25', ['2007-07-01', '2007-09-30']],
+            ['2007-12-25', ['2007-10-01', '2007-12-31']],
+        ];
+    }
+
+    #[DataProvider('toQuarterRangeProvider')]
+    public function testToQuarterRange($date, $expected)
+    {
+        $this->assertSame($expected, (new Chronos($date))->toQuarterRange());
+        $this->deprecated(function() use ($date, $expected) {
+            $this->assertSame($expected, (new Chronos($date))->toQuarter(true));
+        });
     }
 
     /**


### PR DESCRIPTION
This replaces the deprecated `DATE_RFC7231` constant. Added to Chronos only since it doesn't make much sense for ChronosDate even though we include all of FormattingTrait for backwards compatibility.