### PR TITLE
Update .gitattributes to ignore additional files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,10 +14,13 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .stickler.yml export-ignore
+Dockerfile export-ignore
+docs.Dockerfile export-ignore
 phpbench.json export-ignore
 phpcs.xml export-ignore
 phpstan.neon export-ignore
 phpstan-baseline.neon export-ignore
 phpunit.xml.dist export-ignore
 /.github export-ignore
+/.phive export-ignore
 /tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,4 +23,5 @@ phpstan-baseline.neon export-ignore
 phpunit.xml.dist export-ignore
 /.github export-ignore
 /.phive export-ignore
+/docs export-ignore
 /tests export-ignore


### PR DESCRIPTION

- With this PR, The archive targets other than src/ will be as follows:

```
gh api repos/sasezaki/chronos/tarball/patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE
README.md
composer.json
docs/
docs/config/
docs/config/__init__.py
docs/config/all.py
docs/en/
docs/en/3-x-migration-guide.rst
docs/en/conf.py
docs/en/contents.rst
docs/en/index.rst
docs/fr/
docs/fr/conf.py
docs/fr/contents.rst
docs/fr/index.rst
docs/ja/
docs/ja/conf.py
docs/ja/contents.rst
docs/ja/index.rst
docs/pt/
docs/pt/conf.py
docs/pt/contents.rst
docs/pt/index.rst
```

 - **IMO** I think `docs/` is unnecessary. If there is a demand, I will also export-ignore docs.