### PR TITLE
Add nextOccurrenceOf() and previousOccurrenceOf() methods

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -1619,6 +1619,89 @@ class Chronos extends DateTimeImmutable implements Stringable
     }
 
     /**
+     * Get the next occurrence of a given day of the week at a specific time.
+     *
+     * Unlike `next()`, this method considers both the day AND the time. If
+     * today is the target day and the specified time hasn't passed yet,
+     * it returns today at that time. Otherwise, it returns next week.
+     *
+     * This is useful when you need a relative date that always points to
+     * the next future occurrence of a specific day and time.
+     *
+     * ### Example
+     *
+     * ```
+     * // If it's Tuesday 9am, get "Tuesday 12pm" (today)
+     * // If it's Tuesday 4pm, get "Tuesday 12pm" (next week)
+     * $date = Chronos::now()->nextOccurrenceOf(Chronos::TUESDAY, 12, 0);
+     * ```
+     *
+     * @param int $dayOfWeek The day of the week (use Chronos::MONDAY, etc.)
+     * @param int $hour The hour (0-23)
+     * @param int $minute The minute (0-59)
+     * @param int $second The second (0-59)
+     * @return static
+     */
+    public function nextOccurrenceOf(
+        int $dayOfWeek,
+        int $hour,
+        int $minute = 0,
+        int $second = 0,
+    ): static {
+        // If today is the target day
+        if ($this->dayOfWeek === $dayOfWeek) {
+            $todayAtTime = $this->setTime($hour, $minute, $second);
+            // If the time hasn't passed yet, return today
+            if ($todayAtTime->greaterThan($this)) {
+                return $todayAtTime;
+            }
+        }
+
+        // Otherwise, get next week's occurrence
+        return $this->next($dayOfWeek)->setTime($hour, $minute, $second);
+    }
+
+    /**
+     * Get the previous occurrence of a given day of the week at a specific time.
+     *
+     * Unlike `previous()`, this method considers both the day AND the time.
+     * If today is the target day and the specified time has already passed,
+     * it returns today at that time. Otherwise, it returns last week.
+     *
+     * ### Example
+     *
+     * ```
+     * // If it's Tuesday 4pm, get "Tuesday 12pm" (today, already passed)
+     * // If it's Tuesday 9am, get "Tuesday 12pm" (last week)
+     * $date = Chronos::now()->previousOccurrenceOf(Chronos::TUESDAY, 12, 0);
+     * ```
+     *
+     * @param int $dayOfWeek The day of the week (use Chronos::MONDAY, etc.)
+     * @param int $hour The hour (0-23)
+     * @param int $minute The minute (0-59)
+     * @param int $second The second (0-59)
+     * @return static
+     */
+    public function previousOccurrenceOf(
+        int $dayOfWeek,
+        int $hour,
+        int $minute = 0,
+        int $second = 0,
+    ): static {
+        // If today is the target day
+        if ($this->dayOfWeek === $dayOfWeek) {
+            $todayAtTime = $this->setTime($hour, $minute, $second);
+            // If the time has already passed, return today
+            if ($todayAtTime->lessThan($this)) {
+                return $todayAtTime;
+            }
+        }
+
+        // Otherwise, get last week's occurrence
+        return $this->previous($dayOfWeek)->setTime($hour, $minute, $second);
+    }
+
+    /**
      * Modify to the first occurrence of a given day of the week
      * in the current month. If no dayOfWeek is provided, modify to the
      * first day of the current month.  Use the supplied consts

--- a/tests/TestCase/DateTime/DayOfWeekModifiersTest.php
+++ b/tests/TestCase/DateTime/DayOfWeekModifiersTest.php
@@ -306,4 +306,102 @@ class DayOfWeekModifiersTest extends TestCase
         $d = Chronos::createFromDate(1975, 8, 5)->nthOfYear(3, 3);
         $this->assertDateTime($d, 1975, 1, 15, 0, 0, 0);
     }
+
+    /**
+     * Test nextOccurrenceOf when today is the target day and time hasn't passed.
+     */
+    public function testNextOccurrenceOfSameDayBeforeTime()
+    {
+        // It's Tuesday 9am, looking for Tuesday 12pm -> should be today
+        $d = Chronos::create(2024, 1, 9, 9, 0, 0); // Tuesday
+        $result = $d->nextOccurrenceOf(Chronos::TUESDAY, 12, 0);
+        $this->assertDateTime($result, 2024, 1, 9, 12, 0, 0);
+    }
+
+    /**
+     * Test nextOccurrenceOf when today is the target day but time has passed.
+     */
+    public function testNextOccurrenceOfSameDayAfterTime()
+    {
+        // It's Tuesday 4pm, looking for Tuesday 12pm -> should be next Tuesday
+        $d = Chronos::create(2024, 1, 9, 16, 0, 0); // Tuesday
+        $result = $d->nextOccurrenceOf(Chronos::TUESDAY, 12, 0);
+        $this->assertDateTime($result, 2024, 1, 16, 12, 0, 0);
+    }
+
+    /**
+     * Test nextOccurrenceOf when today is not the target day.
+     */
+    public function testNextOccurrenceOfDifferentDay()
+    {
+        // It's Monday, looking for Tuesday 12pm -> should be tomorrow
+        $d = Chronos::create(2024, 1, 8, 9, 0, 0); // Monday
+        $result = $d->nextOccurrenceOf(Chronos::TUESDAY, 12, 0);
+        $this->assertDateTime($result, 2024, 1, 9, 12, 0, 0);
+    }
+
+    /**
+     * Test nextOccurrenceOf with seconds.
+     */
+    public function testNextOccurrenceOfWithSeconds()
+    {
+        $d = Chronos::create(2024, 1, 8, 9, 0, 0); // Monday
+        $result = $d->nextOccurrenceOf(Chronos::WEDNESDAY, 14, 30, 45);
+        $this->assertDateTime($result, 2024, 1, 10, 14, 30, 45);
+    }
+
+    /**
+     * Test nextOccurrenceOf at exact same time returns next week.
+     */
+    public function testNextOccurrenceOfAtExactTime()
+    {
+        // It's Tuesday 12pm exactly, looking for Tuesday 12pm -> should be next week
+        $d = Chronos::create(2024, 1, 9, 12, 0, 0); // Tuesday 12pm
+        $result = $d->nextOccurrenceOf(Chronos::TUESDAY, 12, 0);
+        $this->assertDateTime($result, 2024, 1, 16, 12, 0, 0);
+    }
+
+    /**
+     * Test previousOccurrenceOf when today is the target day and time has passed.
+     */
+    public function testPreviousOccurrenceOfSameDayAfterTime()
+    {
+        // It's Tuesday 4pm, looking for previous Tuesday 12pm -> should be today
+        $d = Chronos::create(2024, 1, 9, 16, 0, 0); // Tuesday
+        $result = $d->previousOccurrenceOf(Chronos::TUESDAY, 12, 0);
+        $this->assertDateTime($result, 2024, 1, 9, 12, 0, 0);
+    }
+
+    /**
+     * Test previousOccurrenceOf when today is the target day but time hasn't passed.
+     */
+    public function testPreviousOccurrenceOfSameDayBeforeTime()
+    {
+        // It's Tuesday 9am, looking for previous Tuesday 12pm -> should be last Tuesday
+        $d = Chronos::create(2024, 1, 9, 9, 0, 0); // Tuesday
+        $result = $d->previousOccurrenceOf(Chronos::TUESDAY, 12, 0);
+        $this->assertDateTime($result, 2024, 1, 2, 12, 0, 0);
+    }
+
+    /**
+     * Test previousOccurrenceOf when today is not the target day.
+     */
+    public function testPreviousOccurrenceOfDifferentDay()
+    {
+        // It's Wednesday, looking for previous Tuesday 12pm -> should be yesterday
+        $d = Chronos::create(2024, 1, 10, 9, 0, 0); // Wednesday
+        $result = $d->previousOccurrenceOf(Chronos::TUESDAY, 12, 0);
+        $this->assertDateTime($result, 2024, 1, 9, 12, 0, 0);
+    }
+
+    /**
+     * Test previousOccurrenceOf at exact same time returns last week.
+     */
+    public function testPreviousOccurrenceOfAtExactTime()
+    {
+        // It's Tuesday 12pm exactly, looking for previous Tuesday 12pm -> should be last week
+        $d = Chronos::create(2024, 1, 9, 12, 0, 0); // Tuesday 12pm
+        $result = $d->previousOccurrenceOf(Chronos::TUESDAY, 12, 0);
+        $this->assertDateTime($result, 2024, 1, 2, 12, 0, 0);
+    }
 }


