### PR TITLE
Cleanup for new major (required by Cake6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run phpcs
         if: always()
-        run: tools/phpcs --report=checkstyle | cs2pr
+        run: vendor/bin/phpcs --report=checkstyle | cs2pr
 
       - name: Run phpstan
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - 2.x
       - 2.next
       - 3.x
+      - 4.x
   pull_request:
     branches:
       - '*'
@@ -19,5 +20,34 @@ jobs:
     secrets: inherit
 
   cs-stan:
-    uses: cakephp/.github/.github/workflows/cs-stan.yml@5.x
-    secrets: inherit
+    name: Coding Standard & Static Analysis
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, intl
+          coverage: none
+          tools: phive, cs2pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Composer install
+        uses: ramsey/composer-install@v3
+
+      - name: Install PHP tools with phive.
+        run: "phive install --trust-gpg-keys 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5,99BF4D9A33D65E1E'"
+
+      - name: Run phpcs
+        if: always()
+        run: tools/phpcs --report=checkstyle | cs2pr
+
+      - name: Run phpstan
+        if: always()
+        run: tools/phpstan analyse --error-format=github

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,10 +10,6 @@ parameters:
 		- identifier: property.readOnlyByPhpDocDefaultValue
 		- identifier: property.readOnlyByPhpDocAssignNotInConstructor
 		-
-			message: "#^Call to an undefined static method DateTimeImmutable\\:\\:createFromTimestamp\\(\\)\\.$#"
-			count: 1
-			path: src/Chronos.php
-		-
 			message: "#with generic class DatePeriod but does not specify its types: TDate, TEnd, TRecurrences$#"
 			count: 1
 			path: src/ChronosPeriod.php

--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -163,9 +163,12 @@ class Chronos extends DateTimeImmutable implements Stringable
     /**
      * Format to use for __toString method when type juggling occurs.
      *
-     * @var string
+     * The widened type allows subclasses (like CakePHP I18n classes) to use
+     * IntlDateFormatter constants while maintaining backward compatibility.
+     *
+     * @var array|string|int
      */
-    protected static string $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
+    protected static array|string|int $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
 
     /**
      * Days of weekend

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -58,9 +58,12 @@ class ChronosDate implements Stringable
     /**
      * Format to use for __toString method when type juggling occurs.
      *
-     * @var string
+     * The widened type allows subclasses (like CakePHP I18n classes) to use
+     * IntlDateFormatter constants while maintaining backward compatibility.
+     *
+     * @var array|string|int
      */
-    protected static string $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
+    protected static array|string|int $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
 
     /**
      * Names of days of the week.

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -60,9 +60,12 @@ class ChronosTime implements Stringable
     /**
      * Format to use for __toString method.
      *
-     * @var string
+     * The widened type allows subclasses to use IntlDateFormatter constants
+     * while maintaining backward compatibility.
+     *
+     * @var array|string|int
      */
-    protected static string $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
+    protected static array|string|int $toStringFormat = self::DEFAULT_TO_STRING_FORMAT;
 
     /**
      * @var int
@@ -381,6 +384,8 @@ class ChronosTime implements Stringable
      */
     public function __toString(): string
     {
+        assert(is_string(static::$toStringFormat));
+
         return $this->format(static::$toStringFormat);
     }
 

--- a/src/FormattingTrait.php
+++ b/src/FormattingTrait.php
@@ -19,7 +19,9 @@ use DateTime;
 /**
  * Provides string formatting methods for datetime instances.
  *
- * Expects implementing classes to define static::$toStringFormat
+ * Expects implementing classes to define static::$toStringFormat as `array|string|int`.
+ * The widened type allows subclasses (like CakePHP I18n classes) to use
+ * IntlDateFormatter constants while maintaining backward compatibility.
  *
  * @internal
  */
@@ -54,6 +56,8 @@ trait FormattingTrait
      */
     public function __toString(): string
     {
+        assert(is_string(static::$toStringFormat));
+
         return $this->format(static::$toStringFormat);
     }
 

--- a/src/FormattingTrait.php
+++ b/src/FormattingTrait.php
@@ -236,24 +236,11 @@ trait FormattingTrait
     /**
      * Returns the quarter
      *
-     * Deprecated 3.3.0: The $range parameter is deprecated. Use toQuarterRange() for quarter ranges.
-     *
-     * @param bool $range Range.
-     * @return array|int 1, 2, 3, or 4 quarter of year or array if $range true
+     * @return int 1, 2, 3, or 4 quarter of year
      */
-    public function toQuarter(bool $range = false): int|array
+    public function toQuarter(): int
     {
-        $quarter = (int)ceil((int)$this->format('m') / 3);
-        if ($range === false) {
-            return $quarter;
-        }
-
-        trigger_error(
-            'Using toQuarter() with `$range=true` is deprecated. Use `toQuarterRange()` instead.',
-            E_USER_DEPRECATED,
-        );
-
-        return $this->toQuarterRange();
+        return (int)ceil((int)$this->format('m') / 3);
     }
 
     /**

--- a/tests/TestCase/DateTime/StringsTest.php
+++ b/tests/TestCase/DateTime/StringsTest.php
@@ -186,7 +186,7 @@ class StringsTest extends TestCase
      * @return void
      */
     #[DataProvider('toQuarterProvider')]
-    public function testToQuarter($date, $expected, $range = false)
+    public function testToQuarter($date, $expected)
     {
         $this->assertSame($expected, (new Chronos($date))->toQuarter());
     }
@@ -205,9 +205,6 @@ class StringsTest extends TestCase
     public function testToQuarterRange($date, $expected)
     {
         $this->assertSame($expected, (new Chronos($date))->toQuarterRange());
-        $this->deprecated(function () use ($date, $expected) {
-            $this->assertSame($expected, (new Chronos($date))->toQuarter(true));
-        });
     }
 
     /**


### PR DESCRIPTION
## Summary

Major release cleanup for Chronos 4.0 / CakePHP 6.0 compatibility:

- Remove the `$range` parameter from `toQuarter()` which was deprecated in 3.3.0
  - Users should use `toQuarterRange()` for quarter range functionality
- Widen `$toStringFormat` property type from `string` to `array|string|int`
  - This allows CakePHP I18n classes to rename `$_toStringFormat` to `$toStringFormat` without type conflicts
  - Enables CakePHP upgrade tool to apply PSR naming conventions consistently
- Remove outdated PHPStan ignore for `DateTimeImmutable::createFromTimestamp()` (now available in PHP 8.4)

Refs: https://github.com/cakephp/upgrade/pull/386

Note:
The type widening is backwards compatible because CakePHP 5 I18n classes use their own $_toStringFormat property and override all related methods - they don't touch Chronos's property at all. The widening just enables       
  CakePHP 6 to do the PSR naming cleanup.        