### PR TITLE
Fix createFromFormat with Unix timestamp format 'U'

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -694,9 +694,11 @@ class Chronos extends DateTimeImmutable implements Stringable
         $hasMicro = (bool)array_intersect($formatChars, ['u', 'v']);
 
         // If the format includes '!' or '|', PHP resets unspecified components to Unix epoch or zero
-        // In that case, we should not override with testNow
+        // If 'U' is present, all components are set from the Unix timestamp
+        // In these cases, we should not override with testNow
         $hasReset = in_array('!', $formatChars, true) || in_array('|', $formatChars, true);
-        if ($hasReset) {
+        $hasUnixTimestamp = in_array('U', $formatChars, true);
+        if ($hasReset || $hasUnixTimestamp) {
             return $dateTime;
         }
 

--- a/tests/TestCase/DateTime/CreateFromFormatTest.php
+++ b/tests/TestCase/DateTime/CreateFromFormatTest.php
@@ -111,6 +111,22 @@ class CreateFromFormatTest extends TestCase
         $this->assertSame(123456, $d->micro);
     }
 
+    public function testCreateFromFormatWithTestNowUnixTimestamp()
+    {
+        // Unix timestamp ('U' format) sets all components, should not use testNow
+        Chronos::setTestNow(new Chronos('2020-12-01 14:30:45'));
+        $d = Chronos::createFromFormat('U', '0');
+        $this->assertDateTime($d, 1970, 1, 1, 0, 0, 0);
+    }
+
+    public function testCreateFromFormatWithTestNowNegativeUnixTimestamp()
+    {
+        // Negative Unix timestamp should also not use testNow
+        Chronos::setTestNow(new Chronos('2020-12-01 14:30:45'));
+        $d = Chronos::createFromFormat('U', '-1000');
+        $this->assertDateTime($d, 1969, 12, 31, 23, 43, 20);
+    }
+
     public function testCreateFromFormatWithTimezoneString()
     {
         $d = Chronos::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11', 'Europe/London');


### PR DESCRIPTION
## Summary
The 3.3.2 fix for respecting testNow in createFromFormat (#494) incorrectly applied testNow values when using the Unix timestamp format 'U'. Since 'U' sets all date/time components from the Unix timestamp value, testNow should not be applied.

## Problem
```php
Chronos::setTestNow(new Chronos('2020-12-01 14:30:45'));
$d = Chronos::createFromFormat('U', '0');
// Expected: 1970-01-01 00:00:00 (Unix epoch)
// Actual (broken): 2020-12-01 14:30:45 (testNow value)
```

This broke CakePHP's test suite after 3.3.2 was released.

## Fix
Add 'U' to the list of format specifiers that should skip the testNow application, similar to '!' and '|'.

## Test
Added test cases for Unix timestamp format with testNow set.