### PR TITLE
Add withTestNow() for scoped time mocking

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -328,6 +328,38 @@ class Chronos extends DateTimeImmutable implements Stringable
     }
 
     /**
+     * Temporarily sets "now" to the given value and executes the callback.
+     *
+     * After the callback is executed, the previous value of "now" is restored.
+     * This is useful for testing time-sensitive code without affecting other tests.
+     *
+     * ### Example:
+     *
+     * ```
+     * $result = Chronos::withTestNow('2023-06-15 12:00:00', function () {
+     *     return Chronos::now()->format('Y-m-d');
+     * });
+     * // $result === '2023-06-15'
+     * ```
+     *
+     * @template T
+     * @param \Cake\Chronos\Chronos|string|null $testNow The instance to use as "now".
+     * @param callable(): T $callback The callback to execute.
+     * @return T The return value of the callback.
+     */
+    public static function withTestNow(Chronos|string|null $testNow, callable $callback): mixed
+    {
+        $previous = static::getTestNow();
+        static::setTestNow($testNow);
+
+        try {
+            return $callback();
+        } finally {
+            static::setTestNow($previous);
+        }
+    }
+
+    /**
      * Determine if there is just a time in the time string
      *
      * @param string|null $time The time string to check.

--- a/tests/TestCase/DateTime/TestingAidsTest.php
+++ b/tests/TestCase/DateTime/TestingAidsTest.php
@@ -19,6 +19,7 @@ use Cake\Chronos\Chronos;
 use Cake\Chronos\ChronosDate;
 use Cake\Chronos\Test\TestCase\TestCase;
 use DateTimeZone;
+use RuntimeException;
 
 class TestingAidsTest extends TestCase
 {
@@ -230,5 +231,90 @@ class TestingAidsTest extends TestCase
         Chronos::setTestNow($c);
 
         $this->assertSame($c, Chronos::getTestNow());
+    }
+
+    public function testWithTestNowSetsAndRestoresNull()
+    {
+        $this->assertNull(Chronos::getTestNow());
+
+        $result = Chronos::withTestNow('2023-06-15 12:00:00', function () {
+            $this->assertNotNull(Chronos::getTestNow());
+            $this->assertSame('2023-06-15', Chronos::now()->format('Y-m-d'));
+
+            return 'callback result';
+        });
+
+        $this->assertSame('callback result', $result);
+        $this->assertNull(Chronos::getTestNow());
+    }
+
+    public function testWithTestNowRestoresPreviousTestNow()
+    {
+        $original = new Chronos('2020-01-01 00:00:00');
+        Chronos::setTestNow($original);
+
+        Chronos::withTestNow('2023-06-15 12:00:00', function () {
+            $this->assertSame('2023-06-15', Chronos::now()->format('Y-m-d'));
+        });
+
+        $this->assertSame($original, Chronos::getTestNow());
+        $this->assertSame('2020-01-01', Chronos::now()->format('Y-m-d'));
+    }
+
+    public function testWithTestNowNested()
+    {
+        Chronos::setTestNow('2020-01-01 00:00:00');
+
+        Chronos::withTestNow('2021-06-15 00:00:00', function () {
+            $this->assertSame('2021-06-15', Chronos::now()->format('Y-m-d'));
+
+            Chronos::withTestNow('2022-12-25 00:00:00', function () {
+                $this->assertSame('2022-12-25', Chronos::now()->format('Y-m-d'));
+            });
+
+            $this->assertSame('2021-06-15', Chronos::now()->format('Y-m-d'));
+        });
+
+        $this->assertSame('2020-01-01', Chronos::now()->format('Y-m-d'));
+    }
+
+    public function testWithTestNowRestoresOnException()
+    {
+        $original = new Chronos('2020-01-01 00:00:00');
+        Chronos::setTestNow($original);
+
+        try {
+            Chronos::withTestNow('2023-06-15 12:00:00', function () {
+                throw new RuntimeException('Test exception');
+            });
+            $this->fail('Exception should have been thrown');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Test exception', $e->getMessage());
+        }
+
+        $this->assertSame($original, Chronos::getTestNow());
+    }
+
+    public function testWithTestNowWithChronosInstance()
+    {
+        $testTime = new Chronos('2023-06-15 14:30:00');
+
+        $result = Chronos::withTestNow($testTime, function () {
+            return Chronos::now()->format('Y-m-d H:i:s');
+        });
+
+        $this->assertSame('2023-06-15 14:30:00', $result);
+        $this->assertNull(Chronos::getTestNow());
+    }
+
+    public function testWithTestNowWithNull()
+    {
+        Chronos::setTestNow('2020-01-01 00:00:00');
+
+        Chronos::withTestNow(null, function () {
+            $this->assertNull(Chronos::getTestNow());
+        });
+
+        $this->assertSame('2020-01-01', Chronos::now()->format('Y-m-d'));
     }
 }


### PR DESCRIPTION
## Summary

- Adds a new static method `withTestNow()` that temporarily sets the test time, executes a callback, and then restores the previous test time state
- Uses try/finally to ensure state restoration even when callback throws exceptions
- Includes comprehensive tests for basic usage, nested calls, and exception handling

## Use Cases

This is useful for:
- Nested time mocking scenarios
- Tests that need to temporarily override a global mock time set in `setUp()`
- Clean time mocking that automatically restores state

## Example

```php
// Basic usage
$result = Chronos::withTestNow('2023-06-15 12:00:00', function () {
    return Chronos::now()->format('Y-m-d');
});
// $result === '2023-06-15'

// Nested calls work correctly
Chronos::setTestNow('2020-01-01');
Chronos::withTestNow('2023-06-15', function () {
    // Here now is 2023-06-15
    Chronos::withTestNow('2024-12-25', function () {
        // Here now is 2024-12-25
    });
    // Back to 2023-06-15
});
// Back to 2020-01-01
```

## Related

Inspired by Carbon's `withTestNow()` implementation and the fix in [briannesbitt/Carbon#3283](https://github.com/briannesbitt/Carbon/pull/3283) which ensures the previous test time is restored (not unconditionally reset to null).