### PR TITLE
Add time comparison methods to ChronosTime

### DIFF
--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -461,6 +461,54 @@ class ChronosTime implements Stringable
     }
 
     /**
+     * Returns whether time is start of day.
+     *
+     * @return bool
+     */
+    public function isStartOfDay(): bool
+    {
+        return $this->ticks === 0;
+    }
+
+    /**
+     * Returns whether time is end of day.
+     *
+     * Compares against 23:59:59, ignoring microseconds.
+     *
+     * @return bool
+     */
+    public function isEndOfDay(): bool
+    {
+        $endOfDayTicks = 23 * self::TICKS_PER_HOUR
+            + 59 * self::TICKS_PER_MINUTE
+            + 59 * self::TICKS_PER_SECOND;
+
+        $ticksWithoutMicroseconds = $this->ticks - $this->ticks % self::TICKS_PER_SECOND;
+
+        return $ticksWithoutMicroseconds === $endOfDayTicks;
+    }
+
+    /**
+     * Returns whether time is midnight.
+     *
+     * @return bool
+     */
+    public function isMidnight(): bool
+    {
+        return $this->isStartOfDay();
+    }
+
+    /**
+     * Returns whether time is midday.
+     *
+     * @return bool
+     */
+    public function isMidday(): bool
+    {
+        return $this->ticks === 12 * self::TICKS_PER_HOUR;
+    }
+
+    /**
      * Returns an `DateTimeImmutable` instance set to this clock time.
      *
      * @param \DateTimeZone|string|null $timezone Time zone the DateTimeImmutable instance will be in

--- a/tests/TestCase/ChronosTimeTest.php
+++ b/tests/TestCase/ChronosTimeTest.php
@@ -269,6 +269,42 @@ class ChronosTimeTest extends TestCase
         $this->assertFalse($t3->between($t1, $t2));
     }
 
+    public function testIsStartOfDay(): void
+    {
+        $this->assertTrue(ChronosTime::parse('00:00:00')->isStartOfDay());
+        $this->assertTrue(ChronosTime::midnight()->isStartOfDay());
+        $this->assertFalse(ChronosTime::parse('00:00:00.000001')->isStartOfDay());
+        $this->assertFalse(ChronosTime::parse('00:00:01')->isStartOfDay());
+        $this->assertFalse(ChronosTime::noon()->isStartOfDay());
+    }
+
+    public function testIsEndOfDay(): void
+    {
+        $this->assertTrue(ChronosTime::parse('23:59:59')->isEndOfDay());
+        $this->assertTrue(ChronosTime::endOfDay()->isEndOfDay());
+        $this->assertTrue(ChronosTime::parse('23:59:59.999999')->isEndOfDay());
+        $this->assertFalse(ChronosTime::parse('23:59:58')->isEndOfDay());
+        $this->assertFalse(ChronosTime::midnight()->isEndOfDay());
+        $this->assertFalse(ChronosTime::noon()->isEndOfDay());
+    }
+
+    public function testIsMidnight(): void
+    {
+        $this->assertTrue(ChronosTime::midnight()->isMidnight());
+        $this->assertTrue(ChronosTime::parse('00:00:00')->isMidnight());
+        $this->assertFalse(ChronosTime::parse('00:00:00.000001')->isMidnight());
+        $this->assertFalse(ChronosTime::noon()->isMidnight());
+    }
+
+    public function testIsMidday(): void
+    {
+        $this->assertTrue(ChronosTime::noon()->isMidday());
+        $this->assertTrue(ChronosTime::parse('12:00:00')->isMidday());
+        $this->assertFalse(ChronosTime::parse('12:00:00.000001')->isMidday());
+        $this->assertFalse(ChronosTime::parse('12:00:01')->isMidday());
+        $this->assertFalse(ChronosTime::midnight()->isMidday());
+    }
+
     public function testToDateTimeImmutable(): void
     {
         $time = ChronosTime::parse('23:59:59.999999');


### PR DESCRIPTION
## Summary

Adds four new methods to `ChronosTime` for checking if a time instance represents common boundary times:

- `isStartOfDay()`: Checks if time is 00:00:00.000000
- `isEndOfDay()`: Checks if time is 23:59:59 (ignores microseconds)
- `isMidnight()`: Alias for `isStartOfDay()`
- `isMidday()`: Checks if time is 12:00:00.000000

### Example Usage

```php
$time = ChronosTime::midnight();
$time->isStartOfDay(); // true
$time->isMidnight();   // true

$time = ChronosTime::noon();
$time->isMidday(); // true

$time = ChronosTime::endOfDay();
$time->isEndOfDay(); // true
```