### PR TITLE
4.x: Return 'just now' for zero-second differences

### DIFF
--- a/src/DifferenceFormatter.php
+++ b/src/DifferenceFormatter.php
@@ -96,6 +96,11 @@ class DifferenceFormatter implements DifferenceFormatterInterface
                 $unit = 'second';
                 break;
         }
+
+        if ($count === 0 && $unit === 'second') {
+            return $this->translate->singular('just_now');
+        }
+
         $time = $this->translate->plural($unit, $count, ['count' => $count]);
         if ($absolute) {
             return $time;

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -40,6 +40,7 @@ class Translator
         'minute_plural' => '{count} minutes',
         'second' => '1 second',
         'second_plural' => '{count} seconds',
+        'just_now' => 'just now',
         'ago' => '{time} ago',
         'from_now' => '{time} from now',
         'after' => '{time} after',

--- a/tests/TestCase/Date/DiffTest.php
+++ b/tests/TestCase/Date/DiffTest.php
@@ -350,14 +350,14 @@ class DiffTest extends TestCase
     public function testDiffForHumansWithoutDiff()
     {
         $this->wrapWithTestNow(function () {
-            $this->assertSame('0 seconds ago', ChronosDate::parse(Chronos::now())->diffForHumans());
+            $this->assertSame('just now', ChronosDate::parse(Chronos::now())->diffForHumans());
         });
     }
 
     public function testDiffForHumansWithoutDiffAbsolute()
     {
         $this->wrapWithTestNow(function () {
-            $this->assertSame('0 seconds', ChronosDate::parse(Chronos::now())->diffForHumans(null, true));
+            $this->assertSame('just now', ChronosDate::parse(Chronos::now())->diffForHumans(null, true));
         });
     }
 }

--- a/tests/TestCase/DateTime/DiffTest.php
+++ b/tests/TestCase/DateTime/DiffTest.php
@@ -612,14 +612,14 @@ class DiffTest extends TestCase
     public function testDiffForHumansWithoutDiff()
     {
         $this->wrapWithTestNow(function () {
-            $this->assertSame('0 seconds ago', Chronos::now()->diffForHumans());
+            $this->assertSame('just now', Chronos::now()->diffForHumans());
         });
     }
 
     public function testDiffForHumansWithoutDiffAbsolute()
     {
         $this->wrapWithTestNow(function () {
-            $this->assertSame('0 seconds', Chronos::now()->diffForHumans(null, true));
+            $this->assertSame('just now', Chronos::now()->diffForHumans(null, true));
         });
     }
 


### PR DESCRIPTION
## Summary

- Returns "just now" instead of "0 seconds ago" when `diffForHumans()` is called on identical timestamps
- Adds `just_now` translation string to `Translator`

## Before / After

| Before | After |
|--------|-------|
| "0 seconds ago" | "just now" |
| "0 seconds from now" | "just now" |
| "0 seconds" (absolute) | "just now" |

## Example

```php
$now = Chronos::now();
echo $now->diffForHumans(); // "just now" (was "0 seconds ago")
```

## Related

Inspired by Carbon's handling of zero-second differences. See [briannesbitt/Carbon#3218](https://github.com/briannesbitt/Carbon/pull/3218).