### PR DESCRIPTION
## Summary

Adds two new methods to `Chronos` that solve the problem of constructing a relative date that always points to the next (or previous) future occurrence of a specific day *and* time.

### Problem

As described in #406, PHP's relative date parsing with `next` only considers the date, not the time:

```php
// If it's Tuesday 4pm:
new Chronos('Tue 12:00');       // Tuesday 12pm (in the past!)
new Chronos('next Tue 12:00');  // Next week Tuesday 12pm (always skips to next week)
```

There's no way to get "the next future occurrence of Tuesday 12pm" that returns today if it's before noon, or next week if it's after noon.

### Solution

Two new methods:

- `nextOccurrenceOf(int $dayOfWeek, int $hour, int $minute, int $second)` - Returns the next future occurrence, considering both day and time
- `previousOccurrenceOf(int $dayOfWeek, int $hour, int $minute, int $second)` - Returns the most recent past occurrence

```php
// If it's Tuesday 9am:
Chronos::now()->nextOccurrenceOf(Chronos::TUESDAY, 12, 0);
// → Today at 12pm (still in the future)

// If it's Tuesday 4pm:
Chronos::now()->nextOccurrenceOf(Chronos::TUESDAY, 12, 0);
// → Next Tuesday at 12pm (today's has passed)
```

### Behavior at exact time

When the current time matches exactly, `nextOccurrenceOf` returns next week and `previousOccurrenceOf` returns last week (strict comparison, not inclusive).

## Discussion Points

- Method naming: `nextOccurrenceOf` vs `nextOrSame` or something shorter?
- Should the time be at the exact second, or should it also consider `greaterThanOrEquals`?

Related to #406

## Test plan

- [x] Tests for same day before/after target time
- [x] Tests for different day
- [x] Tests for exact time edge case
- [x] Tests for seconds parameter
- [x] All existing tests pass (907 tests)
- [x] Code style passes