### PR TITLE
4.x: Auto-append pipe modifier in createFromFormat

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -668,6 +668,12 @@ class Chronos extends DateTimeImmutable implements Stringable
     /**
      * Create an instance from a specific format
      *
+     * Unlike PHP's native DateTimeImmutable::createFromFormat(), this method
+     * automatically appends the `|` modifier if no reset modifier (`|` or `!`)
+     * is present. This ensures that unparsed components are reset to zero
+     * instead of being filled from the current time, providing more predictable
+     * and deterministic behavior.
+     *
      * @param string $format The date() compatible format string.
      * @param string $time The formatted date string to interpret.
      * @param \DateTimeZone|string|null $timezone The DateTimeZone object or timezone name the new instance should use.
@@ -679,6 +685,12 @@ class Chronos extends DateTimeImmutable implements Stringable
         string $time,
         DateTimeZone|string|null $timezone = null,
     ): static {
+        // Auto-append | modifier if no reset modifier is present
+        // This ensures unparsed components are zero instead of current time
+        if (!str_contains($format, '|') && !str_contains($format, '!')) {
+            $format .= '|';
+        }
+
         if ($timezone !== null) {
             $dateTime = parent::createFromFormat($format, $time, $timezone ? static::safeCreateDateTimeZone($timezone) : null);
         } else {

--- a/tests/TestCase/DateTime/CreateFromFormatTest.php
+++ b/tests/TestCase/DateTime/CreateFromFormatTest.php
@@ -29,6 +29,49 @@ class CreateFromFormatTest extends TestCase
         $this->assertTrue($d instanceof Chronos);
     }
 
+    public function testCreateFromFormatMissingTimeIsZero()
+    {
+        // Missing time components should be zero, not current time
+        $d = Chronos::createFromFormat('Y-m-d', '2024-03-14');
+        $this->assertDateTime($d, 2024, 3, 14, 0, 0, 0);
+        $this->assertSame(0, $d->micro);
+    }
+
+    public function testCreateFromFormatMissingSecondsIsZero()
+    {
+        // Missing seconds should be zero
+        $d = Chronos::createFromFormat('Y-m-d H:i', '2024-03-14 12:30');
+        $this->assertDateTime($d, 2024, 3, 14, 12, 30, 0);
+    }
+
+    public function testCreateFromFormatMissingDateIsEpoch()
+    {
+        // Missing date components should be Unix epoch (1970-01-01)
+        $d = Chronos::createFromFormat('H:i:s', '12:30:45');
+        $this->assertDateTime($d, 1970, 1, 1, 12, 30, 45);
+    }
+
+    public function testCreateFromFormatMissingMicrosecondsIsZero()
+    {
+        // Missing microseconds should be zero
+        $d = Chronos::createFromFormat('Y-m-d H:i:s', '2024-03-14 12:30:45');
+        $this->assertSame(0, $d->micro);
+    }
+
+    public function testCreateFromFormatWithExplicitPipeModifier()
+    {
+        // Explicit | should still work
+        $d = Chronos::createFromFormat('Y-m-d|', '2024-03-14');
+        $this->assertDateTime($d, 2024, 3, 14, 0, 0, 0);
+    }
+
+    public function testCreateFromFormatWithExplicitBangModifier()
+    {
+        // Explicit ! should still work
+        $d = Chronos::createFromFormat('!Y-m-d', '2024-03-14');
+        $this->assertDateTime($d, 2024, 3, 14, 0, 0, 0);
+    }
+
     public function testCreateFromFormatWithTimezoneString()
     {
         $d = Chronos::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11', 'Europe/London');
@@ -49,6 +92,18 @@ class CreateFromFormatTest extends TestCase
         $this->assertSame(254687, $d->micro);
     }
 
+    public function testCreateFromFormatWithUnixTimestamp()
+    {
+        $d = Chronos::createFromFormat('U', '0');
+        $this->assertDateTime($d, 1970, 1, 1, 0, 0, 0);
+    }
+
+    public function testCreateFromFormatWithNegativeUnixTimestamp()
+    {
+        $d = Chronos::createFromFormat('U', '-1000');
+        $this->assertDateTime($d, 1969, 12, 31, 23, 43, 20);
+    }
+
     public function testCreateFromFormatInvalidFormat()
     {
         $parseException = null;
@@ -65,9 +120,9 @@ class CreateFromFormatTest extends TestCase
 
     public function testCreateFromFormatDoesNotUseTestNow()
     {
-        // createFromFormat should not use testNow - it should behave like PHP's native method
+        // testNow should not affect createFromFormat - missing components are zero
         Chronos::setTestNow(new Chronos('2020-12-01 14:30:45'));
-        $d = Chronos::createFromFormat('Y-m-d H:i:s', '1975-05-21 22:32:11');
-        $this->assertDateTime($d, 1975, 5, 21, 22, 32, 11);
+        $d = Chronos::createFromFormat('Y-m-d', '2024-03-14');
+        $this->assertDateTime($d, 2024, 3, 14, 0, 0, 0);
     }
 }


### PR DESCRIPTION
Attempt of https://github.com/cakephp/chronos/pull/494 redo of "deterministic behavior"

## Summary

Auto-append `|` modifier in `createFromFormat()` for deterministic behavior.

### The Change

Unlike PHP's native `DateTimeImmutable::createFromFormat()`, this method now automatically appends the `|` modifier if no reset modifier (`|` or `!`) is present.

This ensures that unparsed components are reset to zero instead of being filled from the current time.

The 4.x philosophy: Always deterministic, everywhere                                                                                                                     

### Examples

```php
// Before (PHP native behavior): time filled from current system time
// After (Chronos 4.x): time is 00:00:00.000000
Chronos::createFromFormat('Y-m-d', '2024-03-14');

// Before: seconds filled from current system time
// After: seconds is 00
Chronos::createFromFormat('Y-m-d H:i', '2024-03-14 12:30');

// Missing date components use Unix epoch (1970-01-01)
Chronos::createFromFormat('H:i:s', '12:30:45');
// Result: 1970-01-01 12:30:45
```

This is what most users intuitively expect. When you parse just a date, you get midnight - not "midnight plus whatever seconds happen to be on the clock."                                                                                                                                                 
                                                                                                                                                          
The only "BC break" scenario is someone who intentionally wanted:                                                                                       
```php
  // "Give me this date but with current time" (unusual use case)                                                                                         
  $d = Chronos::createFromFormat('Y-m-d', '2024-03-14');                                                                                                  
  // They expected 2024-03-14 14:32:45 (current time)                                                                                                     
  // Now they get 2024-03-14 00:00:00                                                                                                                     
```                                                                                                                                                          
That's a rare/unusual pattern. If someone actually needs current time for missing components, they'd explicitly do:                                     
```php
  $d = Chronos::parse('2024-03-14'); // This keeps current time                                                                                           
  // or construct it explicitly    
```

### Benefits

- **Deterministic**: No more flaky tests due to time-dependent behavior
- **Intuitive**: Missing = zero is what most users expect
- **No workarounds needed**: No need to add `|` to format strings manually

### Migration

Test Code that relied on missing components being filled from current time will need adjustment.
But this "test" BC break is more theoretical than practical:                                                                                                     
                                                                                                                                                          
  1. People who wanted zeros → already using setTestNow() or adding | manually                                                                            
  2. People who wanted current time → this is the edge case that breaks, but it's likely unintentional/accidental rather than deliberate                  
     