### PR TITLE
Pin action image and reduce permissions

### DIFF
--- a/.github/workflows/deploy_docs_2x.yml
+++ b/.github/workflows/deploy_docs_2x.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 2.x
 
+permissions:
+    contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -15,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@cc7dec1d2b9fed249a14ae462bc953bba436f78c # v1.10.0
         with:
           git_remote_url: 'ssh://dokku@apps.cakephp.org:22/chronos-docs-2'
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}

--- a/.github/workflows/deploy_docs_3x.yml
+++ b/.github/workflows/deploy_docs_3x.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 3.x
 
+permissions:
+    contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -15,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@cc7dec1d2b9fed249a14ae462bc953bba436f78c # v1.10.0
         with:
           git_remote_url: 'ssh://dokku@apps.cakephp.org:22/chronos-docs-3'
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Pin the image revision used for dokku deployments and reduce permissions for deploy jobs. Pinning the image revision reduces the chances of supply chain attacks on images with access to real credentials.