### PR TITLE
Add toArray() method to Chronos, ChronosDate, and ChronosTime

### DIFF
--- a/src/Chronos.php
+++ b/src/Chronos.php
@@ -2643,6 +2643,25 @@ class Chronos extends DateTimeImmutable implements Stringable
     }
 
     /**
+     * Returns the date and time as an associative array.
+     *
+     * @return array{year: int, month: int, day: int, hour: int, minute: int, second: int, microsecond: int, timezone: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'year' => $this->year,
+            'month' => $this->month,
+            'day' => $this->day,
+            'hour' => $this->hour,
+            'minute' => $this->minute,
+            'second' => $this->second,
+            'microsecond' => $this->microsecond,
+            'timezone' => $this->timezone->getName(),
+        ];
+    }
+
+    /**
      * Get a part of the object
      *
      * @param string $name The property name to read.

--- a/src/ChronosDate.php
+++ b/src/ChronosDate.php
@@ -1609,6 +1609,20 @@ class ChronosDate implements Stringable
     }
 
     /**
+     * Returns the date as an associative array.
+     *
+     * @return array{year: int, month: int, day: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'year' => $this->year,
+            'month' => $this->month,
+            'day' => $this->day,
+        ];
+    }
+
+    /**
      * Get a part of the object
      *
      * @param string $name The property name to read.

--- a/src/ChronosTime.php
+++ b/src/ChronosTime.php
@@ -490,4 +490,19 @@ class ChronosTime implements Stringable
     {
         return $this->toDateTimeImmutable($timezone);
     }
+
+    /**
+     * Returns the time as an associative array.
+     *
+     * @return array{hour: int, minute: int, second: int, microsecond: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'hour' => $this->getHours(),
+            'minute' => $this->getMinutes(),
+            'second' => $this->getSeconds(),
+            'microsecond' => $this->getMicroseconds(),
+        ];
+    }
 }

--- a/tests/TestCase/ChronosTimeTest.php
+++ b/tests/TestCase/ChronosTimeTest.php
@@ -298,4 +298,16 @@ class ChronosTimeTest extends TestCase
         ChronosTime::resetToStringFormat();
         $this->assertSame('12:13:14', (string)$t);
     }
+
+    public function testToArray(): void
+    {
+        $t = new ChronosTime('12:30:45.123456');
+        $array = $t->toArray();
+
+        $this->assertSame(12, $array['hour']);
+        $this->assertSame(30, $array['minute']);
+        $this->assertSame(45, $array['second']);
+        $this->assertSame(123456, $array['microsecond']);
+        $this->assertCount(4, $array);
+    }
 }

--- a/tests/TestCase/Date/GettersTest.php
+++ b/tests/TestCase/Date/GettersTest.php
@@ -26,4 +26,15 @@ class GettersTest extends TestCase
         $d = ChronosDate::create(year: 2012, month: $month, day: 1);
         $this->assertSame($expectedHalfOfYear, $d->half);
     }
+
+    public function testToArray(): void
+    {
+        $d = ChronosDate::create(2024, 1, 15);
+        $array = $d->toArray();
+
+        $this->assertSame(2024, $array['year']);
+        $this->assertSame(1, $array['month']);
+        $this->assertSame(15, $array['day']);
+        $this->assertCount(3, $array);
+    }
 }

--- a/tests/TestCase/DateTime/GettersTest.php
+++ b/tests/TestCase/DateTime/GettersTest.php
@@ -333,4 +333,19 @@ class GettersTest extends TestCase
         $d = Chronos::now();
         $d->doesNotExit;
     }
+
+    public function testToArray(): void
+    {
+        $d = Chronos::create(2024, 1, 15, 12, 30, 45, 123456, 'America/Toronto');
+        $array = $d->toArray();
+
+        $this->assertSame(2024, $array['year']);
+        $this->assertSame(1, $array['month']);
+        $this->assertSame(15, $array['day']);
+        $this->assertSame(12, $array['hour']);
+        $this->assertSame(30, $array['minute']);
+        $this->assertSame(45, $array['second']);
+        $this->assertSame(123456, $array['microsecond']);
+        $this->assertSame('America/Toronto', $array['timezone']);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `toArray()` method to return date/time components as an associative array. This is the inverse of the existing `createFromArray()` method.

- `Chronos::toArray()` returns: year, month, day, hour, minute, second, microsecond, timezone
- `ChronosDate::toArray()` returns: year, month, day
- `ChronosTime::toArray()` returns: hour, minute, second, microsecond

### Example Usage

```php
$dt = Chronos::create(2024, 1, 15, 12, 30, 45, 123456, 'America/Toronto');
$array = $dt->toArray();
// [
//     'year' => 2024,
//     'month' => 1,
//     'day' => 15,
//     'hour' => 12,
//     'minute' => 30,
//     'second' => 45,
//     'microsecond' => 123456,
//     'timezone' => 'America/Toronto',
// ]

// Round-trip
$restored = Chronos::createFromArray($array);
```